### PR TITLE
Fix undefined diameter_check warning on admin planet creator

### DIFF
--- a/includes/pages/adm/ShowCreatorPage.php
+++ b/includes/pages/adm/ShowCreatorPage.php
@@ -152,7 +152,7 @@ function ShowCreatorPage()
 
 				$moonId	= PlayerUtil::createMoon(Universe::getEmulated(), $MoonPlanet['galaxy'], $MoonPlanet['system'],
 					$MoonPlanet['planet'], $MoonPlanet['id_owner'], 20,
-					(($_POST['diameter_check'] == 'on') ? NULL : $Diameter), $MoonName);
+					((isset($_POST['diameter_check']) && $_POST['diameter_check'] == 'on') ? NULL : $Diameter), $MoonName);
 
 
 
@@ -211,7 +211,7 @@ function ShowCreatorPage()
 						
 				$SQL  = "UPDATE ".PLANETS." SET ";
 				
-				if ($_POST['diameter_check'] != 'on' || $field_max > 0)
+				if ($field_max > 0)
 					$SQL .= "field_max = '".$field_max."' ";
 			
 				if (!empty($name))


### PR DESCRIPTION
## Summary
- Fixes PHP warning `Undefined array key "diameter_check"` when creating a planet via admin (`admin.php?page=create&mode=planet`).
- Planet form never had a `diameter_check` checkbox (moon-only); planet creation now only updates `field_max` when the admin enters a value greater than 0.
- Moon creation guards `diameter_check` with `isset()` so an unchecked random-diameter box does not warn.

## Test plan
- [ ] Admin → Create → Planet: submit with user id, coordinates, and optional name/fields — no PHP warning in logs
- [ ] Verify created planet has default `field_max` when field input is left empty
- [ ] Admin → Create → Moon: submit with random diameter checked and unchecked — no warnings, diameter behaves as before
- [x] `./tests/run-ci-local.sh` passes locally