### PR TITLE
Use game name only on login home page title

### DIFF
--- a/styles/templates/login/page.index.default.tpl
+++ b/styles/templates/login/page.index.default.tpl
@@ -1,4 +1,4 @@
-{block name="title" prepend}{$LNG.siteTitleIndex}{/block}
+{block name="title"}{$gameName}{/block}
 {block name="content"}
 <section class="hero-section">
 	<h1>{$descHeader}</h1>


### PR DESCRIPTION
## Summary
- Login index page browser title is now just the configured game name (e.g. **MOON**) instead of **Index - MOON**.

## Test plan
- [ ] Open `/index.php` and confirm the tab title is `MOON` (or your configured `game_name`).
- [ ] Other login pages (register, rules, etc.) still use their page-specific titles.