### PR TITLE
Fix PHP deprecation warnings in Smarty template and FleetFunctions

### DIFF
--- a/includes/classes/FleetFunctions.php
+++ b/includes/classes/FleetFunctions.php
@@ -334,6 +334,8 @@ class FleetFunctions
 			':fleetNoMReturn'  => 0,
 		));
 
+		if(empty($fleetResult)) { return false; }
+
 		if(empty($fleetResult['start_time'])) { $fleetResult['start_time'] = 0; }
 		if(empty($fleetResult['fleet_start_time'])) { $fleetResult['fleet_start_time'] = 0; }
 		if(empty($fleetResult['fleet_mission'])) { $fleetResult['fleet_mission'] = 0; }

--- a/styles/templates/game/page.questions.default.tpl
+++ b/styles/templates/game/page.questions.default.tpl
@@ -8,7 +8,7 @@
 		<td class="left">{foreach $LNG.questions as $categoryID => $categoryRow}<h2>{$categoryRow.category}</h2>
 		<ul>
 		{foreach $categoryRow as $questionID => $questionRow}
-		{if is_numeric($questionID)}
+		{if $questionID|is_numeric}
 			<li><a href="game.php?page=questions&amp;mode=single&amp;categoryID={$categoryID}&amp;questionID={$questionID}">{$questionRow.title}</a></li>
 		{/if}
 		{/foreach}


### PR DESCRIPTION
## Summary
- Fix Smarty deprecated warning: change `{if is_numeric($questionID)}` to `{if $questionID|is_numeric}` in the questions template — `is_numeric` is already registered as a modifier, just wasn't using the modifier syntax
- Fix PHP 8.1 deprecation: `SendFleetBack` now returns early when `selectSingle` finds no fleet row, preventing automatic conversion of `false` to array when accessing `$fleetResult['start_time']` etc.

## Test plan
- [ ] Navigate to the FAQ/questions page — no Smarty deprecation in logs
- [ ] Trigger fleet send-back on a fleet that no longer exists — no PHP deprecation in logs, function returns `false` cleanly
- [ ] Run `./tests/run-ci-local.sh` — all tests pass