### PR TITLE
Fix mobile overview layout and command timers

### DIFF
--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -1282,14 +1282,13 @@ table.tablesorter thead tr .headerSortDown {
     }
 
     .overview-mobile-shortcuts {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: 1fr 1fr;
         gap: 8px;
         margin: 12px 0;
     }
 
     .overview-mobile-shortcuts a {
-        flex: 1 1 40%;
         min-height: 44px;
         display: flex;
         align-items: center;
@@ -1301,14 +1300,53 @@ table.tablesorter thead tr .headerSortDown {
         color: var(--color-text);
         text-decoration: none;
         font-weight: 600;
+        box-sizing: border-box;
     }
 
     .overview-command-timers {
-        padding: 10px;
+        display: block;
+        padding: 10px 12px;
         margin-bottom: 10px;
         border: 1px solid var(--color-border);
         border-radius: 8px;
         background: var(--color-bg-surface);
+        box-sizing: border-box;
+        width: 100%;
+    }
+
+    .overview-command-timers > div {
+        padding: 6px 0;
+        line-height: 1.4;
+        text-align: left;
+    }
+
+    .overview-command-timers > div + div {
+        border-top: 1px solid var(--color-border);
+    }
+
+    .overview-command-timers a {
+        font-weight: 600;
+    }
+
+    #overview .infos .moon,
+    #overview .infos .planeth {
+        float: none;
+        width: auto;
+        max-width: 100%;
+        box-sizing: border-box;
+    }
+
+    #overview .infos .planeth img {
+        float: none;
+        display: block;
+        max-width: 100%;
+        height: auto;
+        margin: 0 auto 8px;
+    }
+
+    #overview .infos .planeth {
+        clear: both;
+        padding: 10px;
     }
 
     content button,

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -49,11 +49,13 @@ $("#tn3").hide();
 	<a href="game.php?page=galaxy&amp;galaxy={$galaxy}&amp;system={$system}">{$LNG.lm_galaxy}</a>
 	<a href="game.php?page=messages">{$LNG.lm_messages}</a>
 </div>
+{if $buildInfo.buildings || $buildInfo.tech || $buildInfo.fleet}
 <div class="overview-command-timers mobile">
 	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
 	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</span></div>{/if}
 	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
 </div>
+{/if}
 	{if $messages}
 	<div class="message"><a href="?page=messages">{$messages}</a></div>
 	

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -50,7 +50,7 @@ $("#tn3").hide();
 	<a href="game.php?page=messages">{$LNG.lm_messages}</a>
 </div>
 {if $buildInfo.buildings || $buildInfo.tech || $buildInfo.fleet}
-<div class="overview-command-timers mobile">
+<div class="overview-command-timers">
 	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
 	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</span></div>{/if}
 	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
@@ -109,13 +109,17 @@ $("#tn3").hide();
 {if $Moon}<div class="moon"><a href="game.php?page=overview&amp;cp={$Moon.id}&amp;re=0" title="{$Moon.name}"><img src="{$dpath}planeten/mond.jpg" height="100" width="100" style="margin: 20% 0px 5px 0px;" alt="{$Moon.name} ({$LNG.fcm_moon})"></a><br>{$Moon.name} ({$LNG.fcm_moon})
 </div>
 {else}&nbsp;{/if}
-		<div class="planeth">
-			<img style="float: left;" src="{$dpath}planeten/{$planetimage}.jpg" height="200" width="200" alt="{$planetname}"></div><div class="planeth">
- {$planetname}<br>
-			
+		<div class="planeth overview-planet-visual">
+			<img src="{$dpath}planeten/{$planetimage}.jpg" width="200" height="200" alt="{$planetname}">
+		</div>
+		<div class="planeth overview-planet-details">
+			{$planetname}<br>
+
+			<div class="no-mobile">
 			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
 			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
 			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
+			</div>
 </br>
 {$LNG.ov_diameter}: {$LNG.ov_distance_unit} (<a title="{$LNG.ov_developed_fields}">{$planet_field_current}</a> / <a title="{$LNG.ov_max_developed_fields}">{$planet_field_max}</a> {$LNG.ov_fields})
 <br>{$LNG.ov_temperature}: {$LNG.ov_aprox} {$planet_temp_min}{$LNG.ov_temp_unit} {$LNG.ov_to} {$planet_temp_max}{$LNG.ov_temp_unit}


### PR DESCRIPTION
## Summary
- Hide the mobile command-timer panel when no build, research, or shipyard queue is active (fixes the empty strip under shortcuts).
- Style active queues in a proper full-width card (`display: block`) instead of floating unboxed text.
- Use a 2×2 grid for overview shortcut buttons and fix planet section floats on mobile (no duplicate queue rows).

## Test plan
- [ ] Mobile overview with idle queues: four shortcut tiles, no empty timer box, planet info stacks cleanly
- [ ] Start a building: timer card appears under shortcuts with readable layout
- [ ] Desktop overview unchanged (queue rows still in planet details)
- [ ] Fleet/galaxy pages still show bottom nav and header correctly