### PR TITLE
Require database backup on Solar System Destruction

### DIFF
--- a/includes/pages/adm/ShowDestructionPage.php
+++ b/includes/pages/adm/ShowDestructionPage.php
@@ -774,12 +774,8 @@ function ShowDestructionPage()
         $broadcast     = $p['broadcast'];
         $message       = $p['message'];
 
-        $backupBefore = HTTP::_GP('backup_before', 1);
-
         try {
-            if ($backupBefore) {
-                $backupPath = runDestructionDatabaseBackup();
-            }
+            $backupPath = runDestructionDatabaseBackup();
 
             if ($p['spawn_apply']) {
                 if ($p['spawn_galaxy'] < 1 || $p['spawn_system'] < 1 || $p['spawn_planet'] < 1) {
@@ -860,7 +856,6 @@ function ShowDestructionPage()
         'reviewStage'       => $reviewStage,
         'sqlPreviewLines'   => $sqlPreviewLines,
         'reviewToken'       => $reviewToken,
-        'backup_default_on' => 1,
         'preview_error'     => $previewError,
     ]);
 

--- a/language/en/ADMIN.php
+++ b/language/en/ADMIN.php
@@ -685,13 +685,13 @@ $LNG['dest_result_done']             = 'All steps completed successfully. The zo
 $LNG['dest_result_skipped']          = 'Warning: %d player(s) could not be relocated and have no planets. Manual follow-up required.';
 
 $LNG['dest_story_title']            = 'MOON Universe 2 storyline';
-$LNG['dest_story_body']             = 'This admin tool was built for the MOON Universe 2 storyline events: galaxy-wide resets, staged destruction, and curated relocations. Always preview impact, review the SQL summary, and keep backups enabled before executing destructive writes.';
+$LNG['dest_story_body']             = 'This admin tool was built for the MOON Universe 2 storyline events: galaxy-wide resets, staged destruction, and curated relocations. Always preview impact, review the SQL summary, and confirm the automatic database backup step before executing destructive writes.';
 $LNG['dest_preview_continue']       = 'Continue to execution review';
 $LNG['dest_preview_discard']        = 'Discard preview';
 $LNG['dest_review_title']           = 'Execution review — confirm';
 $LNG['dest_review_sql_title']       = 'SQL operations (summary)';
 $LNG['dest_backup_before']          = 'Database backup';
-$LNG['dest_backup_before_label']    = 'Save a full game-database backup before any destructive writes (recommended)';
+$LNG['dest_backup_before_label']    = 'A full game-database backup runs automatically before any destructive writes (required).';
 $LNG['dest_spawn_section']          = 'New-account spawn cursor';
 $LNG['dest_spawn_apply']            = 'Update universe registration spawn cursor after destruction';
 $LNG['dest_spawn_help']             = 'Sets %%CONFIG%% LastSettedGalaxyPos / LastSettedSystemPos / LastSettedPlanetPos — used when PlayerUtil creates new accounts without explicit coordinates.';

--- a/styles/templates/adm/DestructionPage.tpl
+++ b/styles/templates/adm/DestructionPage.tpl
@@ -198,13 +198,10 @@ $(function() {
     <input type="hidden" name="spawn_galaxy" value="{$spawn_galaxy}">
     <input type="hidden" name="spawn_system" value="{$spawn_system}">
     <input type="hidden" name="spawn_planet" value="{$spawn_planet}">
-    <input type="hidden" name="backup_before" value="0">
     <table class="table569">
         <tr>
             <td>{$LNG.dest_backup_before}</td>
-            <td>
-                <label><input type="checkbox" name="backup_before" value="1" checked> {$LNG.dest_backup_before_label}</label>
-            </td>
+            <td>{$LNG.dest_backup_before_label}</td>
         </tr>
         <tr>
             <td colspan="2">

--- a/styles/templates/adm/DestructionPage.tpl
+++ b/styles/templates/adm/DestructionPage.tpl
@@ -270,31 +270,6 @@ $(function() {
     <tr id="row_spawn_coords">
         <td>{$LNG.dest_spawn_coords}</td>
         <td>
-            {$LNG.dest_galaxy}: <input type="number" name="spawn_galaxy" value="{$spawn_galaxy}" style="width:70px" step="1">
-            &nbsp; {$LNG.dest_system}: <input type="number" name="spawn_system" value="{$spawn_system}" style="width:70px" step="1">
-            &nbsp; {$LNG.dest_slot}: <input type="number" name="spawn_planet" value="{$spawn_planet}" style="width:70px" step="1">
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2"><strong>{$LNG.dest_spawn_section}</strong></td>
-    </tr>
-    <tr>
-        <td>{$LNG.dest_spawn_apply}</td>
-        <td>
-            <input type="hidden" name="spawn_apply" value="0">
-            <input type="checkbox" name="spawn_apply" value="1" id="spawn_apply" {if $spawn_apply}checked{/if} title="{$LNG.dest_spawn_apply|escape:'html'}">
-        </td>
-    </tr>
-    <tr>
-        <td colspan="2" valign="top" style="font-size:11px; line-height:1.45; opacity:0.95;">{$LNG.dest_spawn_help}</td>
-    </tr>
-    <tr>
-        <td style="padding-top:8px;"><strong>{$LNG.dest_spawn_coords_heading}</strong></td>
-        <td style="padding-top:8px;"></td>
-    </tr>
-    <tr id="row_spawn_coords">
-        <td>{$LNG.dest_spawn_coords}</td>
-        <td>
             {$LNG.dest_galaxy}: <input type="number" name="spawn_galaxy" min="1" value="{$spawn_galaxy}" style="width:70px">
             &nbsp; {$LNG.dest_system}: <input type="number" name="spawn_system" min="1" value="{$spawn_system}" style="width:70px">
             &nbsp; {$LNG.dest_slot}: <input type="number" name="spawn_planet" min="1" value="{$spawn_planet}" style="width:70px">

--- a/tests/Unit/ShowDestructionPageTest.php
+++ b/tests/Unit/ShowDestructionPageTest.php
@@ -167,7 +167,7 @@ final class ShowDestructionPageTest extends TestCase
         $this->assertStringContainsString('cancel_preview', $tpl);
         $this->assertStringContainsString('dest_review_execute', $tpl);
         $this->assertStringContainsString('review_token', $tpl);
-        $this->assertStringContainsString('backup_before', $tpl);
+        $this->assertStringContainsString('dest_backup_before_label', $tpl);
         $this->assertStringContainsString('cancel_review', $tpl);
         $this->assertStringContainsString('dest_backup_saved', $tpl);
     }
@@ -196,6 +196,7 @@ final class ShowDestructionPageTest extends TestCase
         $this->assertStringContainsString('review_token', $src);
         $this->assertStringContainsString('hash_equals', $src);
         $this->assertStringContainsString('runDestructionDatabaseBackup', $src);
+        $this->assertStringNotContainsString("HTTP::_GP('backup_before'", $src);
         $this->assertStringContainsString('applySpawnCursor', $src);
         $this->assertStringContainsString('destructionSqlPreviewLines', $src);
         $this->assertStringContainsString('destructionPackParams', $src);


### PR DESCRIPTION
## Summary
- Solar System Destruction always runs `runDestructionDatabaseBackup()` before any destructive writes; execution no longer reads an optional `backup_before` POST flag.
- The execution review step still shows the Database backup row for admins, but as informational text instead of a checkbox.
- English admin strings updated to describe the backup as automatic and required.

## Test plan
- [x] `./tests/run-ci-local.sh` (unit tests include `ShowDestructionPageTest`)
- [ ] Open Admin → Solar System Destruction, preview a zone, continue to execution review — confirm backup row is visible without a checkbox
- [ ] Execute destruction (staging only) — confirm a `2MoonsBackup_destruction_*.sql` file is created and success message shows backup path
- [ ] Confirm unchecking backup is no longer possible (no checkbox on review form)