### PR TITLE
Fix ACS attack allied fleet shown as hostile on Overview page

### DIFF
--- a/includes/classes/FlyingFleetsTable.php
+++ b/includes/classes/FlyingFleetsTable.php
@@ -195,9 +195,10 @@ class FlyingFleetsTable
 	    $GoodMissions	= array(3, 5);
 		$MissionType    = $fleetRow['fleet_mission'];
 
-		$FleetPrefix    = ($Owner == true) ? 'own' : '';
+		$isACSAllyFleet = !$Owner && ($MissionType == 1 || $MissionType == 2) && $Status == FLEET_OUTWARD && $fleetRow['fleet_target_owner'] != $this->userId;
+		$FleetPrefix    = ($Owner || $isACSAllyFleet) ? 'own' : '';
 		$FleetType		= $FleetPrefix.$FleetStyle[$MissionType];
-		$FleetName		= (!$Owner && ($MissionType == 1 || $MissionType == 2) && $Status == FLEET_OUTWARD && $fleetRow['fleet_target_owner'] != $this->userId) ? $LNG['cff_acs_fleet'] : $LNG['ov_fleet'];
+		$FleetName		= $isACSAllyFleet ? $LNG['cff_acs_fleet'] : $LNG['ov_fleet'];
 		$FleetContent   = $this->CreateFleetPopupedFleetLink($fleetRow, $FleetName, $FleetPrefix.$FleetStyle[$MissionType]);
 		$FleetCapacity  = $this->CreateFleetPopupedMissionLink($fleetRow, $LNG['type_mission_'.$MissionType], $FleetPrefix.$FleetStyle[$MissionType]);
 		$FleetStatus    = array(0 => 'flight', 1 => 'return' , 2 => 'holding');

--- a/includes/classes/missions/MissionCaseDestruction.php
+++ b/includes/classes/missions/MissionCaseDestruction.php
@@ -527,7 +527,7 @@ HTML;
 
 				$db->insert($sql, array(
 					':reportId'	=> $reportID,
-					':userRole'	=> 1,
+					':userRole'	=> $i + 1,
 					':username'	=> $userName,
 					':userId'	=> $userID
 				));


### PR DESCRIPTION
## Summary
- When viewing an ACS attack group on the Overview page, allied fleets (not owned by the current player) were displayed with the hostile `attack` CSS class (red), because `$FleetPrefix` was only set to `'own'` for fleets the player directly owns
- The same ACS-ally detection already used for fleet name labeling (`$FleetName = 'cff_acs_fleet'`) is now also applied to `$FleetPrefix`, so allied ACS fleets get friendly `own*` styling
- **Creator's view**: ally's mission-2 fleet → `ownfederation` (pink/salmon) instead of `federation`  
- **Ally's view**: creator's mission-1 fleet → `ownattack` (green) instead of `attack` (red)

Closes #8

## Test plan
- [ ] Set up an ACS attack with two allied players
- [ ] Verify the fleet creator sees their ally's fleet in a friendly color (not red)
- [ ] Verify the ally sees the fleet creator's attack fleet in green (`ownattack`), not red
- [ ] Verify that a real incoming enemy attack (not ACS) still shows as red (hostile)
- [ ] Verify ACS defense (mission 2, hold) colors are unaffected