### PR TITLE
Fix ResourceUpdate warning when research planet is missing

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -370,7 +370,11 @@ function CheckNoobProtec($OwnerPlayer, $TargetPlayer, $Player)
 
 function safe_unserialize(?string $data): mixed
 {
-	return isset($data[0]) ? unserialize($data) : false;
+	if (!is_string($data) || $data === '') {
+		return false;
+	}
+
+	return unserialize($data);
 }
 
 function shortly_number($number, $decial = NULL)

--- a/includes/classes/ResourceUpdate.php
+++ b/includes/classes/ResourceUpdate.php
@@ -114,6 +114,11 @@ class ResourceUpdate
 		$this->USER			= $this->isGlobalMode ? $GLOBALS['USER'] : $USER;
 		$this->PLANET		= $this->isGlobalMode ? $GLOBALS['PLANET'] : $PLANET;
 		$this->TIME			= is_null($TIME) ? TIMESTAMP : $TIME;
+
+		if (!is_array($this->USER) || !is_array($this->PLANET)) {
+			return $this->ReturnVars();
+		}
+
 		$this->config		= Config::get($this->USER['universe']);
 		
 		if(isVacationMode($this->USER))
@@ -190,7 +195,7 @@ class ResourceUpdate
 	private function ShipyardQueue()
 	{
 		$BuildQueue 	= safe_unserialize($this->PLANET['b_hangar_id']);
-		if (!$BuildQueue) {
+		if (!is_array($BuildQueue) || $BuildQueue === array()) {
 			$this->PLANET['b_hangar'] = 0;
 			$this->PLANET['b_hangar_id'] = '';
 			return false;
@@ -200,6 +205,9 @@ class ResourceUpdate
 		$BuildArray					= array();
 		foreach($BuildQueue as $Item)
 		{
+			if (!is_array($Item) || !isset($Item[0], $Item[1])) {
+				continue;
+			}
 			$AcumTime			= BuildFunctions::getBuildingTime($this->USER, $this->PLANET, $Item[0]);
 			$BuildArray[] 		= array($Item[0], $Item[1], $AcumTime);
 		}
@@ -412,6 +420,13 @@ class ResourceUpdate
 	
 
 		$CurrentQueue	= safe_unserialize($this->USER['b_tech_queue']);
+		if (!is_array($CurrentQueue)) {
+			$this->USER['b_tech']			= 0;
+			$this->USER['b_tech_id']		= 0;
+			$this->USER['b_tech_planet']	= 0;
+			$this->USER['b_tech_queue']		= '';
+			return false;
+		}
 		array_shift($CurrentQueue);		
 			
 		$this->USER['b_tech_id']		= 0;
@@ -440,6 +455,13 @@ class ResourceUpdate
 		}
 
 		$CurrentQueue 	= safe_unserialize($this->USER['b_tech_queue']);
+		if (!is_array($CurrentQueue) || empty($CurrentQueue)) {
+			$this->USER['b_tech']			= 0;
+			$this->USER['b_tech_id']		= 0;
+			$this->USER['b_tech_planet']	= 0;
+			$this->USER['b_tech_queue']		= '';
+			return false;
+		}
 		$Loop       	= true;
 		while ($Loop == true)
 		{
@@ -451,6 +473,20 @@ class ResourceUpdate
 				$PLANET	= Database::get()->selectSingle($sql, array(
 					':planetId'	=> $ListIDArray[4],
 				));
+
+				if (empty($PLANET)) {
+					array_shift($CurrentQueue);
+					if (count($CurrentQueue) == 0) {
+						$this->USER['b_tech']			= 0;
+						$this->USER['b_tech_id']		= 0;
+						$this->USER['b_tech_planet']	= 0;
+						$this->USER['b_tech_queue']		= '';
+						$Loop							= false;
+					} else {
+						$this->USER['b_tech_queue'] = serialize(array_values($CurrentQueue));
+					}
+					continue;
+				}
 
 				$RPLANET 		= new ResourceUpdate(true, false);
 				$RPLANET->setResourceData($this->resource, $this->reslist);

--- a/includes/pages/game/ShowLogoutPage.php
+++ b/includes/pages/game/ShowLogoutPage.php
@@ -27,7 +27,7 @@ class ShowLogoutPage extends AbstractGamePage
 	function __construct() 
 	{
 		parent::__construct();
-		$this->setWindow('popup');
+		$this->setWindow('bare');
 	}
 	
 	function show() 

--- a/styles/templates/game/layout.bare.tpl
+++ b/styles/templates/game/layout.bare.tpl
@@ -1,0 +1,6 @@
+{include file="main.header.tpl" bodyclass="popup"}
+
+<div id="content">{block name="content"}{/block}</div>
+{include file="main.footer.tpl" nocache}
+</body>
+</html>

--- a/tests/Unit/GeneralFunctionsTest.php
+++ b/tests/Unit/GeneralFunctionsTest.php
@@ -23,6 +23,11 @@ class GeneralFunctionsTest extends TestCase
         $this->assertFalse(safe_unserialize(''));
     }
 
+    public function testSafeUnserializeFalseReturnsFalse(): void
+    {
+        $this->assertFalse(safe_unserialize(false));
+    }
+
     public function testSafeUnserializeValidArrayRoundtrips(): void
     {
         $data = ['foo' => 'bar', 'n' => 42];

--- a/tests/Unit/ResourceUpdateTest.php
+++ b/tests/Unit/ResourceUpdateTest.php
@@ -445,6 +445,24 @@ class ResourceUpdateTest extends TestCase
 		$this->assertSame('return 0;', $result);
 	}
 
+	public function testCalcResourceWithFalsePlanetDoesNotError(): void
+	{
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist();
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser();
+		$planet   = $this->makePlanet();
+
+		Config::setInstance($config, 1);
+		$eco = new ResourceUpdate(true, false);
+		$eco->setResourceData($resource, $reslist);
+
+		$result = $eco->CalcResource($user, false, false, $planet['last_update'] + 3600);
+
+		$this->assertIsArray($result);
+		$this->assertSame($user, $result[0]);
+	}
+
 	public function testReturnVarsReturnsArrayWhenNotGlobalMode(): void
 	{
 		$resource = $this->makeResource();


### PR DESCRIPTION
## Summary

- Fixes `Trying to access array offset on false` in `ResourceUpdate::ShipyardQueue()` (line 192) seen on overview load when a user has research queued on a planet that no longer exists.
- `SetNextQueueTechOnTop()` now drops tech-queue entries whose planet ID cannot be loaded, instead of calling `CalcResource()` with `false` from `selectSingle()`.
- Adds guards for invalid/malformed hangar and tech queues, and makes `safe_unserialize()` accept only non-empty strings.
- Hides the game menu sidebar on the logout page by switching to a new `bare` layout (header, content, footer only).

## Root cause

Research on another planet loads the planet via `Database::selectSingle()`. If that planet was deleted, `false` was passed into `CalcResource()`, and `$this->PLANET['b_hangar_id']` triggered the warning.

## Test plan

- [x] `./tests/run-ci-local.sh` (language, CSS, 398 unit tests, smoke)
- [x] `ResourceUpdateTest::testCalcResourceWithFalsePlanetDoesNotError`
- [x] `GeneralFunctionsTest::testSafeUnserializeFalseReturnsFalse`
- [ ] Manual: user with `b_tech_queue` pointing at a deleted planet loads overview without PHP warnings
- [ ] Manual: open `game.php?page=logout` and confirm no left sidebar or bottom nav; only logout message and redirect