### PR TITLE
Develop to master release 5/22/26

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -370,7 +370,11 @@ function CheckNoobProtec($OwnerPlayer, $TargetPlayer, $Player)
 
 function safe_unserialize(?string $data): mixed
 {
-	return isset($data[0]) ? unserialize($data) : false;
+	if (!is_string($data) || $data === '') {
+		return false;
+	}
+
+	return unserialize($data);
 }
 
 function shortly_number($number, $decial = NULL)

--- a/includes/classes/ResourceUpdate.php
+++ b/includes/classes/ResourceUpdate.php
@@ -114,6 +114,11 @@ class ResourceUpdate
 		$this->USER			= $this->isGlobalMode ? $GLOBALS['USER'] : $USER;
 		$this->PLANET		= $this->isGlobalMode ? $GLOBALS['PLANET'] : $PLANET;
 		$this->TIME			= is_null($TIME) ? TIMESTAMP : $TIME;
+
+		if (!is_array($this->USER) || !is_array($this->PLANET)) {
+			return $this->ReturnVars();
+		}
+
 		$this->config		= Config::get($this->USER['universe']);
 		
 		if(isVacationMode($this->USER))
@@ -190,7 +195,7 @@ class ResourceUpdate
 	private function ShipyardQueue()
 	{
 		$BuildQueue 	= safe_unserialize($this->PLANET['b_hangar_id']);
-		if (!$BuildQueue) {
+		if (!is_array($BuildQueue) || $BuildQueue === array()) {
 			$this->PLANET['b_hangar'] = 0;
 			$this->PLANET['b_hangar_id'] = '';
 			return false;
@@ -200,6 +205,9 @@ class ResourceUpdate
 		$BuildArray					= array();
 		foreach($BuildQueue as $Item)
 		{
+			if (!is_array($Item) || !isset($Item[0], $Item[1])) {
+				continue;
+			}
 			$AcumTime			= BuildFunctions::getBuildingTime($this->USER, $this->PLANET, $Item[0]);
 			$BuildArray[] 		= array($Item[0], $Item[1], $AcumTime);
 		}
@@ -412,6 +420,13 @@ class ResourceUpdate
 	
 
 		$CurrentQueue	= safe_unserialize($this->USER['b_tech_queue']);
+		if (!is_array($CurrentQueue)) {
+			$this->USER['b_tech']			= 0;
+			$this->USER['b_tech_id']		= 0;
+			$this->USER['b_tech_planet']	= 0;
+			$this->USER['b_tech_queue']		= '';
+			return false;
+		}
 		array_shift($CurrentQueue);		
 			
 		$this->USER['b_tech_id']		= 0;
@@ -440,6 +455,13 @@ class ResourceUpdate
 		}
 
 		$CurrentQueue 	= safe_unserialize($this->USER['b_tech_queue']);
+		if (!is_array($CurrentQueue) || empty($CurrentQueue)) {
+			$this->USER['b_tech']			= 0;
+			$this->USER['b_tech_id']		= 0;
+			$this->USER['b_tech_planet']	= 0;
+			$this->USER['b_tech_queue']		= '';
+			return false;
+		}
 		$Loop       	= true;
 		while ($Loop == true)
 		{
@@ -451,6 +473,20 @@ class ResourceUpdate
 				$PLANET	= Database::get()->selectSingle($sql, array(
 					':planetId'	=> $ListIDArray[4],
 				));
+
+				if (empty($PLANET)) {
+					array_shift($CurrentQueue);
+					if (count($CurrentQueue) == 0) {
+						$this->USER['b_tech']			= 0;
+						$this->USER['b_tech_id']		= 0;
+						$this->USER['b_tech_planet']	= 0;
+						$this->USER['b_tech_queue']		= '';
+						$Loop							= false;
+					} else {
+						$this->USER['b_tech_queue'] = serialize(array_values($CurrentQueue));
+					}
+					continue;
+				}
 
 				$RPLANET 		= new ResourceUpdate(true, false);
 				$RPLANET->setResourceData($this->resource, $this->reslist);

--- a/includes/pages/game/ShowLogoutPage.php
+++ b/includes/pages/game/ShowLogoutPage.php
@@ -27,7 +27,7 @@ class ShowLogoutPage extends AbstractGamePage
 	function __construct() 
 	{
 		parent::__construct();
-		$this->setWindow('popup');
+		$this->setWindow('bare');
 	}
 	
 	function show() 

--- a/includes/pages/game/ShowOverviewPage.php
+++ b/includes/pages/game/ShowOverviewPage.php
@@ -141,14 +141,17 @@ class ShowOverviewPage extends AbstractGamePage
 		if (!empty($PLANET['b_hangar_id'])) {
 			$Queue	= safe_unserialize($PLANET['b_hangar_id']);
 			$time	= BuildFunctions::getBuildingTime($USER, $PLANET, $Queue[0][0]) * $Queue[0][1];
-			$buildInfo['fleet']	= array(
-				'id'		=> $Queue[0][0],
-				'level'		=> $Queue[0][1],
-				'timeleft'	=> $time - $PLANET['b_hangar'],
-				'time'		=> $time,
-				'endtime'	=> TIMESTAMP + ($time - $PLANET['b_hangar']),
-				'starttime'	=> pretty_time($time - $PLANET['b_hangar']),
-			);
+			$timeleft = max($time - $PLANET['b_hangar'], 0);
+			if ($timeleft > 0) {
+				$buildInfo['fleet']	= array(
+					'id'		=> $Queue[0][0],
+					'level'		=> $Queue[0][1],
+					'timeleft'	=> $timeleft,
+					'time'		=> $time,
+					'endtime'	=> TIMESTAMP + $timeleft,
+					'starttime'	=> pretty_time($timeleft),
+				);
+			}
 		}
 		else {
 			$buildInfo['fleet']	= false;

--- a/scripts/game/overview.js
+++ b/scripts/game/overview.js
@@ -1,19 +1,28 @@
 var overviewTimerReloadPending = false;
+var overviewTimersWereActive = false;
 
 function updateOverviewTimers() {
 	var needsReload = false;
 
 	$('.timer').each(function() {
-		var endTs = $(this).data('time');
-		if (endTs === undefined || endTs === null) {
+		// data-time is seconds remaining at page load (same as buildings/research pages),
+		// not a unix timestamp — serverTime is a local clock, not epoch seconds.
+		var secondsLeft = $(this).data('time');
+		if (secondsLeft === undefined || secondsLeft === null) {
 			return;
 		}
 
-		var remaining = Math.floor(endTs - serverTime.getTime() / 1000);
+		var remaining = Math.floor(secondsLeft - (serverTime.getTime() - startTime) / 1000);
 		if (remaining <= 0) {
 			$(this).text(Ready);
-			needsReload = true;
+			// Only reload after a timer was actively counting down. Timers already
+			// at zero on first paint (e.g. shipyard queue with elapsed endtime)
+			// would otherwise reload the page in an infinite loop.
+			if (overviewTimersWereActive) {
+				needsReload = true;
+			}
 		} else {
+			overviewTimersWereActive = true;
 			$(this).text(GetRestTimeFormat(remaining));
 		}
 	});

--- a/styles/templates/game/layout.bare.tpl
+++ b/styles/templates/game/layout.bare.tpl
@@ -1,0 +1,6 @@
+{include file="main.header.tpl" bodyclass="popup"}
+
+<div id="content">{block name="content"}{/block}</div>
+{include file="main.footer.tpl" nocache}
+</body>
+</html>

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -50,9 +50,9 @@ $("#tn3").hide();
 {/if}
 {if $buildInfo.buildings || $buildInfo.tech || $buildInfo.fleet}
 <div class="overview-command-timers">
-	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
-	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</span></div>{/if}
-	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
+	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
+	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</span></div>{/if}
+	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
 </div>
 {/if}
 	{if $messages}
@@ -115,9 +115,9 @@ $("#tn3").hide();
 			{$planetname}<br>
 
 			<div class="no-mobile">
-			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
 			</div>
 </br>
 {$LNG.ov_diameter}: {$LNG.ov_distance_unit} (<a title="{$LNG.ov_developed_fields}">{$planet_field_current}</a> / <a title="{$LNG.ov_max_developed_fields}">{$planet_field_max}</a> {$LNG.ov_fields})

--- a/tests/Unit/GeneralFunctionsTest.php
+++ b/tests/Unit/GeneralFunctionsTest.php
@@ -23,6 +23,11 @@ class GeneralFunctionsTest extends TestCase
         $this->assertFalse(safe_unserialize(''));
     }
 
+    public function testSafeUnserializeFalseReturnsFalse(): void
+    {
+        $this->assertFalse(safe_unserialize(false));
+    }
+
     public function testSafeUnserializeValidArrayRoundtrips(): void
     {
         $data = ['foo' => 'bar', 'n' => 42];

--- a/tests/Unit/ResourceUpdateTest.php
+++ b/tests/Unit/ResourceUpdateTest.php
@@ -445,6 +445,24 @@ class ResourceUpdateTest extends TestCase
 		$this->assertSame('return 0;', $result);
 	}
 
+	public function testCalcResourceWithFalsePlanetDoesNotError(): void
+	{
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist();
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser();
+		$planet   = $this->makePlanet();
+
+		Config::setInstance($config, 1);
+		$eco = new ResourceUpdate(true, false);
+		$eco->setResourceData($resource, $reslist);
+
+		$result = $eco->CalcResource($user, false, false, $planet['last_update'] + 3600);
+
+		$this->assertIsArray($result);
+		$this->assertSame($user, $result[0]);
+	}
+
 	public function testReturnVarsReturnsArrayWhenNotGlobalMode(): void
 	{
 		$resource = $this->makeResource();


### PR DESCRIPTION
## Summary

- Fix overview build/research/shipyard timers showing "Ready" too early and stop the refresh loop from re-fetching every second after completion (#182).
- Fix `ResourceUpdate` warnings when tech queue references a deleted planet; harden queue deserialization and `safe_unserialize()` (#181).

## Test plan

- [ ] On overview, confirm queue timers count down correctly and show Ready only when complete (no premature Ready, no endless reload).
- [ ] With a user whose research queue points at a removed planet, confirm no PHP warnings and queue advances/skips safely.
- [ ] Run `./tests/run-ci-local.sh` (or confirm CI green on this PR).
- [ ] Smoke-test login and overview after deploy to production.