### PR TITLE
Give mobile overview shortcuts and buttons visible backgrounds

### DIFF
--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -1039,7 +1039,10 @@ table.tablesorter thead tr .headerSortDown {
         padding: 10px;
         border: 1px solid var(--color-border);
         border-radius: 8px;
+        background: var(--color-menu-bg);
+        color: var(--color-text);
         text-decoration: none;
+        font-weight: 600;
     }
 
     .overview-command-timers {
@@ -1047,5 +1050,19 @@ table.tablesorter thead tr .headerSortDown {
         margin-bottom: 10px;
         border: 1px solid var(--color-border);
         border-radius: 8px;
+        background: var(--color-bg-surface);
+    }
+
+    content button,
+    content input[type="button"],
+    content input[type="submit"],
+    content .button {
+        -webkit-appearance: none;
+        appearance: none;
+        background: var(--color-menu-bg);
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        color: var(--color-text);
+        padding: 8px 14px;
     }
 }


### PR DESCRIPTION
## Summary
- Follow-up to #165: overview mobile shortcut tiles (Buildings, Fleet, Galaxy, Messages) now use `var(--color-menu-bg)` instead of border-only styling on the dark background.
- Command timers panel gets `var(--color-bg-surface)`.
- Mobile ingame buttons (e.g. Check News, Hide fleets) get explicit backgrounds and `appearance: none` for consistent styling on iOS.

## Test plan
- [ ] Overview on viewport ≤699px: 2×2 shortcut grid has visible button backgrounds.
- [ ] Check News / Hide fleets buttons have filled backgrounds, not outline-only.
- [ ] Desktop layout unchanged.