### PR TITLE
Fix undefined $Minimize on admin search page

### DIFF
--- a/includes/pages/adm/ShowSearchPage.php
+++ b/includes/pages/adm/ShowSearchPage.php
@@ -87,9 +87,7 @@ function ShowSearchPage()
 	);
 	$template	= new Template();
 
-	
-	
-	
+	$Minimize = '';
 	if (HTTP::_GP('minimize', '') == 'on')
 	{
 		$Minimize			= "&amp;minimize=on";


### PR DESCRIPTION
Initialize $Minimize to an empty string when the minimize checkbox is off, so MyCrazyLittleSearch receives a defined value for pagination URL fragments and PHP 8.4 no longer raises an undefined variable error.