### PR TITLE
Fix Overview queue timers and refresh loop

### DIFF
--- a/includes/pages/game/ShowOverviewPage.php
+++ b/includes/pages/game/ShowOverviewPage.php
@@ -141,14 +141,17 @@ class ShowOverviewPage extends AbstractGamePage
 		if (!empty($PLANET['b_hangar_id'])) {
 			$Queue	= safe_unserialize($PLANET['b_hangar_id']);
 			$time	= BuildFunctions::getBuildingTime($USER, $PLANET, $Queue[0][0]) * $Queue[0][1];
-			$buildInfo['fleet']	= array(
-				'id'		=> $Queue[0][0],
-				'level'		=> $Queue[0][1],
-				'timeleft'	=> $time - $PLANET['b_hangar'],
-				'time'		=> $time,
-				'endtime'	=> TIMESTAMP + ($time - $PLANET['b_hangar']),
-				'starttime'	=> pretty_time($time - $PLANET['b_hangar']),
-			);
+			$timeleft = max($time - $PLANET['b_hangar'], 0);
+			if ($timeleft > 0) {
+				$buildInfo['fleet']	= array(
+					'id'		=> $Queue[0][0],
+					'level'		=> $Queue[0][1],
+					'timeleft'	=> $timeleft,
+					'time'		=> $time,
+					'endtime'	=> TIMESTAMP + $timeleft,
+					'starttime'	=> pretty_time($timeleft),
+				);
+			}
 		}
 		else {
 			$buildInfo['fleet']	= false;

--- a/scripts/game/overview.js
+++ b/scripts/game/overview.js
@@ -1,19 +1,28 @@
 var overviewTimerReloadPending = false;
+var overviewTimersWereActive = false;
 
 function updateOverviewTimers() {
 	var needsReload = false;
 
 	$('.timer').each(function() {
-		var endTs = $(this).data('time');
-		if (endTs === undefined || endTs === null) {
+		// data-time is seconds remaining at page load (same as buildings/research pages),
+		// not a unix timestamp — serverTime is a local clock, not epoch seconds.
+		var secondsLeft = $(this).data('time');
+		if (secondsLeft === undefined || secondsLeft === null) {
 			return;
 		}
 
-		var remaining = Math.floor(endTs - serverTime.getTime() / 1000);
+		var remaining = Math.floor(secondsLeft - (serverTime.getTime() - startTime) / 1000);
 		if (remaining <= 0) {
 			$(this).text(Ready);
-			needsReload = true;
+			// Only reload after a timer was actively counting down. Timers already
+			// at zero on first paint (e.g. shipyard queue with elapsed endtime)
+			// would otherwise reload the page in an infinite loop.
+			if (overviewTimersWereActive) {
+				needsReload = true;
+			}
 		} else {
+			overviewTimersWereActive = true;
 			$(this).text(GetRestTimeFormat(remaining));
 		}
 	});

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -50,9 +50,9 @@ $("#tn3").hide();
 {/if}
 {if $buildInfo.buildings || $buildInfo.tech || $buildInfo.fleet}
 <div class="overview-command-timers">
-	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
-	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</span></div>{/if}
-	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
+	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
+	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</span></div>{/if}
+	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
 </div>
 {/if}
 	{if $messages}
@@ -115,9 +115,9 @@ $("#tn3").hide();
 			{$planetname}<br>
 
 			<div class="no-mobile">
-			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
 			</div>
 </br>
 {$LNG.ov_diameter}: {$LNG.ov_distance_unit} (<a title="{$LNG.ov_developed_fields}">{$planet_field_current}</a> / <a title="{$LNG.ov_max_developed_fields}">{$planet_field_max}</a> {$LNG.ov_fields})


### PR DESCRIPTION
## Summary
- Restore `timeleft`-based countdown on Overview (same model as buildings/research) so timers no longer flip to Ready early due to comparing unix timestamps against the local `serverTime` clock.
- Reload Overview only after a timer was actively counting down, preventing an infinite refresh when shipyard timers were already at zero on page load.
- Hide shipyard queue timers when remaining build time is zero.

## Test plan
- [ ] Start a building on Overview; confirm countdown matches `game.php?page=buildings` and does not show Ready until the build actually finishes.
- [ ] With an active shipyard queue, confirm Overview does not refresh in a loop.
- [ ] Let a queue timer reach zero; confirm a single reload updates the queue display.
- [ ] `./tests/run-ci-local.sh`