### PR TITLE
Fix overview queue timers going negative

### DIFF
--- a/includes/pages/game/ShowOverviewPage.php
+++ b/includes/pages/game/ShowOverviewPage.php
@@ -146,6 +146,7 @@ class ShowOverviewPage extends AbstractGamePage
 				'level'		=> $Queue[0][1],
 				'timeleft'	=> $time - $PLANET['b_hangar'],
 				'time'		=> $time,
+				'endtime'	=> TIMESTAMP + ($time - $PLANET['b_hangar']),
 				'starttime'	=> pretty_time($time - $PLANET['b_hangar']),
 			);
 		}

--- a/scripts/game/overview.js
+++ b/scripts/game/overview.js
@@ -1,3 +1,31 @@
+var overviewTimerReloadPending = false;
+
+function updateOverviewTimers() {
+	var needsReload = false;
+
+	$('.timer').each(function() {
+		var endTs = $(this).data('time');
+		if (endTs === undefined || endTs === null) {
+			return;
+		}
+
+		var remaining = Math.floor(endTs - serverTime.getTime() / 1000);
+		if (remaining <= 0) {
+			$(this).text(Ready);
+			needsReload = true;
+		} else {
+			$(this).text(GetRestTimeFormat(remaining));
+		}
+	});
+
+	if (needsReload && !overviewTimerReloadPending) {
+		overviewTimerReloadPending = true;
+		window.setTimeout(function() {
+			window.location.href = 'game.php?page=overview';
+		}, 1000);
+	}
+}
+
 $(document).ready(function()
 {
 	window.setInterval(function() {
@@ -10,15 +38,7 @@ $(document).ready(function()
 			}
 		})
 	}, 1000);
-	
-	window.setInterval(function() {
-		$('.timer').each(function() {
-			var s		= $(this).data('time') - (serverTime.getTime() - startTime) / 1000;
-			if(s == 0) {
-				window.location.href = "game.php?page=overview";
-			} else {
-				$(this).text(GetRestTimeFormat(s));
-			}
-		});
-	}, 1000);
+
+	window.setInterval(updateOverviewTimers, 1000);
+	updateOverviewTimers();
 });

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -51,9 +51,9 @@ $("#tn3").hide();
 </div>
 {if $buildInfo.buildings || $buildInfo.tech || $buildInfo.fleet}
 <div class="overview-command-timers">
-	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
-	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</span></div>{/if}
-	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
+	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
+	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</span></div>{/if}
+	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
 </div>
 {/if}
 	{if $messages}
@@ -116,9 +116,9 @@ $("#tn3").hide();
 			{$planetname}<br>
 
 			<div class="no-mobile">
-			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
 			</div>
 </br>
 {$LNG.ov_diameter}: {$LNG.ov_distance_unit} (<a title="{$LNG.ov_developed_fields}">{$planet_field_current}</a> / <a title="{$LNG.ov_max_developed_fields}">{$planet_field_max}</a> {$LNG.ov_fields})


### PR DESCRIPTION
## Summary
- Overview queue timers now use unix end timestamps in `data-time` (same as buildings/research pages), not seconds-remaining-at-page-load.
- When a queue finishes, the display shows **Ready** immediately instead of counting into negative values.
- Reload overview once after any queue completes (debounced), instead of only when the countdown hits exactly zero.

## Test plan
- [ ] Start a building on overview, wait for completion — timer stops at Ready, page reloads, queue row gone
- [ ] With multiple queues active, each timer counts down correctly
- [ ] No negative `00:00:-XX` values after completion