### PR TITLE
Fix Hall of Fame showing destruction battle players on wrong side

### DIFF
--- a/includes/classes/missions/MissionCaseDestruction.php
+++ b/includes/classes/missions/MissionCaseDestruction.php
@@ -527,7 +527,7 @@ HTML;
 
 				$db->insert($sql, array(
 					':reportId'	=> $reportID,
-					':userRole'	=> 1,
+					':userRole'	=> $i + 1,
 					':username'	=> $userName,
 					':userId'	=> $userID
 				));


### PR DESCRIPTION
## Summary
- In `MissionCaseDestruction`, the role inserted into `users_to_topkb` was hardcoded to `1` instead of using `$i + 1`
- This caused all players (attackers and defenders) to be stored as role=1 (attacker), so the Hall of Fame showed both players on the attacker side with an empty defender column
- Fix matches the pattern already used in `MissionCaseAttack` where `$i + 1` correctly assigns role=1 to attackers and role=2 to defenders

Closes #129

## Test plan
- [ ] Trigger a Destruction mission battle and verify it appears in the Hall of Fame with correct attacker/defender names on opposite sides
- [ ] Verify existing Attack mission battles in Hall of Fame are unaffected
- [ ] View the battle report via `?page=raport&mode=battlehall&raport=...` and confirm players are labeled on the correct sides