### PR TITLE
Improve fleet ship selection controls

### DIFF
--- a/scripts/game/fleet-mobile.js
+++ b/scripts/game/fleet-mobile.js
@@ -18,10 +18,6 @@
 	}
 
 	$(function () {
-		if (!window.matchMedia('(max-width: 699px)').matches) {
-			return;
-		}
-
 		$(document).on('click', '.fleet-step-minus', function () {
 			adjustShipInput($(this).data('target'), -1);
 		});

--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -312,6 +312,66 @@ textarea.tinymce {
     font-weight: bold;
 }
 
+.fleet-select-table td:last-child {
+    text-align: right;
+    vertical-align: middle;
+}
+
+.fleet-ship-stepper {
+    display: inline-flex;
+    flex-wrap: nowrap;
+    align-items: center;
+    gap: 4px;
+    max-width: 100%;
+}
+
+.fleet-ship-stepper .fleet-ship-input {
+    width: 3.25rem;
+    min-width: 2.5rem;
+    max-width: 4.5rem;
+    padding: 4px 2px;
+    margin: 0;
+    text-align: center;
+    box-sizing: border-box;
+}
+
+.fleet-select-table .fleet-ship-stepper button.fleet-ship-btn,
+.fleet-select-table .fleet-ship-bulk-actions button.fleet-ship-btn {
+    -webkit-appearance: none;
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    box-sizing: border-box;
+    padding: 4px 7px;
+    min-width: 2rem;
+    min-height: 1.75rem;
+    border-radius: 6px;
+    background: var(--color-menu-bg);
+    border: 1px solid var(--color-border);
+    color: var(--color-text);
+    font: inherit;
+    font-size: 12px;
+    line-height: 1.2;
+    cursor: pointer;
+    white-space: nowrap;
+}
+
+.fleet-select-table .fleet-ship-stepper button.fleet-ship-btn:hover,
+.fleet-select-table .fleet-ship-bulk-actions button.fleet-ship-btn:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+}
+
+td.fleet-ship-bulk-actions {
+    text-align: center;
+}
+
+.fleet-ship-bulk-actions button.fleet-ship-btn {
+    margin: 0 6px;
+    min-width: 5.5rem;
+}
+
 .build_form {
     display: inline;
 }
@@ -1267,15 +1327,29 @@ table.tablesorter thead tr .headerSortDown {
         background: var(--color-accent);
     }
 
-    .fleet-ship-stepper {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 4px;
+    .fleet-select-table .fleet-ship-stepper button.fleet-ship-btn {
+        min-height: 36px;
+        min-width: 36px;
+        padding: 4px 6px;
+        font-size: 12px;
     }
 
-    .fleet-ship-stepper button {
-        min-width: 36px;
+    .fleet-ship-stepper .fleet-ship-input {
+        width: 2.75rem;
+        min-height: 36px;
+    }
+
+    .fleet-ship-bulk-actions {
+        display: flex;
+        justify-content: center;
+        gap: 8px;
+    }
+
+    .fleet-ship-bulk-actions button.fleet-ship-btn {
+        flex: 1 1 calc(50% - 8px);
+        max-width: calc(50% - 8px);
+        min-height: 44px;
+        margin: 0;
     }
 
     .overview-mobile-shortcuts {

--- a/styles/templates/game/page.fleetTable.default.tpl
+++ b/styles/templates/game/page.fleetTable.default.tpl
@@ -102,46 +102,46 @@
 <input type="hidden" name="planet" value="{$targetPlanet}">
 <input type="hidden" name="type" value="{$targetType}">
 <input type="hidden" name="target_mission" value="{$targetMission}">
-<table class="table519">
+<table class="table519 fleet-select-table">
 	<tr>
-		<th colspan="4">{$LNG.fl_new_mission_title}</th>
+		<th colspan="3">{$LNG.fl_new_mission_title}</th>
 	</tr>
 	<tr style="height:20px;">
 		<td>{$LNG.fl_ship_type}</td>
 		<td>{$LNG.fl_ship_available}</td>
-		<td>-</td>
-		<td>-</td>
+		<td>{$LNG.fl_ammount}</td>
 	</tr>
 	{foreach $FleetsOnPlanet as $FleetRow}
 	<tr style="height:20px;">
 		<td>{if $FleetRow.speed != 0} <a class='tooltip' data-tooltip-content='<table><tr><td>{$LNG.fl_speed_title}</td><td>{$FleetRow.speed}</td></tr></table>'>{$LNG.tech.{$FleetRow.id}}</a>{else}{$LNG.tech.{$FleetRow.id}}{/if}</td>
 		<td id="ship{$FleetRow.id}_value">{$FleetRow.count|number}</td>
 		{if $FleetRow.speed != 0}
-		<td><a href="javascript:maxShip('ship{$FleetRow.id}');">{$LNG.fl_max}</a></td>
 		<td>
 			<div class="fleet-ship-stepper">
-				<button type="button" class="fleet-step-minus mobile" data-target="ship{$FleetRow.id}_input" aria-label="-1">-</button>
-				<input type="text" inputmode="numeric" name="ship{$FleetRow.id}" id="ship{$FleetRow.id}_input" size="10" placeholder="0">
-				<button type="button" class="fleet-step-plus mobile" data-target="ship{$FleetRow.id}_input" data-step="1" aria-label="+1">+</button>
-				<button type="button" class="fleet-step-plus mobile" data-target="ship{$FleetRow.id}_input" data-step="10" aria-label="+10">+10</button>
+				<button type="button" class="fleet-ship-btn fleet-step-minus" data-target="ship{$FleetRow.id}_input" aria-label="-1">-</button>
+				<input type="text" inputmode="numeric" class="fleet-ship-input" name="ship{$FleetRow.id}" id="ship{$FleetRow.id}_input" placeholder="0">
+				<button type="button" class="fleet-ship-btn fleet-step-plus" data-target="ship{$FleetRow.id}_input" data-step="1" aria-label="+1">+</button>
+				<button type="button" class="fleet-ship-btn fleet-step-plus" data-target="ship{$FleetRow.id}_input" data-step="10" aria-label="+10">+10</button>
+				<button type="button" class="fleet-ship-btn fleet-step-max" onclick="maxShip('ship{$FleetRow.id}');">{$LNG.fl_max}</button>
 			</div>
 		</td>
 		{else}
-		<td>&nbsp;</td>
 		<td>&nbsp;</td>
 		{/if}
 	</tr>
 	{/foreach}
 	<tr style="height:20px;">
 	{if $FleetsOnPlanet|count == 0}
-	<td colspan="4">{$LNG.fl_no_ships}</td>
+	<td colspan="3">{$LNG.fl_no_ships}</td>
 	{else}
-	<td colspan="2"><a href="javascript:noShips();">{$LNG.fl_remove_all_ships}</a></td>
-	<td colspan="2"><a href="javascript:maxShips();">{$LNG.fl_select_all_ships}</a></td>
+	<td colspan="3" class="fleet-ship-bulk-actions">
+		<button type="button" class="fleet-ship-btn" onclick="noShips();">{$LNG.fl_remove_all_ships}</button>
+		<button type="button" class="fleet-ship-btn" onclick="maxShips();">{$LNG.fl_select_all_ships}</button>
+	</td>
 	{/if}
 	</tr>
 	<tr id="fleetContinueRow" style="height:20px;{if $maxFleetSlots == $activeFleetSlots}display:none;{/if}">
-		<td colspan="4"><input type="submit" value="{$LNG.fl_continue}"></td>
+		<td colspan="3"><input type="submit" value="{$LNG.fl_continue}"></td>
 	</tr>
 </table>
 </form>


### PR DESCRIPTION
## Summary
- Fleet table ship picker uses a compact inline stepper: `-`, input, `+`, `+10`, and **max** on one row.
- **No ship** and **All ships** are styled as matching buttons instead of plain links.
- Stepper +/- controls work on desktop as well as mobile.

## Test plan
- [ ] Open `game.php?page=fleetTable` on a planet with ships.
- [ ] Confirm **max** sits beside **+10** on the same row.
- [ ] Confirm **No ship** / **All ships** match stepper button styling.
- [ ] Test `-`, `+`, `+10`, and **max** update ship counts correctly.
- [ ] Verify layout on mobile (~390px) and desktop.