### PR TITLE
Fix mobile fleet page header clip and bottom nav

### DIFF
--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -776,6 +776,10 @@ table.tablesorter thead tr .headerSortDown {
 }
 
 @media screen and (max-width: 699px) {
+    body.full {
+        padding-top: max(12px, env(safe-area-inset-top, 0px));
+    }
+
     .wrapper {
         grid-template-columns: 1fr;
         grid-template-rows: auto 1fr auto;
@@ -799,6 +803,8 @@ table.tablesorter thead tr .headerSortDown {
     header .fixed {
         position: sticky;
         top: 0;
+        left: 0;
+        right: 0;
         z-index: 100;
         display: grid;
         grid-template-columns: 44px 1fr;
@@ -807,9 +813,11 @@ table.tablesorter thead tr .headerSortDown {
         align-items: center;
         width: 100%;
         height: auto;
-        min-height: calc(44px + env(safe-area-inset-top, 0px));
-        padding: calc(4px + env(safe-area-inset-top, 0px)) 6px 6px 6px;
+        min-height: 80px;
+        padding: 8px 6px 6px 6px;
         max-width: none;
+        overflow: visible;
+        box-sizing: border-box;
     }
 
     content {
@@ -847,6 +855,8 @@ table.tablesorter thead tr .headerSortDown {
         grid-row: 1;
         flex-grow: 1;
         min-width: 0;
+        align-self: start;
+        padding-top: 2px;
     }
 
     #resource_mobile {
@@ -1015,7 +1025,7 @@ table.tablesorter thead tr .headerSortDown {
         left: 0;
         right: 0;
         bottom: 0;
-        z-index: 100;
+        z-index: 500;
         height: calc(56px + env(safe-area-inset-bottom, 0px));
         padding-bottom: env(safe-area-inset-bottom, 0px);
         background: var(--color-bg-surface);
@@ -1215,6 +1225,12 @@ table.tablesorter thead tr .headerSortDown {
 
     .fleet-table-desktop {
         display: none;
+    }
+
+    .fleet-bonus-table {
+        min-width: 0 !important;
+        max-width: 100% !important;
+        width: 100% !important;
     }
 
     .fleet-mobile-list {

--- a/styles/templates/game/layout.full.tpl
+++ b/styles/templates/game/layout.full.tpl
@@ -50,18 +50,19 @@
 		{include file="main.footer.tpl" nocache}
 	</footer>
 
-	<div id="pwa-install-banner" class="pwa-install-banner" hidden>
-		<p class="pwa-install-banner__title">{$LNG.pwa_install_banner_title}</p>
-		<p class="pwa-install-banner__text" data-pwa-android hidden>{$LNG.pwa_install_banner_android}</p>
-		<p class="pwa-install-banner__text" data-pwa-ios hidden>{$LNG.pwa_install_ios_steps}</p>
-		<div class="pwa-install-banner__actions">
-			<button type="button" class="button" data-pwa-install hidden>{$LNG.pwa_install_button}</button>
-			<button type="button" class="button" data-pwa-dismiss>{$LNG.pwa_install_dismiss}</button>
-		</div>
-	</div>
-
-	{include file="main.bottomnav.tpl"}
 </div>
+
+<div id="pwa-install-banner" class="pwa-install-banner" hidden>
+	<p class="pwa-install-banner__title">{$LNG.pwa_install_banner_title}</p>
+	<p class="pwa-install-banner__text" data-pwa-android hidden>{$LNG.pwa_install_banner_android}</p>
+	<p class="pwa-install-banner__text" data-pwa-ios hidden>{$LNG.pwa_install_ios_steps}</p>
+	<div class="pwa-install-banner__actions">
+		<button type="button" class="button" data-pwa-install hidden>{$LNG.pwa_install_button}</button>
+		<button type="button" class="button" data-pwa-dismiss>{$LNG.pwa_install_dismiss}</button>
+	</div>
+</div>
+
+{include file="main.bottomnav.tpl"}
 
 </body>
 </html>

--- a/styles/templates/game/page.fleetTable.default.tpl
+++ b/styles/templates/game/page.fleetTable.default.tpl
@@ -146,7 +146,7 @@
 </table>
 </form>
 <br>
-<table style="min-width:519px;width:519px;">
+<table class="table519 fleet-bonus-table">
 	<tr><th colspan="3">{$LNG.fl_bonus}</th></tr>
 	<tr><th style="width:33%">{$LNG.fl_bonus_attack}</th><th style="width:33%">{$LNG.fl_bonus_defensive}</th><th style="width:33%">{$LNG.fl_bonus_shield}</th></tr>
 	<tr><td>+{$bonusAttack} %</td><td>+{$bonusDefensive} %</td><td>+{$bonusShield} %</td></tr>


### PR DESCRIPTION
## Summary
- Moves `#bottom-nav` and the PWA install banner outside the grid `.wrapper` so `position: fixed` is not affected by grid placement (fixes missing bottom nav on some mobile/PWA views).
- Adds safe-area top padding on `body.full` and sizes the mobile header for the two-row resource/planet layout (fixes clipped resource bar).
- Makes the fleet bonus table fluid on narrow screens instead of forcing 519px width.

## Test plan
- [ ] On mobile/PWA, open `game.php?page=fleetTable` — resource bar fully visible, bottom nav pinned at bottom
- [ ] Scroll fleet page — header stays sticky, nav remains visible
- [ ] Galaxy and overview pages still show bottom nav and header correctly
- [ ] PWA install banner (when shown) sits above bottom nav without covering it