### PR TITLE
Compact galaxy mobile layout to fit full solar system

### DIFF
--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -1127,21 +1127,25 @@ table.tablesorter thead tr .headerSortDown {
     }
 
     .galaxy-system-table tr {
-        margin-bottom: 10px;
+        margin-bottom: 3px;
         border: 1px solid var(--color-border);
-        border-radius: 8px;
-        padding: 8px;
+        border-radius: 4px;
+        padding: 3px 5px;
         background: var(--color-bg-surface);
     }
 
     .galaxy-system-table tr:not(.galaxy-planet-row) {
         display: block;
+        margin-bottom: 4px;
+        padding: 4px 6px;
+        font-size: 12px;
+        line-height: 1.3;
     }
 
     .galaxy-system-table tr:not(.galaxy-planet-row) td {
         display: block;
         text-align: left;
-        padding: 4px 0;
+        padding: 2px 0;
         border: none;
     }
 
@@ -1149,8 +1153,8 @@ table.tablesorter thead tr .headerSortDown {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        column-gap: 8px;
-        row-gap: 4px;
+        column-gap: 4px;
+        row-gap: 0;
         width: 100%;
     }
 
@@ -1168,40 +1172,50 @@ table.tablesorter thead tr .headerSortDown {
 
     .galaxy-planet-row td:nth-child(1) {
         order: 0;
-        flex: 0 0 26px;
+        flex: 0 0 18px;
         font-weight: bold;
+        font-size: 12px;
         text-align: center;
-        line-height: 36px;
+        line-height: 28px;
     }
 
     .galaxy-planet-row td:nth-child(2) {
         order: 1;
-        flex: 0 0 36px;
-        align-self: flex-start;
-        padding-top: 2px;
+        flex: 0 0 28px;
+        align-self: center;
+        padding-top: 0;
     }
 
     .galaxy-planet-row td:nth-child(2) img {
         display: block;
-        width: 36px;
-        height: 36px;
+        width: 28px;
+        height: 28px;
     }
 
     .galaxy-planet-row td:nth-child(3) {
         order: 2;
-        flex: 1 1 8rem;
+        flex: 1 1 4rem;
         min-width: 0;
         font-weight: bold;
-        line-height: 1.3;
-        white-space: normal;
+        font-size: 12px;
+        line-height: 1.2;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .galaxy-planet-row td:nth-child(6) {
-        order: 7;
-        flex: 1 1 100%;
-        padding-left: 70px;
-        line-height: 1.3;
-        white-space: normal;
+        order: 2;
+        flex: 0 1 auto;
+        min-width: 0;
+        max-width: 42%;
+        padding-left: 0;
+        font-size: 11px;
+        line-height: 1.2;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        opacity: 0.85;
     }
 
     .galaxy-planet-row td:nth-child(4),
@@ -1231,53 +1245,72 @@ table.tablesorter thead tr .headerSortDown {
     .galaxy-planet-row td:nth-child(4) img,
     .galaxy-planet-row td:nth-child(5) img {
         display: block;
-        width: 28px;
-        height: 28px;
+        width: 22px;
+        height: 22px;
     }
 
     .galaxy-planet-row .galaxy-card-actions-cell {
         display: inline-flex;
         flex-wrap: nowrap;
         align-items: center;
-        gap: 2px;
+        gap: 0;
     }
 
     .galaxy-planet-row .galaxy-card-actions-cell img {
-        min-width: 32px;
-        min-height: 32px;
-        width: 32px;
-        height: 32px;
-        padding: 4px;
+        min-width: 24px;
+        min-height: 24px;
+        width: 24px;
+        height: 24px;
+        padding: 2px;
     }
 
     .galaxy-coords-picker {
         width: 100%;
         min-width: 0;
-        grid-template-columns: 1fr;
-        gap: 10px;
-        margin-bottom: 12px;
+        grid-template-columns: 1fr 1fr;
+        gap: 4px 6px;
+        margin-bottom: 6px;
+    }
+
+    .galaxy-coords-title {
+        padding: 2px 4px;
+        font-size: 11px;
     }
 
     .galaxy-coords-controls {
-        grid-template-columns: minmax(56px, auto) 1fr minmax(56px, auto);
-        gap: 10px;
+        grid-template-columns: 36px 1fr 36px;
+        gap: 4px;
         padding: 0;
     }
 
     .galaxy-coords-controls .galaxy-coords-step {
-        min-height: 56px;
-        min-width: 56px;
-        font-size: 30px;
+        min-height: 36px;
+        min-width: 36px;
+        font-size: 18px;
     }
 
     .galaxy-coords-controls input[type="text"] {
-        min-height: 56px;
-        font-size: 24px;
+        min-height: 36px;
+        font-size: 16px;
+        padding: 2px 4px;
+    }
+
+    .galaxy-coords-submit {
+        padding: 2px 0 0;
     }
 
     .galaxy-coords-submit input[type="submit"] {
         width: 100%;
-        min-height: 44px;
+        min-height: 36px;
+        padding: 4px 8px;
+        font-size: 14px;
+    }
+
+    .galaxy-coords-warning {
+        font-size: 10px;
+        line-height: 1.2;
+        padding: 2px 4px 0;
+        text-align: center;
     }
 
     .fleet-table-desktop {


### PR DESCRIPTION
## Summary
- Puts galaxy and system coordinate pickers side by side on mobile with smaller step buttons and inputs (was stacked full-width at 56px tall).
- Denser planet rows: smaller thumbnails, name and username on one line, tighter card padding so more of the 15-slot system is visible without scrolling.
- Slightly smaller footer rows (legend, fleet counts) on mobile.

Player feedback: galaxy/system controls were too large to see a whole solar system on one screen.

## Test plan
- [ ] On a phone or narrow viewport (<700px), open Galaxy and confirm galaxy + system pickers appear in one row with compact controls.
- [ ] View a populated system and confirm most or all planet slots are visible with minimal scrolling.
- [ ] Confirm planet name, username, moon/debris icons, and action buttons remain usable.
- [ ] Desktop galaxy layout unchanged (breakpoint >699px).
- [ ] `bash tests/check-css.sh` passes.