### PR TITLE
Show overview Messages shortcut only with unread mail

### DIFF
--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -43,9 +43,11 @@ $("#tn3").hide();
 </style>	
 
 <div>
+{if $messages}
 <div class="overview-mobile-shortcuts mobile">
 	<a href="game.php?page=messages">{$LNG.lm_messages}</a>
 </div>
+{/if}
 {if $buildInfo.buildings || $buildInfo.tech || $buildInfo.fleet}
 <div class="overview-command-timers">
 	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</span></div>{/if}


### PR DESCRIPTION
## Summary
- Mobile overview **Messages** shortcut is shown only when the player has unread messages (`$messages` is set), same condition as the existing "you have new messages" notice.

## Test plan
- [ ] Overview with unread messages: shortcut visible, links to messages page.
- [ ] Overview with zero unread: shortcut hidden (messages still reachable via bottom nav Menu).
- [ ] Read all messages, return to overview: shortcut disappears after refresh.