### PR TITLE
Fix admin planet creator SQL error and occupied coordinates

### DIFF
--- a/includes/pages/adm/ShowCreatorPage.php
+++ b/includes/pages/adm/ShowCreatorPage.php
@@ -207,19 +207,16 @@ function ShowCreatorPage()
 					exit;
 				}
 
-				$planetId	= PlayerUtil::createPlanet($Galaxy, $System, $Planet, Universe::getEmulated(), $id, NULL, false, $ISUser['authlevel']);
-						
-				$SQL  = "UPDATE ".PLANETS." SET ";
-				
-				if ($field_max > 0)
-					$SQL .= "field_max = '".$field_max."' ";
-			
-				if (!empty($name))
-					$SQL .= ", name = '".$GLOBALS['DATABASE']->sql_escape($name)."' ";
+				if (!PlayerUtil::isPositionFree(Universe::getEmulated(), $Galaxy, $System, $Planet)) {
+					$template->message($LNG['po_complete_all'], '?page=create&mode=planet', 3, true);
+					exit;
+				}
 
-				$SQL .= "WHERE ";
-				$SQL .= "id = '".$planetId."'";
-				$GLOBALS['DATABASE']->query($SQL);
+				$planetId	= PlayerUtil::createPlanet($Galaxy, $System, $Planet, Universe::getEmulated(), $id, !empty($name) ? $name : NULL, false, $ISUser['authlevel']);
+
+				if ($field_max > 0) {
+					$GLOBALS['DATABASE']->query("UPDATE ".PLANETS." SET field_max = '".$field_max."' WHERE id = '".$planetId."';");
+				}
 
 				$template->message($LNG['po_complete_succes'], '?page=create&mode=planet', 3, true);
 				exit;


### PR DESCRIPTION
## Summary
- Validates coordinates are free with `PlayerUtil::isPositionFree()` before calling `createPlanet()`, showing the existing admin message instead of an uncaught exception.
- Passes the planet name into `createPlanet()` (parameterized INSERT) instead of a fragile follow-up UPDATE.
- Only runs a separate `field_max` UPDATE when the admin enters a value > 0, fixing invalid SQL (`SET , name = ...`) when only a name was provided.

Builds on #150 (merged): `diameter_check` warning fix on develop.

## Code review notes
- **Correctness:** Root cause of the SQL error was a leading comma when `field_max` was skipped but `name` was set; delegating the name to `createPlanet()` removes that class of bug entirely.
- **Consistency:** `isPositionFree()` matches the user-creation path in the same file (line 84); occupied slots now get the same UX as other validation failures.
- **Security:** Name now goes through `createPlanet()`'s prepared statement instead of string-concatenated UPDATE; `field_max` remains an integer from `HTTP::_GP` (pre-existing pattern).
- **Minor (out of scope):** `po_complete_all` is generic for invalid user, bad coords, and occupied slot; a dedicated string would be clearer. TOCTOU between `isPositionFree` and `createPlanet` is possible but unchanged from user creation; `createPlanet` still throws if a race occurs.

## Test plan
- [ ] Admin → Create → Planet at empty coords with name only (no `field_max`) — succeeds, no SQL error
- [ ] Same form at occupied coords (e.g. existing planet) — friendly message, no exception in logs
- [ ] Custom `field_max` > 0 — planet created with overridden fields
- [ ] Empty name — default colony name from `createPlanet`
- [x] `./tests/run-ci-local.sh` passes locally