### PR TITLE
Harden web push security and fix Settings / bottom nav UX

### DIFF
--- a/includes/classes/PushNotificationService.php
+++ b/includes/classes/PushNotificationService.php
@@ -23,18 +23,55 @@ class PushNotificationService
 		return defined('PUSH_VAPID_PUBLIC') ? PUSH_VAPID_PUBLIC : '';
 	}
 
-	public static function saveSubscription(int $userId, array $subscription, ?string $userAgent = null): void
+	public static function isValidSubscription(array $subscription): bool
 	{
+		$endpoint = $subscription['endpoint'] ?? '';
+		if (!is_string($endpoint) || $endpoint === '' || strlen($endpoint) > 512) {
+			return false;
+		}
+		if (!filter_var($endpoint, FILTER_VALIDATE_URL) || stripos($endpoint, 'https://') !== 0) {
+			return false;
+		}
+
+		$p256dh = $subscription['keys']['p256dh'] ?? '';
+		$auth   = $subscription['keys']['auth'] ?? '';
+		if (!is_string($p256dh) || !is_string($auth) || $p256dh === '' || $auth === '') {
+			return false;
+		}
+		if (strlen($p256dh) > 255 || strlen($auth) > 255) {
+			return false;
+		}
+		if (!preg_match('#^[A-Za-z0-9_-]+=*$#', $p256dh) || !preg_match('#^[A-Za-z0-9_-]+=*$#', $auth)) {
+			return false;
+		}
+
+		return true;
+	}
+
+	public static function saveSubscription(int $userId, array $subscription, ?string $userAgent = null): bool
+	{
+		if (!self::isValidSubscription($subscription)) {
+			return false;
+		}
+
 		$db = Database::get();
-		$existing = $db->selectSingle(
-			'SELECT id FROM %%PUSH_SUBSCRIPTIONS%% WHERE endpoint = :endpoint',
+		$existingUserId = $db->selectSingle(
+			'SELECT user_id FROM %%PUSH_SUBSCRIPTIONS%% WHERE endpoint = :endpoint',
 			[':endpoint' => $subscription['endpoint']],
-			'id'
+			'user_id'
 		);
 
-		if ($existing) {
+		if ($existingUserId !== false && $existingUserId !== null && $existingUserId !== '' && (int) $existingUserId !== $userId) {
+			return false;
+		}
+
+		if ($userAgent !== null && strlen($userAgent) > 255) {
+			$userAgent = substr($userAgent, 0, 255);
+		}
+
+		if ($existingUserId !== false && $existingUserId !== null && $existingUserId !== '') {
 			$db->update(
-				'UPDATE %%PUSH_SUBSCRIPTIONS%% SET user_id = :userId, p256dh = :p256dh, auth = :auth, user_agent = :userAgent, created_at = :createdAt WHERE endpoint = :endpoint',
+				'UPDATE %%PUSH_SUBSCRIPTIONS%% SET p256dh = :p256dh, auth = :auth, user_agent = :userAgent, created_at = :createdAt WHERE endpoint = :endpoint AND user_id = :userId',
 				[
 					':userId'    => $userId,
 					':p256dh'    => $subscription['keys']['p256dh'],
@@ -44,7 +81,8 @@ class PushNotificationService
 					':endpoint'  => $subscription['endpoint'],
 				]
 			);
-			return;
+
+			return true;
 		}
 
 		$db->insert(
@@ -59,8 +97,27 @@ class PushNotificationService
 				':createdAt' => TIMESTAMP,
 			]
 		);
+
+		return true;
 	}
 
+	public static function removeSubscriptionForUser(int $userId, string $endpoint): void
+	{
+		if ($endpoint === '') {
+			return;
+		}
+
+		$db = Database::get();
+		$db->delete(
+			'DELETE FROM %%PUSH_SUBSCRIPTIONS%% WHERE endpoint = :endpoint AND user_id = :userId',
+			[
+				':endpoint' => $endpoint,
+				':userId'   => $userId,
+			]
+		);
+	}
+
+	/** Remove by endpoint only (expired subscription cleanup from push gateway). */
 	public static function removeSubscription(string $endpoint): void
 	{
 		$db = Database::get();
@@ -218,7 +275,13 @@ class PushNotificationService
 			self::escapePhpSingleQuoted($subject)
 		);
 
-		return file_put_contents($path, $content, LOCK_EX) !== false;
+		if (file_put_contents($path, $content, LOCK_EX) === false) {
+			return false;
+		}
+
+		@chmod($path, 0600);
+
+		return true;
 	}
 
 	private static function defaultInstallSubject(): string

--- a/includes/pages/game/ShowPushPage.php
+++ b/includes/pages/game/ShowPushPage.php
@@ -41,17 +41,23 @@ class ShowPushPage extends AbstractGamePage
 
 		$raw = file_get_contents('php://input');
 		$data = json_decode($raw ?: '', true);
-		if (!is_array($data) || empty($data['endpoint']) || empty($data['keys']['p256dh']) || empty($data['keys']['auth'])) {
+		if (!is_array($data) || !PushNotificationService::isValidSubscription($data)) {
 			HTTP::sendHeader('HTTP/1.1 400 Bad Request');
 			$this->sendJSON(['error' => 'invalid_subscription']);
+			return;
 		}
 
-		PushNotificationService::setUserPreference((int) $USER['id'], true);
-		PushNotificationService::saveSubscription(
+		if (!PushNotificationService::saveSubscription(
 			(int) $USER['id'],
 			$data,
 			$_SERVER['HTTP_USER_AGENT'] ?? null
-		);
+		)) {
+			HTTP::sendHeader('HTTP/1.1 403 Forbidden');
+			$this->sendJSON(['error' => 'subscription_forbidden']);
+			return;
+		}
+
+		PushNotificationService::setUserPreference((int) $USER['id'], true);
 
 		$this->sendJSON(['ok' => true]);
 	}
@@ -62,8 +68,8 @@ class ShowPushPage extends AbstractGamePage
 
 		$raw = file_get_contents('php://input');
 		$data = json_decode($raw ?: '', true);
-		if (!empty($data['endpoint'])) {
-			PushNotificationService::removeSubscription($data['endpoint']);
+		if (!empty($data['endpoint']) && is_string($data['endpoint'])) {
+			PushNotificationService::removeSubscriptionForUser((int) $USER['id'], $data['endpoint']);
 		}
 
 		PushNotificationService::setUserPreference((int) $USER['id'], false);

--- a/includes/pages/game/ShowSettingsPage.php
+++ b/includes/pages/game/ShowSettingsPage.php
@@ -267,9 +267,7 @@ class ShowSettingsPage extends AbstractGamePage
 		
 		$db = Database::get();
 
-		if (PushNotificationService::isConfigured()) {
-			PushNotificationService::setUserPreference((int) $USER['id'], (int) $pushAlerts === 1);
-		}
+		PushNotificationService::setUserPreference((int) $USER['id'], (int) $pushAlerts === 1);
 		
 		if (!empty($username) && $USER['username'] != $username)
 		{

--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -896,6 +896,7 @@ $LNG['op_permanent_email_adress']				= 'Permanente E-Mail Adresse';
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']					= 'Generelle Einstellungen';

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -915,6 +915,7 @@ $LNG['op_permanent_email_adress']			= 'Permanent email address';
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']					= 'General options';

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -885,6 +885,7 @@ $LNG['op_permanent_email_adress']			= 'Dirección pemanente de correo electróni
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']					= 'Opciones generales';

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -878,6 +878,7 @@ $LNG['op_permanent_email_adress']			= 'Adresse Email permanente';
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']					= 'Options générales';

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -905,6 +905,7 @@ $LNG['op_permanent_email_adress']			= 'Stały adres';
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']					= 'Opcje';

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -894,6 +894,7 @@ $LNG['op_permanent_email_adress']			= 'Endereço de E-Mail permanente';
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']					= 'Opções gerais';

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -864,6 +864,7 @@ $LNG['op_permanent_email_adress']         = 'Постоянная электро
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']               = 'Общее';

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -908,6 +908,7 @@ $LNG['op_permanent_email_adress']			= 'Sürekli e-mail adresi';
 $LNG['op_push_notifications']				= 'Mobile push notifications';
 $LNG['op_push_enable']						= 'Enable attack / fleet alerts';
 $LNG['op_push_disable']						= 'Disable notifications';
+$LNG['op_push_not_configured']				= 'Server push is not configured; your preference is saved for when it is enabled.';
 $LNG['push_hostile_title']					= 'Incoming fleet';
 $LNG['push_hostile_body']					= '%s heading to [%d:%d:%d]';
 $LNG['op_general_settings']					= 'Genel Ayarlar';

--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -685,6 +685,14 @@ table.tablesorter thead tr .headerSortDown {
 
 /* MEDIA */
 
+#bottom-nav,
+.fleet-mobile-list,
+.overview-mobile-shortcuts,
+.overview-command-timers,
+.galaxy-nav-swipe {
+    display: none;
+}
+
 @media screen and (min-width: 700px) and (max-width: 969px) {
     .planetImage {
         display: none;
@@ -993,12 +1001,4 @@ table.tablesorter thead tr .headerSortDown {
         border: 1px solid var(--color-border);
         border-radius: 8px;
     }
-}
-
-#bottom-nav,
-.fleet-mobile-list,
-.overview-mobile-shortcuts,
-.overview-command-timers,
-.galaxy-nav-swipe {
-    display: none;
 }

--- a/styles/templates/game/page.settings.default.tpl
+++ b/styles/templates/game/page.settings.default.tpl
@@ -56,12 +56,13 @@
 		<tr>
 			<th colspan="2">{$LNG.op_general_settings}</th>
 		</tr>
-		{if $pushConfigured}
 		<tr>
 			<td>{$LNG.op_push_enable}</td>
-			<td><input id="pushAlerts" name="pushAlerts" type="checkbox" value="1"{if $pushAlerts == 1} checked="checked"{/if}></td>
+			<td>
+				<input id="pushAlerts" name="pushAlerts" type="checkbox" value="1"{if $pushAlerts == 1} checked="checked"{/if}>
+				{if !$pushConfigured}<br><small class="push-settings-hint">{$LNG.op_push_not_configured}</small>{/if}
+			</td>
 		</tr>
-		{/if}
 		<tr>
 			<td>{$LNG.op_timezone}</td>
 			<td>{html_options name=timezone options=$Selectors.timezones selected=$timezone}</td>

--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,15 @@
 const CACHE_NAME = 'hivenova-static-v1';
+const DEFAULT_GAME_URL = 'game.php?page=overview';
+
+function safeGameUrl(url) {
+  if (typeof url !== 'string' || url === '') {
+    return DEFAULT_GAME_URL;
+  }
+  if (/^game\.php\?page=[a-zA-Z0-9_]+$/.test(url)) {
+    return url;
+  }
+  return DEFAULT_GAME_URL;
+}
 const CACHE_URLS = [
   './styles/resource/css/tokens.css',
   './styles/resource/css/ingame/main.css',
@@ -43,7 +54,7 @@ self.addEventListener('fetch', function (event) {
 });
 
 self.addEventListener('push', function (event) {
-  var payload = { title: 'HiveNova', body: '', url: 'game.php?page=overview' };
+  var payload = { title: 'HiveNova', body: '', url: DEFAULT_GAME_URL };
   try {
     if (event.data) {
       payload = Object.assign(payload, event.data.json());
@@ -53,14 +64,14 @@ self.addEventListener('push', function (event) {
     self.registration.showNotification(payload.title, {
       body: payload.body,
       icon: 'favicon.ico',
-      data: { url: payload.url || 'game.php?page=overview' }
+      data: { url: safeGameUrl(payload.url) }
     })
   );
 });
 
 self.addEventListener('notificationclick', function (event) {
   event.notification.close();
-  var target = (event.notification.data && event.notification.data.url) || 'game.php?page=overview';
+  var target = safeGameUrl(event.notification.data && event.notification.data.url);
   event.waitUntil(
     clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (clientList) {
       for (var i = 0; i < clientList.length; i++) {

--- a/tests/Unit/PushNotificationServiceTest.php
+++ b/tests/Unit/PushNotificationServiceTest.php
@@ -1,0 +1,62 @@
+<?php
+
+use HiveNova\Core\PushNotificationService;
+use PHPUnit\Framework\TestCase;
+
+class PushNotificationServiceTest extends TestCase
+{
+	public function testIsValidSubscriptionAcceptsWellFormedPayload(): void
+	{
+		$this->assertTrue(PushNotificationService::isValidSubscription([
+			'endpoint' => 'https://fcm.googleapis.com/fcm/send/example',
+			'keys'     => [
+				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		]));
+	}
+
+	public function testIsValidSubscriptionRejectsHttpEndpoint(): void
+	{
+		$this->assertFalse(PushNotificationService::isValidSubscription([
+			'endpoint' => 'http://fcm.googleapis.com/fcm/send/example',
+			'keys'     => [
+				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		]));
+	}
+
+	public function testIsValidSubscriptionRejectsJavascriptUrl(): void
+	{
+		$this->assertFalse(PushNotificationService::isValidSubscription([
+			'endpoint' => 'javascript:alert(1)',
+			'keys'     => [
+				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		]));
+	}
+
+	public function testIsValidSubscriptionRejectsOversizedEndpoint(): void
+	{
+		$this->assertFalse(PushNotificationService::isValidSubscription([
+			'endpoint' => 'https://example.com/' . str_repeat('a', 512),
+			'keys'     => [
+				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		]));
+	}
+
+	public function testIsValidSubscriptionRejectsInvalidKeyCharacters(): void
+	{
+		$this->assertFalse(PushNotificationService::isValidSubscription([
+			'endpoint' => 'https://fcm.googleapis.com/fcm/send/example',
+			'keys'     => [
+				'p256dh' => 'not valid base64url!',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		]));
+	}
+}


### PR DESCRIPTION
## Summary
- Bind push subscription subscribe/unsubscribe to the logged-in user and validate subscription payloads (prevents hijack/CSRF-style removal of another player’s alerts).
- Sanitize notification click URLs in the service worker to same-origin `game.php?page=…` paths only; restrict `push.config.php` permissions after install.
- Always show the push alerts checkbox on Settings (saves preference even when VAPID keys are missing) and fix bottom nav CSS so it only appears on viewports ≤699px.

## Test plan
- [ ] On desktop (>700px width): bottom nav is hidden; top menu works as before.
- [ ] On mobile (≤699px): bottom nav shows Overview / Buildings / Fleet / Galaxy / Menu.
- [ ] Settings → General: “Enable attack / fleet alerts” is visible; uncheck + save disables `settings_push` and clears subscriptions.
- [ ] `game.php?page=push&mode=subscribe` with another user’s endpoint returns 403.
- [ ] `game.php?page=push&mode=unsubscribe` only removes subscriptions for the current user.
- [ ] Run `./tests/run-ci-local.sh` (unit + language + CSS).