### PR TITLE
ci: pin Composer to 2.9.8 to prevent GitHub Actions token leak

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: php-actions/composer@v6
         with:
+          version: "2.9.8"
           php_version: "8.3"
           php_extensions: "gmp"
       - uses: php-actions/phpunit@v4
@@ -56,6 +57,7 @@ jobs:
         with:
           php-version: "8.3"
           extensions: pdo_mysql, gd, gmp
+          tools: composer:2.9.8
       - run: composer install --no-interaction --prefer-dist
       - run: php tests/ci-install.php
       - run: mkdir -p cache/sessions cache/templates
@@ -99,6 +101,7 @@ jobs:
         with:
           php-version: "8.3"
           extensions: pdo_mysql, gd, gmp, xdebug
+          tools: composer:2.9.8
       - run: composer install --no-interaction --prefer-dist
       - run: php tests/ci-install.php
       - run: mkdir -p cache/sessions cache/templates


### PR DESCRIPTION
## Summary

Pin Composer to **2.9.8** in all three CI jobs so HiveNova is protected when GitHub re-rolls its new hyphenated `GITHUB_TOKEN` format.

In late April 2026, GitHub began rolling out a new `GITHUB_TOKEN` format that included a hyphen. Composer versions prior to **2.9.8** (and **2.2.28 LTS** / **1.10.28**) failed the new format's validation and printed the **full token value** into the Actions log as part of the error message — exposing the credential to anyone with log access.

The `shivammathur/setup-php` action auto-registers `GITHUB_TOKEN` into Composer's global auth config, so any failed `composer install` in our `smoke` / `integration` jobs during the rollout window could in principle have leaked the token. GitHub has since rolled back the new format, but Packagist's advisory recommends pinning to the patched Composer before another rollout.

References:
- Socket.dev advisory: https://socket.dev/blog/packagist-urges-immediate-composer-update
- News writeup: https://cybersecuritynews.com/packagist-urges-immediate-composer-update/

## Changes

- `test` job — pin `php-actions/composer@v6` via its `version: "2.9.8"` input
- `smoke` job — pin `shivammathur/setup-php@v2` via `tools: composer:2.9.8`
- `integration` job — pin `shivammathur/setup-php@v2` via `tools: composer:2.9.8`

## Audit

All 20 CI runs between **2026-04-27** and **2026-05-12** were downloaded and scanned for:
- GitHub token prefixes (`ghp_`, `ghs_`, `gho_`, `ghu_`, `ghr_`, `ghv_`)
- Token-in-URL patterns (`https://x-access-token:TOKEN@...`)
- Hyphenated `gh_*-*` token candidates
- Composer auth/token error keywords

No matches found in any log. No evidence of exposure, no credentials to rotate.

## Test plan

- [x] `./tests/run-ci-local.sh` passes locally (language, CSS, unit, smoke, error-log)
- [ ] CI workflow on this PR runs all three jobs successfully with pinned Composer 2.9.8