### PR TITLE
feat: attack notification banner on all game pages (#99)

### DIFF
--- a/includes/pages/game/AbstractGamePage.php
+++ b/includes/pages/game/AbstractGamePage.php
@@ -4,6 +4,7 @@ namespace HiveNova\Page\Game;
 
 use HiveNova\Core\Cronjob;
 use HiveNova\Core\Config;
+use HiveNova\Core\Database;
 use HiveNova\Core\HTTP;
 use HiveNova\Core\PlayerUtil;
 use HiveNova\Core\ResourceUpdate;
@@ -172,9 +173,15 @@ abstract class AbstractGamePage
 			array(':userId' => $USER['id'])
 		)['cnt'];
 
+		$messageCount = (int) $USER['messages'];
+		$messageNotice = $messageCount > 0
+			? ($messageCount === 1 ? $LNG['ov_have_new_message'] : sprintf($LNG['ov_have_new_messages'], $messageCount))
+			: false;
+
 		$this->assign(array(
 			'PlanetSelect'		=> $PlanetSelect,
-			'new_message' 		=> $USER['messages'],
+			'new_message' 		=> $messageCount,
+			'messages'			=> $messageNotice,
 			'incoming_attack'	=> $incomingAttacks > 0 ? $LNG['ov_under_attack'] : false,
 			'commit'			=> $commit,
 			'commitShort'		=> $commitShort,

--- a/includes/pages/game/AbstractGamePage.php
+++ b/includes/pages/game/AbstractGamePage.php
@@ -163,9 +163,19 @@ abstract class AbstractGamePage
 			$commitShort = substr($commit, 0, 7);
 		}
 
+		$incomingAttacks = Database::get()->selectSingle(
+			'SELECT COUNT(*) as cnt FROM %%FLEETS%%
+			WHERE fleet_target_owner = :userId
+			AND fleet_owner != :userId
+			AND fleet_mission IN (1, 2, 9)
+			AND fleet_mess = 0',
+			array(':userId' => $USER['id'])
+		)['cnt'];
+
 		$this->assign(array(
 			'PlanetSelect'		=> $PlanetSelect,
 			'new_message' 		=> $USER['messages'],
+			'incoming_attack'	=> $incomingAttacks > 0 ? $LNG['ov_under_attack'] : false,
 			'commit'			=> $commit,
 			'commitShort'		=> $commitShort,
 			'vacation'			=> $USER['urlaubs_modus'] ? _date($LNG['php_tdformat'], $USER['urlaubs_until'], $USER['timezone']) : false,

--- a/includes/pages/game/ShowBuildingsPage.php
+++ b/includes/pages/game/ShowBuildingsPage.php
@@ -328,8 +328,7 @@ class ShowBuildingsPage extends AbstractGamePage
 		$BuildTemp          = $PLANET['temp_max'];
 
         $BuildInfoList      = array();
-$Messages		= $USER['messages'];
-		$Elements			= $reslist['allow'][$PLANET['planet_type']];
+$Elements			= $reslist['allow'][$PLANET['planet_type']];
 		
 		foreach($Elements as $Element)
 		{
@@ -401,7 +400,6 @@ $Messages		= $USER['messages'];
 			'Queue'				=> $Queue,
 			'isBusy'			=> array('shipyard' => !empty($PLANET['b_hangar_id']), 'research' => $USER['b_tech_planet'] != 0),
 			'HaveMissiles'		=> (bool) $PLANET[$resource[503]] + $PLANET[$resource[502]],
-			'messages'			=> ($Messages > 0) ? (($Messages == 1) ? $LNG['ov_have_new_message'] : sprintf($LNG['ov_have_new_messages'], $Messages)): false,
 		));
 			
 		$this->display('page.buildings.default.tpl');

--- a/includes/pages/game/ShowOverviewPage.php
+++ b/includes/pages/game/ShowOverviewPage.php
@@ -186,8 +186,6 @@ class ShowOverviewPage extends AbstractGamePage
 			$chatOnline[]	= $chatRow['userName'];
 		}
 
-		$Messages		= $USER['messages'];
-		
 		// Fehler: Wenn Spieler gelöscht werden, werden sie nicht mehr in der Tabelle angezeigt.
 		$sql = "SELECT u.id, u.username, s.total_points FROM %%USERS%% as u
 		LEFT JOIN %%STATPOINTS%% as s ON s.id_owner = u.id AND s.stat_type = '1' WHERE ref_id = :userID;";
@@ -253,7 +251,6 @@ class ShowOverviewPage extends AbstractGamePage
 			'AllPlanets'				=> $AllPlanets,
 			'AdminsOnline'				=> $AdminsOnline,
 			'teamspeakData'				=> $this->GetTeamspeakData(),
-			'messages'					=> ($Messages > 0) ? (($Messages == 1) ? $LNG['ov_have_new_message'] : sprintf($LNG['ov_have_new_messages'], $Messages)): false,
 			'planet_diameter'			=> pretty_number($PLANET['diameter']),
 			'planet_field_current' 		=> $PLANET['field_current'],
 			'planet_field_max' 			=> CalculateMaxPlanetFields($PLANET),

--- a/includes/pages/game/ShowResearchPage.php
+++ b/includes/pages/game/ShowResearchPage.php
@@ -373,7 +373,6 @@ class ShowResearchPage extends AbstractGamePage
 		$elementId     	= HTTP::_GP('tech', 0);
 		$ListID     	= HTTP::_GP('listid', 0);
 
-		$Messages		= $USER['messages'];
 
 		$PLANET[$resource[31].'_inter']	= ResourceUpdate::getNetworkLevel($USER, $PLANET);
 
@@ -441,7 +440,6 @@ class ShowResearchPage extends AbstractGamePage
 			'IsLabinBuild'	=> !$bContinue,
 			'IsFullQueue'	=> Config::get()->max_elements_tech == 0 || Config::get()->max_elements_tech == count($TechQueue),
 			'Queue'			=> $TechQueue,
-			'messages'		=> ($Messages > 0) ? (($Messages == 1) ? $LNG['ov_have_new_message'] : sprintf($LNG['ov_have_new_messages'], $Messages)): false,
 		));
 
 		$this->display('page.research.default.tpl');

--- a/includes/pages/game/ShowShipyardPage.php
+++ b/includes/pages/game/ShowShipyardPage.php
@@ -159,8 +159,6 @@ class ShowShipyardPage extends AbstractGamePage
 		{
 			$this->printMessage($LNG['bd_shipyard_required']);
 		}
-		$Messages		= $USER['messages'];
-
 		$buildTodo	= HTTP::_GP('fmenge', array());
 		$action		= HTTP::_GP('action', '');
 								
@@ -283,7 +281,6 @@ class ShowShipyardPage extends AbstractGamePage
 			'BuildList'		=> $buildList,
 			'maxlength'		=> strlen((string) Config::get()->max_fleet_per_build),
 			'mode'			=> $mode,
-			'messages'		=> ($Messages > 0) ? (($Messages == 1) ? $LNG['ov_have_new_message'] : sprintf($LNG['ov_have_new_messages'], $Messages)): false,
 			'SolarEnergy'		=> $SolarEnergy,
 		));
 

--- a/includes/pages/game/ShowTechtreePage.php
+++ b/includes/pages/game/ShowTechtreePage.php
@@ -47,7 +47,6 @@ class ShowTechtreePage extends AbstractGamePage
         );
 
         $techTreeList = array();
-        $Messages		= $USER['messages'];
         foreach($elementIDs as $elementId)
         {
             if(!isset($resource[$elementId]))
@@ -74,7 +73,6 @@ class ShowTechtreePage extends AbstractGamePage
 
         $this->assign(array(
             'TechTreeList'		=> $techTreeList,
-            'messages'			=> ($Messages > 0) ? (($Messages == 1) ? $LNG['ov_have_new_message'] : sprintf($LNG['ov_have_new_messages'], $Messages)): false,
         ));
 
         $this->display('page.techTree.default.tpl');

--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -112,6 +112,7 @@ $LNG['ov_wrong_pass']						= 'Falsches Passwort. Versuchen sie es noch einmal!';
 $LNG['ov_wrong_name']						= 'Falsches Name. Versuchen sie es noch einmal!';
 $LNG['ov_have_new_message']					= 'Du hast eine neue Nachricht';
 $LNG['ov_have_new_messages']					= 'Du hast %d neue Nachrichten';
+$LNG['ov_under_attack']					= 'Du wirst angegriffen!';
 $LNG['ov_planetmenu']						= 'Name ändern/Löschen';
 $LNG['ov_free']							= 'Frei';
 $LNG['ov_news']							= 'News';

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -121,6 +121,7 @@ $LNG['ov_wrong_pass']						= 'Password incorrect!';
 $LNG['ov_wrong_name']						= 'Name incorrect!';
 $LNG['ov_have_new_message']					= 'You have a new message';
 $LNG['ov_have_new_messages']				= 'You have %d new messages';
+$LNG['ov_under_attack']					= 'You are under attack!';
 $LNG['ov_planetmenu']						= 'Rename or delete';
 $LNG['ov_free']								= 'Free';
 $LNG['ov_news']								= 'News';

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -111,6 +111,7 @@ $LNG['ov_wrong_pass']						= 'Contraseña incorrecta. Intentalo de nuevo!';
 $LNG['ov_wrong_name']						= 'Nombre incorrecta. Intentalo de nuevo!';
 $LNG['ov_have_new_message']					= 'Tienes 1 mensaje nuevo';
 $LNG['ov_have_new_messages']				= 'Tienes %d mensajes nuevos';
+$LNG['ov_under_attack']					= '¡Estás siendo atacado!';
 $LNG['ov_planetmenu']						= 'Cambiar Nombre/Eliminar';
 $LNG['ov_free']								= 'Libre';
 $LNG['ov_news']								= 'Novedades';

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -101,6 +101,7 @@ $LNG['ov_wrong_pass']						= 'Mot de passe incorrect. Essayez à nouveau!';
 $LNG['ov_wrong_name']						= 'Mot de nom incorrect. Essayez à nouveau!';
 $LNG['ov_have_new_message']					= 'Vous avez un nouveau message';
 $LNG['ov_have_new_messages']				= 'Vous avez %d nouveaux messages';
+$LNG['ov_under_attack']					= 'Vous êtes attaqué !';
 $LNG['ov_planetmenu']						= 'Nom Modifier/Abandonner';
 $LNG['ov_free']								= 'Libre';
 $LNG['ov_news']								= 'Actualités';

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -114,6 +114,7 @@ $LNG['ov_wrong_pass']						= 'Błędne hasło, spróbuj ponownie!';
 $LNG['ov_wrong_name']						= 'Błędna nazwa, spróbuj ponownie!';
 $LNG['ov_have_new_message']					= 'Masz wiadomość';
 $LNG['ov_have_new_messages']				= 'Masz %d nowych wiadomości';
+$LNG['ov_under_attack']					= 'Jesteś atakowany!';
 $LNG['ov_planetmenu']						= 'Zmień nazwę / Porzuć planetę';
 $LNG['ov_free']								= 'Bezczynna';
 $LNG['ov_news']								= 'Nowości';

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -113,14 +113,9 @@ $LNG['ov_principal_planet_cant_abanone']	= 'Não pode apagar o planeta principal
 $LNG['ov_abandon_planet_not_possible']		= 'O planeta não pode ser apagado, por ter atividades existentes!';
 $LNG['ov_wrong_pass']						= 'Senha incorreta!';
 $LNG['ov_wrong_name']						= 'Nome incorreta!';
-<<<<<<< HEAD
 $LNG['ov_have_new_message']					= 'Possui uma nova mensagem';
 $LNG['ov_have_new_messages']				= 'Possui %d novas mensagens';
-=======
-$LNG['ov_have_new_message']					= 'Possuis uma nova mensagem';
-$LNG['ov_have_new_messages']				= 'Possuis %d novas mensagens';
 $LNG['ov_under_attack']					= 'Você está sendo atacado!';
->>>>>>> 82199d8 (feat: show attack notification popup on all game pages (issue #99))
 $LNG['ov_planetmenu']						= 'Alterar nome ou excluir';
 $LNG['ov_free']								= 'Livre';
 $LNG['ov_news']								= 'Noticias';

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -113,8 +113,14 @@ $LNG['ov_principal_planet_cant_abanone']	= 'Não pode apagar o planeta principal
 $LNG['ov_abandon_planet_not_possible']		= 'O planeta não pode ser apagado, por ter atividades existentes!';
 $LNG['ov_wrong_pass']						= 'Senha incorreta!';
 $LNG['ov_wrong_name']						= 'Nome incorreta!';
+<<<<<<< HEAD
 $LNG['ov_have_new_message']					= 'Possui uma nova mensagem';
 $LNG['ov_have_new_messages']				= 'Possui %d novas mensagens';
+=======
+$LNG['ov_have_new_message']					= 'Possuis uma nova mensagem';
+$LNG['ov_have_new_messages']				= 'Possuis %d novas mensagens';
+$LNG['ov_under_attack']					= 'Você está sendo atacado!';
+>>>>>>> 82199d8 (feat: show attack notification popup on all game pages (issue #99))
 $LNG['ov_planetmenu']						= 'Alterar nome ou excluir';
 $LNG['ov_free']								= 'Livre';
 $LNG['ov_news']								= 'Noticias';

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -106,6 +106,7 @@ $LNG['ov_wrong_pass']                     = 'Неправильный парол
 $LNG['ov_wrong_name']                     = 'Неправильный название, попробуйте ввести заново!';
 $LNG['ov_have_new_message']               = 'Новых сообщений: 1';
 $LNG['ov_have_new_messages']              = 'Новых сообщений: %d';
+$LNG['ov_under_attack']					= 'Вас атакуют!';
 $LNG['ov_planetmenu']                     = 'Переименовать/удалить планету';
 $LNG['ov_free']                           = '';
 $LNG['ov_news']                           = 'Новости';

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -118,6 +118,7 @@ $LNG['ov_wrong_pass']						= 'Yanlış şifre girdiniz!';
 $LNG['ov_wrong_name']						= 'Yanlış isim girdiniz!';
 $LNG['ov_have_new_message']					= 'Yeni mesajınız var';
 $LNG['ov_have_new_messages']				= ' <b>(%d)</b> Adet Yeni Mesajınız Var';
+$LNG['ov_under_attack']					= 'Saldırı altındasınız!';
 $LNG['ov_planetmenu']						= 'Yeniden Adlandır ya da Sil';
 $LNG['ov_free']								= 'Uygun';
 $LNG['ov_news']								= 'Duyurular';

--- a/styles/resource/css/tokens.css
+++ b/styles/resource/css/tokens.css
@@ -66,6 +66,7 @@
     /* Semantic status */
     --color-success:         #00FF00;
     --color-danger:          #E31337;
+    --color-notification-message-bg: #208c81c4;
     --color-warning:         #FF8040;
     --color-notice:          #FFFF00;
     --color-res-name:        #E31337;

--- a/styles/templates/game/layout.full.tpl
+++ b/styles/templates/game/layout.full.tpl
@@ -39,7 +39,13 @@
 		{elseif $vacation}
 		<div class="infobox">{$LNG.tn_vacation_mode} {$vacation}</div>
 		{/if}
-		
+		{if $messages}
+		<div class="message"><a href="?page=messages">{$messages}</a></div>
+		{/if}
+		{if $incoming_attack}
+		<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
+		{/if}
+
 		{block name="content"}{/block}
 		<table class="hack"></table>
 	</content>

--- a/styles/templates/game/page.buildings.default.tpl
+++ b/styles/templates/game/page.buildings.default.tpl
@@ -3,7 +3,9 @@
 
 		{if $messages}
 	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	
+	{/if}
+	{if $incoming_attack}
+	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
 	{/if}
 {if !empty($Queue)}
 <div id="buildlist" class="infos1">

--- a/styles/templates/game/page.buildings.default.tpl
+++ b/styles/templates/game/page.buildings.default.tpl
@@ -1,12 +1,6 @@
 {block name="title" prepend}{$LNG.lm_buildings}{/block}
 {block name="content"}
 
-		{if $messages}
-	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	{/if}
-	{if $incoming_attack}
-	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
-	{/if}
 {if !empty($Queue)}
 <div id="buildlist" class="infos1">
 	

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -45,7 +45,9 @@ $("#tn3").hide();
 <div>
 	{if $messages}
 	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	
+	{/if}
+	{if $incoming_attack}
+	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
 	{/if}
 <div class="infos">
 <div class="planeto"><a href="#" onclick="return Dialog.PlanetAction();" title="{$LNG.ov_planetmenu}">{$LNG["type_planet_{$planet_type}"]} {$planetname}</a> ({$username})</div>

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -43,12 +43,6 @@ $("#tn3").hide();
 </style>	
 
 <div>
-	{if $messages}
-	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	{/if}
-	{if $incoming_attack}
-	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
-	{/if}
 <div class="infos">
 <div class="planeto"><a href="#" onclick="return Dialog.PlanetAction();" title="{$LNG.ov_planetmenu}">{$LNG["type_planet_{$planet_type}"]} {$planetname}</a> ({$username})</div>
 

--- a/styles/templates/game/page.research.default.tpl
+++ b/styles/templates/game/page.research.default.tpl
@@ -1,11 +1,5 @@
 {block name="title" prepend}{$LNG.lm_research}{/block}
 {block name="content"}
-	{if $messages}
-	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	{/if}
-	{if $incoming_attack}
-	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
-	{/if}
 {if !empty($Queue)}
 <div id="buildlist" class="infos1">
 		{foreach $Queue as $List}

--- a/styles/templates/game/page.research.default.tpl
+++ b/styles/templates/game/page.research.default.tpl
@@ -2,7 +2,9 @@
 {block name="content"}
 	{if $messages}
 	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	
+	{/if}
+	{if $incoming_attack}
+	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
 	{/if}
 {if !empty($Queue)}
 <div id="buildlist" class="infos1">

--- a/styles/templates/game/page.shipyard.default.tpl
+++ b/styles/templates/game/page.shipyard.default.tpl
@@ -3,7 +3,9 @@
 
 	{if $messages}
 	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	
+	{/if}
+	{if $incoming_attack}
+	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
 	{/if}
 {if !$NotBuilding}<table width="70%" id="infobox" style="border: 2px solid red; text-align:center;background:transparent"><tr><td>{$LNG.bd_building_shipyard}</td></tr></table><br><br>{/if}
 {if !empty($BuildList)}

--- a/styles/templates/game/page.shipyard.default.tpl
+++ b/styles/templates/game/page.shipyard.default.tpl
@@ -1,12 +1,6 @@
 {block name="title" prepend}{if $mode == "defense"}{$LNG.lm_defenses}{else}{$LNG.lm_shipshard}{/if}{/block}
 {block name="content"}
 
-	{if $messages}
-	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	{/if}
-	{if $incoming_attack}
-	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
-	{/if}
 {if !$NotBuilding}<table width="70%" id="infobox" style="border: 2px solid red; text-align:center;background:transparent"><tr><td>{$LNG.bd_building_shipyard}</td></tr></table><br><br>{/if}
 {if !empty($BuildList)}
 <div style="text-align: center;">

--- a/styles/templates/game/page.techTree.default.tpl
+++ b/styles/templates/game/page.techTree.default.tpl
@@ -12,7 +12,9 @@
 </style>
 {if $messages}
 	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	
+	{/if}
+	{if $incoming_attack}
+	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
 	{/if}
 <div>
 <div class="infos"> 

--- a/styles/templates/game/page.techTree.default.tpl
+++ b/styles/templates/game/page.techTree.default.tpl
@@ -10,12 +10,6 @@
 .minus {
         display:none;	}
 </style>
-{if $messages}
-	<div class="message"><a href="?page=messages">{$messages}</a></div>
-	{/if}
-	{if $incoming_attack}
-	<div class="attack-notification"><a href="?page=overview">{$incoming_attack}</a></div>
-	{/if}
 <div>
 <div class="infos"> 
 {foreach $TechTreeList as $elementID => $requireList}

--- a/styles/theme/hive/formate.css
+++ b/styles/theme/hive/formate.css
@@ -87,7 +87,6 @@ input[type="radio"] {
 a:hover {
   color: #E31337;
   text-decoration: none;
-  font-weight: bold;
 }
 
 table,
@@ -403,7 +402,6 @@ menu a {
 
 menu a:hover {
   color: var(--color-bg-surface);
-  font-weight: bold;
 }
 
 div#disclamer a {
@@ -590,32 +588,44 @@ th a,
   border-top: 0 none;
 }
 
-.message {
-  margin: 0 0 0 744px;
-  position: fixed;
-  background-color: #208c81c4;
-  padding: 8px;
-  text-align: center;
-  top: 100px;
-  border-radius: 15px 0px 15px 15px;
-  height: fit-content;
-  max-width: 175px;
+content {
+  padding-top: 0;
+  display: flow-root;
 }
 
-@media screen and (min-width: 700px) and (max-width: 1600px) {
-  .message {
-    right: 10.5%;
-    margin: 0;
-  }
+content > .globalWarning {
+  margin-top: 0;
+}
+
+
+.message,
+.attack-notification {
+  display: inline-block;
+  padding: 8px;
+  margin: 0 0 8px;
+  text-align: center;
+  border-radius: 15px 0px 15px 15px;
+}
+
+.message {
+  background-color: var(--color-notification-message-bg);
+}
+
+.attack-notification {
+  background-color: color-mix(in srgb, var(--color-danger) 77%, transparent);
+}
+
+.message a:hover,
+.attack-notification a:hover {
+  color: var(--color-text-bright);
 }
 
 @media screen and (max-width: 699px) {
-  .message {
-    bottom: 0;
+  .message,
+  .attack-notification {
+    display: block;
     width: 100%;
-    max-width: unset;
     border-radius: 15px 15px 0 0;
-    top: unset;
     margin: 0;
   }
 

--- a/styles/theme/nova/formate.css
+++ b/styles/theme/nova/formate.css
@@ -538,7 +538,7 @@ th a,.res_current{
 .attack-notification {
     margin: 0 0 0 744px;
     position: fixed;
-    background-color: #c0392bc4;
+    background-color: color-mix(in srgb, var(--color-danger) 77%, transparent);
     padding: 8px;
     text-align: center;
     top: 155px;

--- a/styles/theme/nova/formate.css
+++ b/styles/theme/nova/formate.css
@@ -535,8 +535,24 @@ th a,.res_current{
     max-width: 175px;
 }
 
+.attack-notification {
+    margin: 0 0 0 744px;
+    position: fixed;
+    background-color: #c0392bc4;
+    padding: 8px;
+    text-align: center;
+    top: 155px;
+    border-radius: 15px 0px 15px 15px;
+    height: fit-content;
+    max-width: 175px;
+}
+
 @media screen and (min-width: 700px) and (max-width: 1600px) {
 .message {
+right: 10.5%;
+margin: 0;
+}
+.attack-notification {
 right: 10.5%;
 margin: 0;
 }
@@ -544,6 +560,14 @@ margin: 0;
 @media screen and (max-width: 699px) {
 .message {
 	bottom: 0;
+	width: 100%;
+	max-width: unset;
+	border-radius: 15px 15px 0 0;
+	top: unset;
+	margin: 0;
+	}
+.attack-notification {
+	bottom: 45px;
 	width: 100%;
 	max-width: unset;
 	border-radius: 15px 15px 0 0;

--- a/tests/simulate-attack.php
+++ b/tests/simulate-attack.php
@@ -1,0 +1,200 @@
+<?php
+
+/**
+ * simulate-attack.php — CLI helper to test the "You are under attack!" banner.
+ *
+ * Usage:
+ *   php tests/simulate-attack.php             # create fake inbound attack fleet
+ *   php tests/simulate-attack.php --cleanup   # remove fleet + attacker user
+ */
+
+if (php_sapi_name() !== 'cli') {
+    die("CLI only\n");
+}
+
+define('ROOT_PATH', str_replace('\\', '/', dirname(__DIR__)) . '/');
+chdir(ROOT_PATH);
+set_include_path(ROOT_PATH);
+
+if (!file_exists(ROOT_PATH . 'includes/config.php')) {
+    die("Missing includes/config.php — run tests/ci-install.php first\n");
+}
+
+define('MODE', 'INSTALL');
+@require ROOT_PATH . 'includes/common.php';
+restore_exception_handler();
+restore_error_handler();
+
+require ROOT_PATH . 'includes/vars.php';
+
+// Fleet direction constants (not defined in INSTALL mode)
+if (!defined('FLEET_OUTWARD')) define('FLEET_OUTWARD', 0);
+
+use HiveNova\Core\Database;
+use HiveNova\Core\PlayerUtil;
+
+$db      = Database::get();
+$cleanup = in_array('--cleanup', $argv);
+
+// ── 1. Look up spacepizzadev ─────────────────────────────────────────────────
+
+$targetUser = $db->selectSingle(
+    'SELECT u.id, u.universe, u.id_planet,
+            p.galaxy, p.`system`, p.planet, p.planet_type, p.name AS planet_name
+     FROM %%USERS%% u
+     JOIN %%PLANETS%% p ON p.id = u.id_planet
+     WHERE u.username = :name;',
+    [':name' => 'spacepizzadev']
+);
+
+if (empty($targetUser)) {
+    die("Error: user 'spacepizzadev' not found.\n");
+}
+
+$universe   = (int) $targetUser['universe'];
+$targetId   = (int) $targetUser['id'];
+$targetPid  = (int) $targetUser['id_planet'];
+
+// ── 2. Find the attacker ─────────────────────────────────────────────────────
+
+$attacker = $db->selectSingle(
+    'SELECT u.id, u.id_planet,
+            p.galaxy, p.`system`, p.planet, p.planet_type
+     FROM %%USERS%% u
+     JOIN %%PLANETS%% p ON p.id = u.id_planet
+     WHERE u.username = :name AND u.universe = :universe;',
+    [':name' => 'attack_simulator', ':universe' => $universe]
+);
+
+// ── 3. --cleanup mode ────────────────────────────────────────────────────────
+
+if ($cleanup) {
+    if (empty($attacker)) {
+        echo "Nothing to clean up — attack_simulator user not found.\n";
+        exit(0);
+    }
+
+    $attackerId = (int) $attacker['id'];
+
+    // Delete any fleets this attacker sent at spacepizzadev
+    // (deletePlayer handles fleet_owner rows, but be explicit for clarity)
+    $db->delete(
+        'DELETE f, fe
+         FROM %%FLEETS%% f
+         LEFT JOIN %%FLEETS_EVENT%% fe ON fe.fleetID = f.fleet_id
+         WHERE f.fleet_owner = :attacker AND f.fleet_target_owner = :target;',
+        [':attacker' => $attackerId, ':target' => $targetId]
+    );
+
+    PlayerUtil::deletePlayer($attackerId);
+
+    echo "Cleaned up: removed attack fleet and deleted attack_simulator user.\n";
+    exit(0);
+}
+
+// ── 4. Create attacker if missing ────────────────────────────────────────────
+
+if (empty($attacker)) {
+    echo "Creating attack_simulator user...\n";
+
+    // Pass null coords — let createPlayer auto-place the planet
+    [$attackerId, $attackerPid] = PlayerUtil::createPlayer(
+        $universe,
+        'attack_simulator',
+        PlayerUtil::cryptPassword('simulator123'),
+        'attack_simulator@localhost',
+        '',       // hive_account
+        'en',     // language
+        null, null, null  // auto-place
+    );
+
+    // Re-fetch planet coords
+    $attacker = $db->selectSingle(
+        'SELECT u.id, u.id_planet,
+                p.galaxy, p.`system`, p.planet, p.planet_type
+         FROM %%USERS%% u
+         JOIN %%PLANETS%% p ON p.id = u.id_planet
+         WHERE u.id = :id;',
+        [':id' => $attackerId]
+    );
+} else {
+    $attackerId = (int) $attacker['id'];
+    echo "Reusing existing attack_simulator user (id={$attackerId}).\n";
+}
+
+// ── 5. Insert fake attack fleet ──────────────────────────────────────────────
+
+$now          = TIMESTAMP;
+$startTime    = $now + 3600;   // arrives in 1 hour
+$endTime      = $now + 7200;   // return (unused but required)
+
+$sql = 'INSERT INTO %%FLEETS%% SET
+    fleet_owner                 = :owner,
+    fleet_target_owner          = :target,
+    fleet_mission               = 1,
+    fleet_mess                  = :mess,
+    fleet_amount                = 1,
+    fleet_array                 = :ships,
+    fleet_universe              = :universe,
+    fleet_start_time            = :startTime,
+    fleet_end_time              = :endTime,
+    fleet_end_stay              = 0,
+    fleet_start_id              = :startId,
+    fleet_start_galaxy          = :sGalaxy,
+    fleet_start_system          = :sSystem,
+    fleet_start_planet          = :sPlanet,
+    fleet_start_type            = :sType,
+    fleet_end_id                = :endId,
+    fleet_end_galaxy            = :eGalaxy,
+    fleet_end_system            = :eSystem,
+    fleet_end_planet            = :ePlanet,
+    fleet_end_type              = :eType,
+    fleet_resource_metal        = 0,
+    fleet_resource_crystal      = 0,
+    fleet_resource_deuterium    = 0,
+    fleet_no_m_return           = 0,
+    fleet_group                 = 0,
+    fleet_target_obj            = 0,
+    start_time                  = :now;';
+
+$db->insert($sql, [
+    ':owner'     => $attackerId,
+    ':target'    => $targetId,
+    ':mess'      => FLEET_OUTWARD,
+    ':ships'     => '202,1',
+    ':universe'  => $universe,
+    ':startTime' => $startTime,
+    ':endTime'   => $endTime,
+    ':now'       => $now,
+    ':startId'   => (int) $attacker['id_planet'],
+    ':sGalaxy'   => (int) $attacker['galaxy'],
+    ':sSystem'   => (int) $attacker['system'],
+    ':sPlanet'   => (int) $attacker['planet'],
+    ':sType'     => (int) $attacker['planet_type'],
+    ':endId'     => $targetPid,
+    ':eGalaxy'   => (int) $targetUser['galaxy'],
+    ':eSystem'   => (int) $targetUser['system'],
+    ':ePlanet'   => (int) $targetUser['planet'],
+    ':eType'     => (int) $targetUser['planet_type'],
+]);
+
+$fleetId = $db->lastInsertId();
+
+$db->insert(
+    'INSERT INTO %%FLEETS_EVENT%% SET fleetID = :fleetId, `time` = :time;',
+    [':fleetId' => $fleetId, ':time' => $startTime]
+);
+
+// ── 6. Confirmation ──────────────────────────────────────────────────────────
+
+$attackerCoords = "[{$attacker['galaxy']}:{$attacker['system']}:{$attacker['planet']}]";
+$targetCoords   = "[{$targetUser['galaxy']}:{$targetUser['system']}:{$targetUser['planet']}]";
+
+echo "\nAttack fleet created (fleet_id={$fleetId}):\n";
+echo "  Attacker : attack_simulator (id={$attackerId}) @ {$attackerCoords}\n";
+echo "  Target   : spacepizzadev   (id={$targetId})   @ {$targetCoords}\n";
+echo "  Arrives  : " . date('Y-m-d H:i:s', $startTime) . " (in 1 hour)\n";
+echo "\nTo verify:\n";
+echo "  1. Open http://localhost:8000 and log in as spacepizzadev\n";
+echo "  2. Navigate any page — a red \"You are under attack!\" banner should appear\n";
+echo "  3. Run: php tests/simulate-attack.php --cleanup\n";


### PR DESCRIPTION
## Summary

- Shows a red \"You are under attack!\" banner on every game page when hostile fleets are inbound, alongside the existing green new-messages bubble
- Both notifications are now centralized in `layout.full.tpl` (previously scattered across individual page templates, missing from most pages)
- Fixes a fatal error introduced in the prior commit: missing `use HiveNova\Core\Database` import in `AbstractGamePage`

## Changes

- **Bug fix:** Add missing `use HiveNova\Core\Database` import — without it every full page render fatalled
- **Centralization:** Move `$messages` formatting from 5 page controllers into `AbstractGamePage::getNavigationData()`; move both notification `<div>`s from individual templates into `layout.full.tpl`
- **CSS (hive theme):** Add `.attack-notification` (red, token-based); both bubbles share shape, margin, and hover style; remove `font-weight:bold` from `a:hover`/`menu a:hover` (was causing layout shift); fix `content` padding/margin-collapse with `padding-top:0` + `display:flow-root`
- **CSS (nova theme):** Replace hardcoded hex on `.attack-notification` with `color-mix` token
- **Token:** Add `--color-notification-message-bg` to `tokens.css`; replace last hardcoded hex in hive theme
- **Test helper:** `tests/simulate-attack.php` — CLI script to insert/cleanup a fake attack fleet for manual banner testing

## Test plan

- [ ] `php tests/simulate-attack.php` — prints confirmation, creates fleet row
- [ ] Log in as `spacepizzadev`, navigate any game page — red banner appears
- [ ] Banner appears on messages, fleetTable, and all other pages (not just buildings/research/shipyard)
- [ ] Green new-messages bubble also appears on all pages when unread messages exist
- [ ] No hover layout shift on nav links or page links
- [ ] `php tests/simulate-attack.php --cleanup` removes fleet and attacker
- [ ] `bash tests/check-css.sh` passes
- [ ] `php vendor/bin/phpunit --configuration phpunit.xml` passes