### PR TITLE
Fix attack mission crash on unknown config key speed

### DIFF
--- a/includes/classes/missions/MissionCaseAttack.php
+++ b/includes/classes/missions/MissionCaseAttack.php
@@ -197,7 +197,7 @@ HTML;
 		$combatResult 		= calculateAttack($fleetAttack, $fleetDefend, $fleetIntoDebris, $defIntoDebris);
 
 		$fuelConsumption = 0;
-		$gameSpeed = Config::get($this->_fleet['fleet_universe'])->speed;
+		$gameSpeed = Config::get((int) $this->_fleet['fleet_universe'])->fleet_speed / 2500;
 		foreach ($incomingFleets as $fleetID => $fleetDetail) {
 			$distance = FleetFunctions::GetTargetDistance(
 				[$fleetDetail['fleet_start_galaxy'], $fleetDetail['fleet_start_system'], $fleetDetail['fleet_start_planet']],


### PR DESCRIPTION
## Summary
- Fixes `Unknown configuration key speed!` when `FleetHandler` processes an arriving attack (e.g. while loading buildings).
- Introduced in #137: fuel consumption calc used `Config->speed`, which does not exist; replaced with `fleet_speed / 2500` matching `FleetFunctions::GetGameSpeedFactor()`.

## Test plan
- [ ] Deploy to novadev and load `game.php?page=buildings` while an attack fleet is due to arrive — no error in `includes/error.log`.
- [ ] Complete an attack and open the combat report — fuel/unprofitable raid highlighting still works.