### PR TITLE
Run bottom-nav markup check in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,7 @@ jobs:
       - run: mkdir -p cache/sessions cache/templates
       - run: php -S localhost:8000 &> /tmp/php-server.log & sleep 2
       - run: php tests/smoke.php
+      - run: php tests/check-bottom-nav.php
       - name: Check error log is empty
         run: |
           errors=$(grep -v '/vendor/' includes/error.log 2>/dev/null || true)

--- a/tests/check-bottom-nav.php
+++ b/tests/check-bottom-nav.php
@@ -30,7 +30,10 @@ function curl_post(string $url, array $fields, string $cookieFile): string {
     return $body ?: '';
 }
 
-function curl_get(string $url, string $cookieFile): string {
+/**
+ * @return array{0: string, 1: string} body and final URL after redirects
+ */
+function curl_get(string $url, string $cookieFile): array {
     $ch = curl_init($url);
     curl_setopt_array($ch, [
         CURLOPT_RETURNTRANSFER => true,
@@ -40,8 +43,15 @@ function curl_get(string $url, string $cookieFile): string {
         CURLOPT_TIMEOUT        => 15,
     ]);
     $body = curl_exec($ch);
+    $effectiveUrl = curl_getinfo($ch, CURLINFO_EFFECTIVE_URL) ?: $url;
     curl_close($ch);
-    return $body ?: '';
+    return [$body ?: '', $effectiveUrl];
+}
+
+function isIngameGameUrl(string $baseUrl, string $url): bool
+{
+    $prefix = rtrim($baseUrl, '/') . '/game.php';
+    return str_starts_with($url, $prefix);
 }
 
 curl_post("$baseUrl/index.php?page=login", [
@@ -74,7 +84,12 @@ echo "=== Bottom nav markup check ===\n";
 echo "Base URL: $baseUrl\n\n";
 
 foreach ($fullPages as $page) {
-    $body = curl_get("$baseUrl/game.php?page=$page", $cookieFile);
+    $url = "$baseUrl/game.php?page=$page";
+    [$body, $effectiveUrl] = curl_get($url, $cookieFile);
+    if (!isIngameGameUrl($baseUrl, $effectiveUrl)) {
+        echo "[ SKIP ] full layout leaves ingame: $page → $effectiveUrl\n";
+        continue;
+    }
     if (strpos($body, 'id="bottom-nav"') === false) {
         echo "[ FAIL ] full layout missing bottom-nav: $page\n";
         $fail++;
@@ -83,7 +98,12 @@ foreach ($fullPages as $page) {
 
 foreach ($popupPages as $query) {
     $label = http_build_query($query);
-    $body = curl_get("$baseUrl/game.php?$label", $cookieFile);
+    $url = "$baseUrl/game.php?$label";
+    [$body, $effectiveUrl] = curl_get($url, $cookieFile);
+    if (!isIngameGameUrl($baseUrl, $effectiveUrl)) {
+        echo "[ SKIP ] popup layout leaves ingame: $label → $effectiveUrl\n";
+        continue;
+    }
     if (strpos($body, 'id="bottom-nav"') === false) {
         echo "[ FAIL ] popup layout missing bottom-nav: $label\n";
         $fail++;

--- a/tests/run-ci-local.sh
+++ b/tests/run-ci-local.sh
@@ -2,7 +2,7 @@
 # run-ci-local.sh — mirrors the GitHub Actions CI pipeline locally.
 #
 # Usage:
-#   ./tests/run-ci-local.sh               # unit tests + language check + smoke test
+#   ./tests/run-ci-local.sh               # unit tests + language check + smoke + bottom-nav check
 #   ./tests/run-ci-local.sh --integration # also run integration tests (requires MySQL)
 #
 # Prerequisites:
@@ -53,6 +53,7 @@ run "Language check"   php .github/scripts/check-language-files.php
 run "CSS check"        bash tests/check-css.sh
 run "Unit tests"       php vendor/bin/phpunit --configuration phpunit.xml
 run "Smoke test"       php tests/smoke.php
+run "Bottom nav check" php tests/check-bottom-nav.php
 run "Error log empty"  check_error_log
 
 if [[ $INTEGRATION -eq 1 ]]; then


### PR DESCRIPTION
## Summary
- Run `php tests/check-bottom-nav.php` in the GitHub Actions `smoke` job immediately after `tests/smoke.php` (same PHP dev server and `ADMIN_*` env as smoke).
- Add a **Bottom nav check** step to `./tests/run-ci-local.sh` after the smoke test.

## Test plan
- [ ] Confirm GitHub Actions `smoke` job runs `check-bottom-nav.php` and passes on this PR.
- [ ] Locally: start `php -S localhost:8000`, set credentials if not using defaults, run `./tests/run-ci-local.sh` and verify **Bottom nav check** passes.
- [ ] Optionally run only `php tests/check-bottom-nav.php` against a running instance.

**Note:** Bottom-nav check (like smoke) requires a running HiveNova instance on port 8000 with a valid login; CI satisfies this via `ci-install.php` and the in-job PHP built-in server.