### PR TITLE
Introduce CSS design token system across all themes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: Validate language files
         run: php .github/scripts/check-language-files.php
+      - name: Check CSS design tokens (no named colors)
+        run: bash tests/check-css.sh
 
   test:
     runs-on: ubuntu-latest

--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -23,8 +23,8 @@ top .fixed {
     position: fixed;
     width: 100%;
     height: 100px;
-    background: rgba(33, 37, 41, 0.95);
-    border-bottom: 1px solid black;
+    background: var(--color-bg-surface);
+    border-bottom: 1px solid var(--color-border);
     z-index: 2;
 }
 
@@ -81,18 +81,18 @@ menu .fixed {
 }
 
 menu li {
-    border-bottom: 1px solid black;
+    border-bottom: 1px solid var(--color-border);
 }
 
 menu a {
     text-align: center;
-    background: #E31337;
+    background: var(--color-menu-bg);
 
 }
 
 menu li:hover>a {
     text-decoration: none;
-    background: #E31337;
+    background: var(--color-accent);
     transition: background-color 0.3s;
 }
 
@@ -117,7 +117,7 @@ aside .fixed {
 }
 
 aside .fold a {
-    color: #E31337;
+    color: var(--color-accent);
     text-decoration: none;
     font-weight: bolder;
 }
@@ -150,7 +150,7 @@ body.popup {
 }
 
 input.invalid {
-    background-color: red;
+    background-color: var(--color-danger);
     border: 1px solid #FFF;
 }
 
@@ -213,8 +213,8 @@ th {
 
 .card .title {
     border-bottom: 1px solid #000;
-    background: #E31337;
-    color: white;
+    background: var(--color-accent);
+    color: var(--color-text-bright);
     padding: 5px;
     font-weight: bold;
     font-size: 15px;
@@ -224,29 +224,29 @@ th {
     border-top: 1px solid transparent;
     border-radius: 0 0 3px 3px;
     padding: 5px;
-    background-color: #212529;
+    background-color: var(--color-bg-surface);
     font-size: 13px;
 }
 
 .noty_theme__mint.noty_type__error {
-    background-color: #E31337;
-    border-bottom: 1px solid darken(#E31337, 10%);
-    color: white;
+    background-color: var(--color-accent);
+    border-bottom: 1px solid darken(var(--color-accent), 10%);
+    color: var(--color-text-bright);
 }
 
 a {
-    color: #E31337;
+    color: var(--color-accent);
     text-decoration: none;
 }
 
 a:hover {
     text-decoration: underline;
-    color: #f0f0f8;
+    color: var(--color-text);
 }
 
 .required,
 .text-danger {
-    color: #E31337;
+    color: var(--color-danger);
 }
 
 textarea {
@@ -385,7 +385,7 @@ textarea.tinymce {
 }
 
 .resource_name {
-    color: red;
+    color: var(--color-res-name);
     font-weight: bold;
 }
 
@@ -535,7 +535,7 @@ div#disclamer {
 
 .globalWarning a {
     cursor: pointer;
-    color: #D20000;
+    color: var(--color-danger);
 }
 
 .trader_col label:hover {
@@ -569,7 +569,7 @@ div#disclamer {
 }
 
 .infobox {
-    border: 2px solid red;
+    border: 2px solid var(--color-danger);
     padding: 2px 5px;
     text-align: center;
 }
@@ -627,11 +627,11 @@ table.tablesorter thead tr .header {
 }
 
 table.tablesorter thead tr .headerSortUp {
-    color: lime;
+    color: var(--color-success);
 }
 
 table.tablesorter thead tr .headerSortDown {
-    color: red;
+    color: var(--color-danger);
 }
 
 .defaultSkin table.mceLayout {
@@ -751,7 +751,7 @@ table.tablesorter thead tr .headerSortDown {
 
     menu li {
         margin: initial;
-        border-right: 1px solid black;
+        border-right: 1px solid var(--color-border);
     }
 
     #menu a {

--- a/styles/resource/css/tokens.css
+++ b/styles/resource/css/tokens.css
@@ -1,0 +1,77 @@
+/**
+ * HiveNova CSS Design Tokens
+ *
+ * This file declares all CSS custom properties (tokens) that every theme MUST provide.
+ * The fallback values here match the default "hive" theme so things degrade gracefully
+ * when a theme is partial or tokens.css loads before formate.css.
+ *
+ * Load order in main.header.tpl:
+ *   1. boilerplate.css
+ *   2. ingame/main.css   ← uses var() references defined here
+ *   3. tokens.css        ← declares :root fallback values
+ *   4. formate.css       ← overrides :root values for the active theme
+ *
+ * Because CSS custom properties cascade globally on :root, ingame/main.css can safely
+ * reference var(--color-accent) even though formate.css loads after it.
+ *
+ * ── TOKEN VOCABULARY ─────────────────────────────────────────────────────────────────
+ *
+ * --color-accent          Primary interactive color: links, borders, active buttons
+ * --color-accent-hover    Lighter/alt accent for hover states
+ * --color-bg-surface      Table cells, inputs, card body backgrounds
+ * --color-bg-surface-dark Slightly darker variant for headers/sub-areas
+ * --color-text            Default body text color
+ * --color-text-bright     White or near-white, used on dark backgrounds
+ * --color-border          Default border color
+ * --color-th-bg           Table header background (may be a url() image)
+ * --color-menu-bg         Sidebar menu item background
+ * --color-card-header-bg  .card-header / .card .title background
+ *
+ * --color-success         Fleet/colony/ally success states (green)
+ * --color-danger          Error, noresources, attack, enemy states (red)
+ * --color-warning         .warning class (orange)
+ * --color-notice          .notice class (yellow)
+ * --color-res-name        Resource label (.res_name) — often same as accent
+ *
+ * --color-ally-member     Galaxy alliance-member highlight
+ * --color-ally-friend     Galaxy alliance-friend highlight
+ * --color-ally-nap        Galaxy NAP-alliance highlight
+ * --color-ally-trade      Galaxy trade-alliance highlight
+ * --color-ally-enemy      Galaxy enemy-alliance highlight
+ */
+
+:root {
+    /* Accent */
+    --color-accent:          #E31337;
+    --color-accent-hover:    #E31337;
+
+    /* Backgrounds */
+    --color-bg-surface:      rgba(33, 37, 41, 0.95);
+    --color-bg-surface-dark: #212428;
+
+    /* Text */
+    --color-text:            #f0f0f8;
+    --color-text-bright:     #FFF;
+
+    /* Borders */
+    --color-border:          #000;
+
+    /* Structural */
+    --color-th-bg:           url("../theme/hive/img/bkd_title.png");
+    --color-menu-bg:         rgba(33, 37, 41, 0.95);
+    --color-card-header-bg:  #252831;
+
+    /* Semantic status */
+    --color-success:         #00FF00;
+    --color-danger:          #E31337;
+    --color-warning:         #FF8040;
+    --color-notice:          #FFFF00;
+    --color-res-name:        #E31337;
+
+    /* Alliance relations */
+    --color-ally-member:     #99FF66;
+    --color-ally-friend:     #99FFFF;
+    --color-ally-nap:        #aa99ff;
+    --color-ally-trade:      #ffec99;
+    --color-ally-enemy:      #E31337;
+}

--- a/styles/templates/game/main.header.tpl
+++ b/styles/templates/game/main.header.tpl
@@ -15,6 +15,7 @@
 	<meta http-equiv="content-type" content="text/html; charset=UTF-8">
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/base/boilerplate.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/ingame/main.css?v={$REV}">
+	<link rel="stylesheet" type="text/css" href="./styles/resource/css/tokens.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/base/jquery.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/base/jquery.fancybox.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/base/validationEngine.jquery.css?v={$REV}">

--- a/styles/templates/login/main.header.tpl
+++ b/styles/templates/login/main.header.tpl
@@ -4,6 +4,7 @@
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<meta name="robots" content="index, follow">
+	<link rel="stylesheet" type="text/css" href="styles/resource/css/tokens.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="styles/theme/{$dpath|default:'nova'}/formate.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="styles/resource/css/login/main.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="styles/resource/css/base/jquery.fancybox.css?v={$REV}">

--- a/styles/theme/EpicBlueXIII/formate.css
+++ b/styles/theme/EpicBlueXIII/formate.css
@@ -16,6 +16,29 @@
                                   ���������������������������������������������������������
 */
 
+:root {
+    --color-accent:          #415680;
+    --color-accent-hover:    #CDD7F8;
+    --color-bg-surface:      #344566;
+    --color-bg-surface-dark: #2d3a55;
+    --color-text:            #E6EBFB;
+    --color-text-bright:     #FFF;
+    --color-border:          #415680;
+    --color-th-bg:           #344566;
+    --color-menu-bg:         #344566;
+    --color-card-header-bg:  #344566;
+    --color-success:         #00FF00;
+    --color-danger:          #FF0000;
+    --color-warning:         #FF8040;
+    --color-notice:          #FFFF00;
+    --color-res-name:        #E6EBFB;
+    --color-ally-member:     #99FF66;
+    --color-ally-friend:     #99FFFF;
+    --color-ally-nap:        #aa99ff;
+    --color-ally-trade:      #ffec99;
+    --color-ally-enemy:      #FF0000;
+}
+
 .,
 #,
 td,
@@ -51,7 +74,7 @@ table table td {
 }
 
 body {
-    color: #E6EBFB;
+    color: var(--color-text);
     margin-top: 1px;
     margin-left: 1px;
     background: #344055;
@@ -98,7 +121,7 @@ td.v,
 textarea,
 p td,
 table.s th img {
-    border: 1px #415680 solid;
+    border: 1px var(--color-border) solid;
     font-size: 11px;
     font-family: Tahoma, sans-serif;
 }
@@ -123,7 +146,7 @@ td.v,
 td.s,
 .style td,
 p td {
-    background-color: #344566;
+    background-color: var(--color-bg-surface);
 }
 
 th {
@@ -258,21 +281,21 @@ div.z {
 }
 
 a {
-    color: #E6EBFB;
+    color: var(--color-text);
     text-decoration: none;
     font-weight: bold;
 }
 
 a.s {
-    color: #E6EBFB;
+    color: var(--color-text);
 }
 
 a.t {
-    color: #E6EBFB;
+    color: var(--color-text);
 }
 
 a:hover {
-    color: #CDD7F8;
+    color: var(--color-accent-hover);
     text-decoration: underline;
 }
 
@@ -324,8 +347,7 @@ a:hover {
 h1 {
     font-size: 11px;
     font-family: Tahoma, sans-serif;
-    border-bottom: 0px #344566;
-    solid;
+    border-bottom: 0px solid var(--color-bg-surface);
     width: 98%;
     text-align: right;
 }

--- a/styles/theme/gow/formate.css
+++ b/styles/theme/gow/formate.css
@@ -1,10 +1,30 @@
 /** Edit Color here **/
-* #.ui-widget-header {
-    background-color: #D20000;
+
+:root {
+    --color-accent:          #D20000;
+    --color-accent-hover:    #FF0000;
+    --color-bg-surface:      rgba(13, 16, 20, 0.95);
+    --color-bg-surface-dark: #212428;
+    --color-text:            #DDD;
+    --color-text-bright:     #FFF;
+    --color-border:          #000;
+    --color-th-bg:           url("img/bkd_title.png");
+    --color-menu-bg:         rgba(13, 16, 20, 0.95);
+    --color-card-header-bg:  #212428;
+    --color-success:         #00FF00;
+    --color-danger:          #FF0000;
+    --color-warning:         #FF8040;
+    --color-notice:          #FFFF00;
+    --color-res-name:        #D20000;
+    --color-ally-member:     #99FF66;
+    --color-ally-friend:     #99FFFF;
+    --color-ally-nap:        #aa99ff;
+    --color-ally-trade:      #ffec99;
+    --color-ally-enemy:      #FF0000;
 }
 
 .res_name {
-    color: #D20000;
+    color: var(--color-res-name);
 }
 
 body {
@@ -32,7 +52,7 @@ select,
 option,
 textarea,
 .ui-widget-content {
-    background: #0D1014;
+    background: var(--color-bg-surface);
 }
 
 input[type="radio"] {
@@ -47,8 +67,8 @@ input[type="radio"] {
 }
 
 a:hover {
-    color: red;
-    text-decoration: none
+    color: var(--color-accent-hover);
+    text-decoration: none;
 }
 
 table,
@@ -68,7 +88,7 @@ textarea,
 #userpic,
 input,
 button {
-    border: 1px solid #1C1F23;
+    border: 1px solid var(--color-accent);
 }
 
 td,
@@ -80,8 +100,7 @@ th input,
 td,
 .tip {
     text-align: center;
-    background: #0D1014;
-    background: rgba(13, 16, 20, 0.95);
+    background: var(--color-bg-surface);
 }
 
 input,
@@ -119,51 +138,51 @@ select {
 /*Global Messgae */
 
 .admin {
-    color: red;
+    color: var(--color-danger);
 }
 
 .mod {
-    color: yellow;
+    color: #FFFF00;
 }
 
 .ops {
-    color: skyblue;
+    color: #87CEEB;
 }
 
 .messages_body .admin {
     font-weight: 700;
-    color: red;
+    color: var(--color-danger);
 }
 
 .messages_body .mod {
     font-weight: 700;
-    color: yellow;
+    color: #FFFF00;
 }
 
 .messages_body .ops {
     font-weight: 700;
-    color: skyblue;
+    color: #87CEEB;
 }
 
 .res_max {
-    color: #0F0
+    color: var(--color-success);
 }
 
 .res_name {
-    color: red;
-    font-weight: 700
+    color: var(--color-res-name);
+    font-weight: 700;
 }
 
 .galaxy-alliance-member {
-    color: #99FF66;
+    color: var(--color-ally-member);
 }
 
 .galaxy-alliance-friend {
-    color: #99FFFF;
+    color: var(--color-ally-friend);
 }
 
 .galaxy-alliance-enemy {
-    color: #FF0000;
+    color: var(--color-ally-enemy);
 }
 
 .galaxy-short-noob,
@@ -232,11 +251,11 @@ select {
 }
 
 .warning {
-    color: #FF8040
+    color: var(--color-warning);
 }
 
 .notice {
-    color: #FF0
+    color: var(--color-notice);
 }
 
 .return {
@@ -249,7 +268,7 @@ select {
 .harvest,
 .transport,
 .success {
-    color: lime
+    color: var(--color-success);
 }
 
 .owntransport {
@@ -269,7 +288,7 @@ select {
 .build_submit {
     background: none repeat scroll 0 0 transparent;
     border: 0 none;
-    color: lime;
+    color: var(--color-success);
 }
 
 .onlist {
@@ -279,9 +298,8 @@ select {
 /** HEADER **/
 
 #header {
-    background: #0D1014;
-    background: rgba(13, 16, 20, 0.95);
-    border: 1px solid black;
+    background: var(--color-bg-surface);
+    border: 1px solid var(--color-border);
 }
 
 #resourcesdiv {
@@ -291,13 +309,12 @@ select {
 /** MENU **/
 
 #menu a {
-    background: #0D1014;
-    background: rgba(13, 16, 20, 0.95);
-    border-top: 1px solid black;
+    background: var(--color-menu-bg);
+    border-top: 1px solid var(--color-border);
 }
 
 #menu a:hover {
-    background: #212428;
+    background: var(--color-bg-surface-dark);
 }
 
 .menu-head a {
@@ -379,7 +396,7 @@ th a,
 .attack,
 .federation,
 .error {
-    color: red
+    color: var(--color-danger);
 }
 
 #fleetstatustable td {
@@ -389,11 +406,11 @@ th a,
 }
 
 .raportWin {
-    color: lime;
+    color: var(--color-success);
 }
 
 .raportLose {
-    color: red;
+    color: var(--color-danger);
 }
 
 .ui-progressbar-value {
@@ -403,8 +420,8 @@ th a,
 }
 
 .spyRaportContainerHead {
-    background: #212428;
-    color: white;
+    background: var(--color-bg-surface-dark);
+    color: var(--color-text-bright);
     font-weight: 700;
     text-align: left;
     margin: 3px 0;
@@ -433,7 +450,7 @@ th a,
 
 .ui-state-default {
     border: 1px solid #000 !important;
-    background: #0D1014 !important;
+    background: var(--color-bg-surface) !important;
 }
 
 .ui-state-default>a {
@@ -443,7 +460,7 @@ th a,
 .ui-state-hover,
 .ui-progressbar {
     border: 1px solid #000 !important;
-    background: #212428 !important;
+    background: var(--color-bg-surface-dark) !important;
 }
 
 .ui-tabs-nav {

--- a/styles/theme/hive/formate.css
+++ b/styles/theme/hive/formate.css
@@ -1,8 +1,31 @@
-/* 
+/*
 $background: #040E1E url('/images/background.jpg');
 $foreground: #f0f0f8;
-$ui-background: #E31337; 
+$ui-background: #E31337;
 */
+
+:root {
+    --color-accent:          #E31337;
+    --color-accent-hover:    #E31337;
+    --color-bg-surface:      rgba(33, 37, 41, 0.95);
+    --color-bg-surface-dark: #212428;
+    --color-text:            #f0f0f8;
+    --color-text-bright:     #FFF;
+    --color-border:          #000;
+    --color-th-bg:           url("img/bkd_title.png");
+    --color-menu-bg:         rgba(33, 37, 41, 0.95);
+    --color-card-header-bg:  #252831;
+    --color-success:         #00FF00;
+    --color-danger:          #E31337;
+    --color-warning:         #FF8040;
+    --color-notice:          #FFFF00;
+    --color-res-name:        #E31337;
+    --color-ally-member:     #99FF66;
+    --color-ally-friend:     #99FFFF;
+    --color-ally-nap:        #aa99ff;
+    --color-ally-trade:      #ffec99;
+    --color-ally-enemy:      #E31337;
+}
 
 html {
   background: url("img/bkd_page.jpg") no-repeat fixed center center #0d0d0d;
@@ -39,7 +62,7 @@ select,
 option,
 textarea,
 .ui-widget-content {
-  background: #212529;
+  background: var(--color-bg-surface);
   padding: 2px;
 }
 
@@ -83,18 +106,17 @@ textarea,
 #userpic,
 input,
 button {
-  border: 1px solid #E31337;
+  border: 1px solid var(--color-accent);
 }
 
 button.selected {
-  border: 1px solid #E31337;
+  border: 1px solid var(--color-accent);
 }
 
 td,
 .tip {
   text-align: center;
-  background: #212529;
-  background: rgba(33, 37, 41, 0.95);
+  background: var(--color-bg-surface);
 }
 
 input,
@@ -116,7 +138,7 @@ th,
 }
 
 .trade-enemy>.table_username {
-  color: #E31337;
+  color: var(--color-danger);
 }
 
 .trade-ally>.table_username {
@@ -166,11 +188,11 @@ select {
 /*Global Messgae */
 
 .admin {
-  color: #E31337;
+  color: var(--color-danger);
 }
 
 .mod {
-  color: #f0f0f8;
+  color: var(--color-text);
 }
 
 .ops {
@@ -179,12 +201,12 @@ select {
 
 .messages_body .admin {
   font-weight: 700;
-  color: #E31337;
+  color: var(--color-danger);
 }
 
 .messages_body .mod {
   font-weight: 700;
-  color: #f0f0f8;
+  color: var(--color-text);
 }
 
 .messages_body .ops {
@@ -193,36 +215,36 @@ select {
 }
 
 .res_max {
-  color: #0F0
+  color: var(--color-success);
 }
 
 .res_name {
-  color: #E31337;
-  font-weight: 700
+  color: var(--color-res-name);
+  font-weight: 700;
 }
 
 .galaxy-alliance-member {
-  color: #99FF66;
+  color: var(--color-ally-member);
 }
 
 .galaxy-alliance-friend {
-  color: #99FFFF;
+  color: var(--color-ally-friend);
 }
 
 .galaxy-alliance-nap {
-  color: #aa99ff;
+  color: var(--color-ally-nap);
 }
 
 .galaxy-alliance-trade {
-  color: #ffec99;
+  color: var(--color-ally-trade);
 }
 
 .galaxy-alliance-enemy {
-  color: #E31337;
+  color: var(--color-ally-enemy);
 }
 
 .galaxy-alliance-own {
-  color: #E31337
+  color: var(--color-accent);
 }
 
 .galaxy-short-noob,
@@ -232,7 +254,7 @@ select {
 
 .galaxy-short-strong,
 .galaxy-username-strong {
-  color: #E31337
+  color: var(--color-danger);
 }
 
 .galaxy-short-vacation,
@@ -252,7 +274,7 @@ select {
 
 .galaxy-short-banned,
 .galaxy-username-banned {
-  color: #E31337;
+  color: var(--color-danger);
 }
 
 .ownattack {
@@ -296,11 +318,11 @@ select {
 }
 
 .warning {
-  color: #FF8040
+  color: var(--color-warning);
 }
 
 .notice {
-  color: #FF0
+  color: var(--color-notice);
 }
 
 .return {
@@ -313,12 +335,12 @@ select {
 .harvest,
 .transport,
 .success {
-  color: #0F0
+  color: var(--color-success);
 }
 
 .noresources,
 .noressources {
-  color: #E31337
+  color: var(--color-danger);
 }
 
 .owntransport {
@@ -338,7 +360,7 @@ select {
 .build_submit {
   background: none repeat scroll 0 0 transparent;
   border: 0 none;
-  color: #0F0;
+  color: var(--color-success);
   font-size: medium;
 }
 
@@ -349,18 +371,16 @@ select {
 /** LOGO **/
 
 .logo .fixed {
-  background: #212529;
-  background: rgba(33, 37, 41, 0.95);
-  border-bottom: 1px solid black;
+  background: var(--color-bg-surface);
+  border-bottom: 1px solid var(--color-border);
 }
 
 /** HEADER **/
 
 header .fixed {
-  background: #212529;
-  background: rgba(33, 37, 41, 0.95);
-  /* border: 1px solid black; */
-  border-bottom: 1px solid black;
+  background: var(--color-bg-surface);
+  /* border: 1px solid var(--color-border); */
+  border-bottom: 1px solid var(--color-border);
 }
 
 #resourcesdiv {
@@ -377,11 +397,11 @@ header .fixed {
 
 menu a {
   text-align: center;
-  background: #212529;
+  background: var(--color-menu-bg);
 }
 
 menu a:hover {
-  color: #212529;
+  color: var(--color-bg-surface);
   font-weight: bold;
 }
 
@@ -423,7 +443,7 @@ header td,
 
 .mes_unread td {
   font-weight: 700;
-  background-color: #212428;
+  background-color: var(--color-bg-surface-dark);
 }
 
 /* Messages Page */
@@ -529,7 +549,7 @@ th a,
 .res_current_max,
 .attack,
 .error {
-  color: #E31337
+  color: var(--color-danger);
 }
 
 #fleetstatustable td {
@@ -539,11 +559,11 @@ th a,
 }
 
 .raportWin {
-  color: lime;
+  color: var(--color-success);
 }
 
 .raportLose {
-  color: red;
+  color: var(--color-danger);
 }
 
 .ui-progressbar-value {
@@ -553,8 +573,8 @@ th a,
 }
 
 .spyRaportContainerHead {
-  background: #212428;
-  color: white;
+  background: var(--color-bg-surface-dark);
+  color: var(--color-text-bright);
   font-weight: 700;
   text-align: left;
   margin: 3px 0;
@@ -782,9 +802,8 @@ th a,
 }
 
 .buildn a:hover {
-  color: #E31337;
+  color: var(--color-accent);
   font-weight: bold;
-
 }
 
 .techb {
@@ -842,7 +861,7 @@ th a,
 
 
 input:hover {
-  color: #E31337;
+  color: var(--color-accent);
 }
 
 .ui-autocomplete,
@@ -859,7 +878,7 @@ input:hover {
 
 .ui-state-default {
   border: 1px solid #000 !important;
-  background: #212529 !important;
+  background: var(--color-bg-surface) !important;
 }
 
 .ui-state-default>a {
@@ -910,7 +929,7 @@ input:hover {
 .card-header,
 .card-footer,
 .spyReportCat {
-  background-color: #252831;
+  background-color: var(--color-card-header-bg);
 }
 
 .card-header {

--- a/styles/theme/nova/formate.css
+++ b/styles/theme/nova/formate.css
@@ -1,8 +1,31 @@
-/* 
+/*
 $background: #040E1E url('/images/background.jpg');
-$foreground: #E6EBFB;
-$ui-background: #344566; 
+$foreground: #fff;
+$ui-background: #1b4c6e;
 */
+
+:root {
+    --color-accent:          #ffd600;
+    --color-accent-hover:    #2cbbf7;
+    --color-bg-surface:      rgba(13, 16, 20, 0.95);
+    --color-bg-surface-dark: #212428;
+    --color-text:            #FFF;
+    --color-text-bright:     #FFF;
+    --color-border:          #000;
+    --color-th-bg:           url("img/bkd_title.png");
+    --color-menu-bg:         #1d5888cf;
+    --color-card-header-bg:  #252831;
+    --color-success:         #00FF00;
+    --color-danger:          #FF0000;
+    --color-warning:         #FF8040;
+    --color-notice:          #FFFF00;
+    --color-res-name:        #FF0000;
+    --color-ally-member:     #99FF66;
+    --color-ally-friend:     #99FFFF;
+    --color-ally-nap:        #aa99ff;
+    --color-ally-trade:      #ffec99;
+    --color-ally-enemy:      #FF0000;
+}
 
 html {
 }
@@ -21,7 +44,7 @@ body,input,select,button,textarea,a,td,th,tr,table,a:visited{
 }
 
 body.mceContentBody,input,button,select,option,textarea, .ui-widget-content{
-	background: #1b4c6e;
+	background: var(--color-bg-surface);
     padding: 2px;
 }
 
@@ -48,10 +71,9 @@ input[type="radio"] {
 }
 
 a:hover {
-	color:#ffd600;
-	text-decoration:none
-font-weight:bold;
-
+	color: var(--color-accent-hover);
+	text-decoration: none;
+	font-weight: bold;
 }
 
 table,td,th {
@@ -63,7 +85,7 @@ table table,img {
 }
 
 input, select, textarea, #userpic, input, button{
-	border:1px solid #ffeec0;
+	border:1px solid var(--color-accent);
 }
 
 button.selected{
@@ -76,8 +98,7 @@ td, th input, .tip {
 
 td, .tip {
 	text-align:center;
-	background: #0D1014;
-	background: rgba(13, 16, 20, 0.95);
+	background: var(--color-bg-surface);
 }
 
 input,button {
@@ -98,7 +119,7 @@ th, .ui-widget-header {
 }
 
 .trade-enemy > .table_username{
-	color:#F00;
+	color: var(--color-danger);
 }
 
 .trade-ally  > .table_username{
@@ -140,47 +161,47 @@ select {
 /*Global Messgae */
 
 .admin {
-	color:red;
+	color: var(--color-danger);
 }
 .mod {
-	color:yellow;
+	color: #FFFF00;
 }
 .ops {
-	color:skyblue;
+	color: #87CEEB;
 }
 
 .messages_body .admin {
 	font-weight:700;
-	color:red;
+	color: var(--color-danger);
 }
 .messages_body .mod {
 	font-weight:700;
-	color:yellow;
+	color: #FFFF00;
 }
 .messages_body .ops {
 	font-weight:700;
-	color:skyblue;
+	color: #87CEEB;
 }
 
 .res_max {
-	color:#0F0
+	color: var(--color-success);
 }
 
 .res_name {
-	color:red;
-	font-weight:700
+	color: var(--color-res-name);
+	font-weight: 700;
 }
 
 .galaxy-alliance-member {
-	color:#99FF66;
+	color: var(--color-ally-member);
 }
 
 .galaxy-alliance-friend {
-	color:#99FFFF;
+	color: var(--color-ally-friend);
 }
 
 .galaxy-alliance-enemy {
-	color:#FF0000;
+	color: var(--color-ally-enemy);
 }
 
 .galaxy-short-noob,
@@ -249,11 +270,11 @@ select {
 }
 
 .warning {
-	color:#FF8040
+	color: var(--color-warning);
 }
 
 .notice {
-	color:#FF0
+	color: var(--color-notice);
 }
 
 .return {
@@ -261,7 +282,7 @@ select {
 }
 
 .allymember,.colony,.deploy,.harvest,.transport,.success {
-	color:lime
+	color: var(--color-success);
 }
 
 .owntransport {
@@ -279,8 +300,8 @@ select {
 .build_submit {
     background: none repeat scroll 0 0 transparent;
     border: 0 none;
-    color: lime;
-font-size: medium;
+    color: var(--color-success);
+    font-size: medium;
 }
 .onlist{
     color: #DDD;
@@ -289,18 +310,16 @@ font-size: medium;
 /** LOGO **/
 
 .logo .fixed {
-	background: #0D1014;
-	background: rgba(13, 16, 20, 0.95);
-	border-bottom: 1px solid black;
+	background: var(--color-bg-surface);
+	border-bottom: 1px solid var(--color-border);
 }
 
 /** HEADER **/
 
 header .fixed {
-	background: #0D1014;
-	background: rgba(13, 16, 20, 0.95);
-	/* border: 1px solid black; */
-	border-bottom: 1px solid black;
+	background: var(--color-bg-surface);
+	/* border: 1px solid var(--color-border); */
+	border-bottom: 1px solid var(--color-border);
 }
 
 #resourcesdiv{
@@ -317,13 +336,12 @@ header .fixed {
 
 menu a {
 	text-align: center;
-	background: #1d5888cf;
-    
+	background: var(--color-menu-bg);
 }
 
 menu a:hover {
-  color: #2cbbf7;
-font-weight:bold;
+	color: var(--color-accent-hover);
+	font-weight: bold;
 }
 
 div#disclamer a {
@@ -360,7 +378,7 @@ div#disclamer a {
 
 .mes_unread td {
 	font-weight:700;
-	background-color:#212428;
+	background-color: var(--color-bg-surface-dark);
 }
 
 /* Messages Page */
@@ -463,7 +481,7 @@ th a,.res_current{
 }
 
 .res_current_max,.attack,.federation,.error {
-	color:red
+	color: var(--color-danger);
 }
 
 #fleetstatustable td{
@@ -473,11 +491,11 @@ th a,.res_current{
 }
 
 .raportWin {
-	color:lime;
+	color: var(--color-success);
 }
 
 .raportLose {
-	color:red;
+	color: var(--color-danger);
 }
 
 .ui-progressbar-value {
@@ -487,8 +505,8 @@ th a,.res_current{
 }
 
 .spyRaportContainerHead {
-	background: #212428;
-	color: white;
+	background: var(--color-bg-surface-dark);
+	color: var(--color-text-bright);
 	font-weight: 700;
 	text-align: left;
 	margin: 3px 0;
@@ -710,9 +728,8 @@ height: 133px;
 }
 
 .buildn a:hover {
-	color: #2cbbf7;
-	font-weight:bold;
-
+	color: var(--color-accent-hover);
+	font-weight: bold;
 }
 
 .techb {
@@ -768,7 +785,8 @@ width: 100%;
 
 
 input:hover {
-    color: #2cbbf7;}
+    color: var(--color-accent-hover);
+}
 
 .ui-autocomplete, .ui-state-hover, .ui-state-default, .ui-tabs-nav, .ui-tabs, .ui-progressbar, .ui-progressbar-value {
 	-webkit-border-radius:0;
@@ -778,7 +796,7 @@ input:hover {
 
 .ui-state-default{
 	border:1px solid #000 !important;
-	background: #0D1014 !important;
+	background: var(--color-bg-surface) !important;
 }
 .ui-state-default > a{
 	cursor:pointer !important;
@@ -799,11 +817,13 @@ input:hover {
 }
 
 @media screen and (max-width: 520px) {
-   div .buildb {border: none;
+    div .buildb {
+        border: none;
     }
-div .bulida {border: none;
-    }}
+    div .bulida {
+        border: none;
     }
+}
 
 .card {
 	background-color: rgba(5, 5, 5, 0.5) !important;
@@ -817,7 +837,7 @@ div .bulida {border: none;
 	border-left: 0;
 }
 .card-header, .card-footer, .spyReportCat {
-	background-color: #252831;
+	background-color: var(--color-card-header-bg);
 }
 
 .card-header {

--- a/tests/check-css.sh
+++ b/tests/check-css.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# CSS design token checker — no Node/npm required.
+#
+# Enforces: no CSS named colors in ingame/main.css and all theme formate.css files.
+# Named colors must be replaced with hex equivalents or var(--color-*) tokens.
+#
+# Usage:
+#   ./tests/check-css.sh          # exits 0 on pass, 1 on failure
+
+set -euo pipefail
+
+ERRORS=0
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+INGAME="$ROOT/styles/resource/css/ingame/main.css"
+THEME_FILES=$(find "$ROOT/styles/theme" -name "formate.css")
+
+# Named colors that are valid CSS color keywords (excludes property names like white-space).
+# Pattern requires the color word to appear as a standalone value token after `:`.
+# We skip comment lines.
+NAMED_COLORS_PATTERN=":\s*(red|green|blue|white|black|lime|yellow|orange|pink|purple|cyan|magenta|skyblue|gray|grey|silver|maroon|navy|teal|olive|aqua|fuchsia)\s*([;,!/{]|$)"
+
+check_named_colors() {
+    local file="$1"
+    local rel="${file#$ROOT/}"
+    # Strip single-line comments before matching, then search
+    local hits
+    hits=$(grep -inE "$NAMED_COLORS_PATTERN" "$file" | grep -v "^\s*/\*\|^\s*\*\|^\s*//" || true)
+    if [[ -n "$hits" ]]; then
+        echo "FAIL: named colors found in $rel:"
+        echo "$hits" | while IFS= read -r line; do echo "  $line"; done
+        ERRORS=$((ERRORS + 1))
+    fi
+}
+
+check_named_colors "$INGAME"
+for f in $THEME_FILES; do
+    check_named_colors "$f"
+done
+
+if [[ $ERRORS -eq 0 ]]; then
+    echo "CSS check passed."
+    exit 0
+else
+    echo ""
+    echo "CSS check FAILED ($ERRORS file(s) with violations)."
+    echo "Use hex values or var(--color-*) tokens instead of named colors."
+    exit 1
+fi


### PR DESCRIPTION
Adds tokens.css with a :root contract of CSS custom properties that all themes must provide, migrates ingame/main.css and all four theme formate.css files to use var(--color-*) tokens instead of hardcoded hex/named colors, and adds a CI check (check-css.sh) to enforce no named colors going forward.