### PR TITLE
Fix TypeError when target planet not found in fleet step 3

### DIFF
--- a/includes/classes/FleetDispatchService.php
+++ b/includes/classes/FleetDispatchService.php
@@ -155,8 +155,6 @@ class FleetDispatchService
         $stayTime          = $fleetData['stayTime'];
         $availableMissions = $fleetData['availableMissions'];
 
-        $db = Database::get();
-
         // Colonize: target must be empty and must target a planet slot
         if ($mission == 7) {
             if (!empty($targetPlanetData)) {
@@ -246,7 +244,7 @@ class FleetDispatchService
                 $sql = "SELECT COUNT(*) as state FROM %%BUDDY%%
                     WHERE id NOT IN (SELECT id FROM %%BUDDY_REQUEST%% WHERE %%BUDDY_REQUEST%%.id = %%BUDDY%%.id) AND
                     (owner = :ownerID AND sender = :userID) OR (owner = :userID AND sender = :ownerID);";
-                $buddy = $db->selectSingle($sql, [
+                $buddy = Database::get()->selectSingle($sql, [
                     ':ownerID' => $targetPlayerData['id'],
                     ':userID'  => $USER['id'],
                 ], 'state');

--- a/includes/pages/game/ShowFleetStep3Page.php
+++ b/includes/pages/game/ShowFleetStep3Page.php
@@ -165,7 +165,7 @@ class ShowFleetStep3Page extends AbstractGamePage
 			':targetSystem' => $targetSystem,
 			':targetPlanet' => $targetPlanet,
 			':targetType'   => ($targetType == 2 ? 1 : $targetType),
-		));
+		)) ?: null;
 
 		// Determine target player data
 		if ($targetMission == 7 || $targetMission == 15 || $targetMission == 16) {

--- a/tests/Unit/FleetDispatchServiceTest.php
+++ b/tests/Unit/FleetDispatchServiceTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use HiveNova\Core\Config;
+use HiveNova\Core\FleetDispatchService;
+
+use PHPUnit\Framework\TestCase;
+
+class FleetDispatchServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // validateMission uses global $LNG for error strings
+        $GLOBALS['LNG'] = [
+            'fl_target_exists'          => 'Target already exists',
+            'fl_only_planets_colonizable' => 'Only planets can be colonized',
+            'fl_no_target'              => 'No target',
+            'fl_empty_target'           => 'Empty target',
+            'fl_invalid_mission'        => 'Invalid mission',
+            'fl_admin_attack'           => 'Admin attack',
+            'fl_player_is_noob'         => 'Player is noob',
+            'fl_player_is_strong'       => 'Player is strong',
+            'fl_bash_protection'        => 'Bash protection',
+            'fl_no_expedition_slot'     => 'No expedition slot',
+        ];
+    }
+
+    // -------------------------------------------------------------------------
+    // validateMission — null target planet (regression: was `false` before fix)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Regression test: selectSingle() returns false when no planet row exists.
+     * The caller coerces false → null so validateMission(?array) doesn't get
+     * a TypeError. For a colonize mission to an empty coordinate, null planet
+     * data is valid; the method should throw a domain RuntimeException (empty
+     * player), not a PHP TypeError.
+     */
+    public function testValidateMissionAcceptsNullPlanetDataForColonize(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Empty target');
+
+        FleetDispatchService::validateMission(
+            null,           // planet not found — coerced from false by the caller
+            [],             // no player → triggers RuntimeException before any DB use
+            7,              // MISSION_COLONIZE
+            ['id' => 1, 'authlevel' => 0],
+            [
+                'fleetArray'        => [202 => 1],
+                'fleetGroup'        => 0,
+                'targetType'        => 1,
+                'stayTime'          => 0,
+                'availableMissions' => ['MissionSelector' => [7]],
+            ],
+            new Config([])
+        );
+    }
+
+    /**
+     * Colonize to a coordinate that already has a planet should throw
+     * regardless of null vs populated planet data.
+     */
+    public function testValidateMissionThrowsWhenColonizeTargetAlreadyExists(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Target already exists');
+
+        FleetDispatchService::validateMission(
+            ['id' => 99, 'id_owner' => 5, 'destruyed' => 0, 'ally_deposit' => 0],
+            ['id' => 5, 'authlevel' => 0, 'onlinetime' => 0, 'vacation' => 0],
+            7,              // MISSION_COLONIZE — target must be empty
+            ['id' => 1, 'authlevel' => 0],
+            [
+                'fleetArray'        => [202 => 1],
+                'fleetGroup'        => 0,
+                'targetType'        => 1,
+                'stayTime'          => 0,
+                'availableMissions' => ['MissionSelector' => [7]],
+            ],
+            new Config([])
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- `$db->selectSingle()` returns `false` when no planet row is found, but `FleetDispatchService::validateMission()` declares `?array` for its first parameter — it accepts `null` but not `false`
- Added `?: null` coercion after the `selectSingle` call in `ShowFleetStep3Page.php` to convert `false` to `null`
- Added `FleetDispatchServiceTest` with a regression test confirming `null` planet data is accepted (domain `RuntimeException`, not `TypeError`), plus a test that colonize to an occupied coordinate still throws correctly

## Test plan
- [ ] Send a fleet to an empty coordinate (no planet) — should no longer throw a `TypeError`
- [ ] Send a fleet to an occupied coordinate — normal flow unaffected
- [ ] Colonize / expedition missions to empty slots still work
- [ ] `./tests/run-ci-local.sh` passes (includes new `FleetDispatchServiceTest`)