### PR TITLE
ci: pin Composer to 2.9.8 to prevent GitHub Actions token leak (develop)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: php-actions/composer@v6
         with:
+          version: "2.9.8"
           php_version: "8.3"
           php_extensions: "gmp"
       - uses: php-actions/phpunit@v4
@@ -56,6 +57,7 @@ jobs:
         with:
           php-version: "8.3"
           extensions: pdo_mysql, gd, gmp
+          tools: composer:2.9.8
       - run: composer install --no-interaction --prefer-dist
       - run: php tests/ci-install.php
       - run: mkdir -p cache/sessions cache/templates
@@ -99,6 +101,7 @@ jobs:
         with:
           php-version: "8.3"
           extensions: pdo_mysql, gd, gmp, xdebug
+          tools: composer:2.9.8
       - run: composer install --no-interaction --prefer-dist
       - run: php tests/ci-install.php
       - run: mkdir -p cache/sessions cache/templates


### PR DESCRIPTION
## Summary

Port of #147 to `develop`. Same 3-line fix, cherry-picked from the master-targeting branch.

In late April 2026, GitHub began rolling out a new `GITHUB_TOKEN` format that included a hyphen. Composer versions prior to **2.9.8** (and **2.2.28 LTS** / **1.10.28**) failed the new format's validation and printed the **full token value** into the Actions log as part of the error message.

The `shivammathur/setup-php` action auto-registers `GITHUB_TOKEN` into Composer's global auth config, so any failed `composer install` in our `smoke` / `integration` jobs during the rollout window could in principle have leaked the token. GitHub has since rolled back the new format, but Packagist's advisory recommends pinning to the patched Composer before another rollout.

`develop` currently has an `ci.yaml` identical to master's pre-fix version, so without this PR the unpinned Composer keeps running on every push/PR to `develop` until a master→develop sync.

References:
- Socket.dev advisory: https://socket.dev/blog/packagist-urges-immediate-composer-update
- News writeup: https://cybersecuritynews.com/packagist-urges-immediate-composer-update/
- Master-targeting PR: #147

## Changes

- `test` job — pin `php-actions/composer@v6` via its `version: "2.9.8"` input
- `smoke` job — pin `shivammathur/setup-php@v2` via `tools: composer:2.9.8`
- `integration` job — pin `shivammathur/setup-php@v2` via `tools: composer:2.9.8`

## Audit

The full log audit was performed on the master-targeting PR (#147): all 20 CI runs between 2026-04-27 and 2026-05-12 were scanned; no token leaks found. No credentials to rotate.

## Test plan

- [x] Cherry-picked cleanly from `chore/pin-composer-2.9.8` (no conflicts)
- [x] Diff is byte-identical to #147
- [ ] CI workflow on this PR runs all three jobs successfully with pinned Composer 2.9.8