### PR TITLE
Mobile galaxy layout, overview timer fix, queue hardening

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -370,7 +370,11 @@ function CheckNoobProtec($OwnerPlayer, $TargetPlayer, $Player)
 
 function safe_unserialize(?string $data): mixed
 {
-	return isset($data[0]) ? unserialize($data) : false;
+	if (!is_string($data) || $data === '') {
+		return false;
+	}
+
+	return unserialize($data);
 }
 
 function shortly_number($number, $decial = NULL)

--- a/includes/classes/ResourceUpdate.php
+++ b/includes/classes/ResourceUpdate.php
@@ -195,7 +195,7 @@ class ResourceUpdate
 	private function ShipyardQueue()
 	{
 		$BuildQueue 	= safe_unserialize($this->PLANET['b_hangar_id']);
-		if (!is_array($BuildQueue) || $BuildQueue === array()) {
+		if (!is_array($BuildQueue) || empty($BuildQueue)) {
 			$this->PLANET['b_hangar'] = 0;
 			$this->PLANET['b_hangar_id'] = '';
 			return false;
@@ -271,6 +271,11 @@ class ResourceUpdate
 			return false;
 		
 		$CurrentQueue	= safe_unserialize($this->PLANET['b_building_id']);
+		if (!is_array($CurrentQueue) || empty($CurrentQueue[0]) || !is_array($CurrentQueue[0])) {
+			$this->PLANET['b_building']		= 0;
+			$this->PLANET['b_building_id']	= '';
+			return false;
+		}
 
 		$Element      	= $CurrentQueue[0][0];
 		$BuildEndTime 	= $CurrentQueue[0][3];
@@ -442,6 +447,16 @@ class ResourceUpdate
 		}
 	}	
 	
+	private function clearTechQueueState(array $currentQueue): void
+	{
+		$this->USER['b_tech']			= 0;
+		$this->USER['b_tech_id']		= 0;
+		$this->USER['b_tech_planet']	= 0;
+		$this->USER['b_tech_queue']		= empty($currentQueue)
+			? ''
+			: serialize(array_values($currentQueue));
+	}
+
 	public function SetNextQueueTechOnTop()
 	{
 		global $LNG;
@@ -466,6 +481,15 @@ class ResourceUpdate
 		while ($Loop == true)
 		{
 			$ListIDArray        = $CurrentQueue[0];
+			if (!is_array($ListIDArray) || !isset($ListIDArray[0], $ListIDArray[4])) {
+				array_shift($CurrentQueue);
+				$this->clearTechQueueState($CurrentQueue);
+				if (empty($CurrentQueue)) {
+					$Loop = false;
+				}
+				continue;
+			}
+
 			$isAnotherPlanet	= $ListIDArray[4] != $this->PLANET['id'];
 			if($isAnotherPlanet)
 			{
@@ -476,14 +500,9 @@ class ResourceUpdate
 
 				if (empty($PLANET)) {
 					array_shift($CurrentQueue);
-					if (count($CurrentQueue) == 0) {
-						$this->USER['b_tech']			= 0;
-						$this->USER['b_tech_id']		= 0;
-						$this->USER['b_tech_planet']	= 0;
-						$this->USER['b_tech_queue']		= '';
-						$Loop							= false;
-					} else {
-						$this->USER['b_tech_queue'] = serialize(array_values($CurrentQueue));
+					$this->clearTechQueueState($CurrentQueue);
+					if (empty($CurrentQueue)) {
+						$Loop = false;
 					}
 					continue;
 				}

--- a/includes/classes/ResourceUpdate.php
+++ b/includes/classes/ResourceUpdate.php
@@ -114,6 +114,11 @@ class ResourceUpdate
 		$this->USER			= $this->isGlobalMode ? $GLOBALS['USER'] : $USER;
 		$this->PLANET		= $this->isGlobalMode ? $GLOBALS['PLANET'] : $PLANET;
 		$this->TIME			= is_null($TIME) ? TIMESTAMP : $TIME;
+
+		if (!is_array($this->USER) || !is_array($this->PLANET)) {
+			return $this->ReturnVars();
+		}
+
 		$this->config		= Config::get($this->USER['universe']);
 		
 		if(isVacationMode($this->USER))
@@ -190,7 +195,7 @@ class ResourceUpdate
 	private function ShipyardQueue()
 	{
 		$BuildQueue 	= safe_unserialize($this->PLANET['b_hangar_id']);
-		if (!$BuildQueue) {
+		if (!is_array($BuildQueue) || $BuildQueue === array()) {
 			$this->PLANET['b_hangar'] = 0;
 			$this->PLANET['b_hangar_id'] = '';
 			return false;
@@ -200,6 +205,9 @@ class ResourceUpdate
 		$BuildArray					= array();
 		foreach($BuildQueue as $Item)
 		{
+			if (!is_array($Item) || !isset($Item[0], $Item[1])) {
+				continue;
+			}
 			$AcumTime			= BuildFunctions::getBuildingTime($this->USER, $this->PLANET, $Item[0]);
 			$BuildArray[] 		= array($Item[0], $Item[1], $AcumTime);
 		}
@@ -412,6 +420,13 @@ class ResourceUpdate
 	
 
 		$CurrentQueue	= safe_unserialize($this->USER['b_tech_queue']);
+		if (!is_array($CurrentQueue)) {
+			$this->USER['b_tech']			= 0;
+			$this->USER['b_tech_id']		= 0;
+			$this->USER['b_tech_planet']	= 0;
+			$this->USER['b_tech_queue']		= '';
+			return false;
+		}
 		array_shift($CurrentQueue);		
 			
 		$this->USER['b_tech_id']		= 0;
@@ -440,6 +455,13 @@ class ResourceUpdate
 		}
 
 		$CurrentQueue 	= safe_unserialize($this->USER['b_tech_queue']);
+		if (!is_array($CurrentQueue) || empty($CurrentQueue)) {
+			$this->USER['b_tech']			= 0;
+			$this->USER['b_tech_id']		= 0;
+			$this->USER['b_tech_planet']	= 0;
+			$this->USER['b_tech_queue']		= '';
+			return false;
+		}
 		$Loop       	= true;
 		while ($Loop == true)
 		{
@@ -451,6 +473,20 @@ class ResourceUpdate
 				$PLANET	= Database::get()->selectSingle($sql, array(
 					':planetId'	=> $ListIDArray[4],
 				));
+
+				if (empty($PLANET)) {
+					array_shift($CurrentQueue);
+					if (count($CurrentQueue) == 0) {
+						$this->USER['b_tech']			= 0;
+						$this->USER['b_tech_id']		= 0;
+						$this->USER['b_tech_planet']	= 0;
+						$this->USER['b_tech_queue']		= '';
+						$Loop							= false;
+					} else {
+						$this->USER['b_tech_queue'] = serialize(array_values($CurrentQueue));
+					}
+					continue;
+				}
 
 				$RPLANET 		= new ResourceUpdate(true, false);
 				$RPLANET->setResourceData($this->resource, $this->reslist);

--- a/includes/pages/game/ShowLogoutPage.php
+++ b/includes/pages/game/ShowLogoutPage.php
@@ -27,7 +27,7 @@ class ShowLogoutPage extends AbstractGamePage
 	function __construct() 
 	{
 		parent::__construct();
-		$this->setWindow('popup');
+		$this->setWindow('bare');
 	}
 	
 	function show() 

--- a/includes/pages/game/ShowOverviewPage.php
+++ b/includes/pages/game/ShowOverviewPage.php
@@ -141,14 +141,17 @@ class ShowOverviewPage extends AbstractGamePage
 		if (!empty($PLANET['b_hangar_id'])) {
 			$Queue	= safe_unserialize($PLANET['b_hangar_id']);
 			$time	= BuildFunctions::getBuildingTime($USER, $PLANET, $Queue[0][0]) * $Queue[0][1];
-			$buildInfo['fleet']	= array(
-				'id'		=> $Queue[0][0],
-				'level'		=> $Queue[0][1],
-				'timeleft'	=> $time - $PLANET['b_hangar'],
-				'time'		=> $time,
-				'endtime'	=> TIMESTAMP + ($time - $PLANET['b_hangar']),
-				'starttime'	=> pretty_time($time - $PLANET['b_hangar']),
-			);
+			$timeleft = max($time - $PLANET['b_hangar'], 0);
+			if ($timeleft > 0) {
+				$buildInfo['fleet']	= array(
+					'id'		=> $Queue[0][0],
+					'level'		=> $Queue[0][1],
+					'timeleft'	=> $timeleft,
+					'time'		=> $time,
+					'endtime'	=> TIMESTAMP + $timeleft,
+					'starttime'	=> pretty_time($timeleft),
+				);
+			}
 		}
 		else {
 			$buildInfo['fleet']	= false;

--- a/includes/pages/game/ShowOverviewPage.php
+++ b/includes/pages/game/ShowOverviewPage.php
@@ -104,7 +104,11 @@ class ShowOverviewPage extends AbstractGamePage
 
 			if (!empty($CPLANET['b_building']) && $CPLANET['b_building'] > TIMESTAMP) {
 				$Queue				= safe_unserialize($CPLANET['b_building_id']);
-				$BuildPlanet		= $LNG['tech'][$Queue[0][0]]." (".$Queue[0][1].")<br><span style=\"color:#7F7F7F;\">(".pretty_time($Queue[0][3] - TIMESTAMP).")</span>";
+				if (is_array($Queue) && isset($Queue[0][0], $Queue[0][3])) {
+					$BuildPlanet	= $LNG['tech'][$Queue[0][0]]." (".$Queue[0][1].")<br><span style=\"color:#7F7F7F;\">(".pretty_time($Queue[0][3] - TIMESTAMP).")</span>";
+				} else {
+					$BuildPlanet	= $LNG['ov_free'];
+				}
 			} else {
 				$BuildPlanet     = $LNG['ov_free'];
 			}
@@ -126,13 +130,17 @@ class ShowOverviewPage extends AbstractGamePage
 			
 		if ($PLANET['b_building'] - TIMESTAMP > 0) {
 			$Queue			= safe_unserialize($PLANET['b_building_id']);
-			$buildInfo['buildings']	= array(
-				'id'		=> $Queue[0][0],
-				'level'		=> $Queue[0][1],
-				'timeleft'	=> $PLANET['b_building'] - TIMESTAMP,
-				'time'		=> $PLANET['b_building'],
-				'starttime'	=> pretty_time($PLANET['b_building'] - TIMESTAMP),
-			);
+			if (is_array($Queue) && isset($Queue[0][0], $Queue[0][1])) {
+				$buildInfo['buildings']	= array(
+					'id'		=> $Queue[0][0],
+					'level'		=> $Queue[0][1],
+					'timeleft'	=> $PLANET['b_building'] - TIMESTAMP,
+					'time'		=> $PLANET['b_building'],
+					'starttime'	=> pretty_time($PLANET['b_building'] - TIMESTAMP),
+				);
+			} else {
+				$buildInfo['buildings']	= false;
+			}
 		}
 		else {
 			$buildInfo['buildings']	= false;
@@ -140,17 +148,19 @@ class ShowOverviewPage extends AbstractGamePage
 		
 		if (!empty($PLANET['b_hangar_id'])) {
 			$Queue	= safe_unserialize($PLANET['b_hangar_id']);
-			$time	= BuildFunctions::getBuildingTime($USER, $PLANET, $Queue[0][0]) * $Queue[0][1];
-			$timeleft = max($time - $PLANET['b_hangar'], 0);
-			if ($timeleft > 0) {
+			if (is_array($Queue) && isset($Queue[0][0], $Queue[0][1])) {
+				$time		= BuildFunctions::getBuildingTime($USER, $PLANET, $Queue[0][0]) * $Queue[0][1];
+				$timeleft	= max($time - $PLANET['b_hangar'], 0);
 				$buildInfo['fleet']	= array(
 					'id'		=> $Queue[0][0],
 					'level'		=> $Queue[0][1],
 					'timeleft'	=> $timeleft,
 					'time'		=> $time,
 					'endtime'	=> TIMESTAMP + $timeleft,
-					'starttime'	=> pretty_time($timeleft),
+					'starttime'	=> $timeleft > 0 ? pretty_time($timeleft) : $LNG['ready'],
 				);
+			} else {
+				$buildInfo['fleet']	= false;
 			}
 		}
 		else {
@@ -159,13 +169,17 @@ class ShowOverviewPage extends AbstractGamePage
 		
 		if ($USER['b_tech'] - TIMESTAMP > 0) {
 			$Queue			= safe_unserialize($USER['b_tech_queue']);
-			$buildInfo['tech']	= array(
-				'id'		=> $Queue[0][0],
-				'level'		=> $Queue[0][1],
-				'timeleft'	=> $USER['b_tech'] - TIMESTAMP,
-				'time'		=> $USER['b_tech'],
-				'starttime'	=> pretty_time($USER['b_tech'] - TIMESTAMP),
-			);
+			if (is_array($Queue) && isset($Queue[0][0], $Queue[0][1])) {
+				$buildInfo['tech']	= array(
+					'id'		=> $Queue[0][0],
+					'level'		=> $Queue[0][1],
+					'timeleft'	=> $USER['b_tech'] - TIMESTAMP,
+					'time'		=> $USER['b_tech'],
+					'starttime'	=> pretty_time($USER['b_tech'] - TIMESTAMP),
+				);
+			} else {
+				$buildInfo['tech']	= false;
+			}
 		}
 		else {
 			$buildInfo['tech']	= false;

--- a/scripts/game/overview.js
+++ b/scripts/game/overview.js
@@ -1,19 +1,28 @@
 var overviewTimerReloadPending = false;
+var overviewTimersWereActive = false;
 
 function updateOverviewTimers() {
 	var needsReload = false;
 
 	$('.timer').each(function() {
-		var endTs = $(this).data('time');
-		if (endTs === undefined || endTs === null) {
+		// data-time is seconds remaining at page load (same as buildings/research pages),
+		// not a unix timestamp — serverTime is a local clock, not epoch seconds.
+		var secondsLeft = $(this).data('time');
+		if (secondsLeft === undefined || secondsLeft === null) {
 			return;
 		}
 
-		var remaining = Math.floor(endTs - serverTime.getTime() / 1000);
+		var remaining = Math.floor(secondsLeft - (serverTime.getTime() - startTime) / 1000);
 		if (remaining <= 0) {
 			$(this).text(Ready);
-			needsReload = true;
+			// Only reload after a timer was actively counting down. Timers already
+			// at zero on first paint (e.g. shipyard queue with elapsed endtime)
+			// would otherwise reload the page in an infinite loop.
+			if (overviewTimersWereActive) {
+				needsReload = true;
+			}
 		} else {
+			overviewTimersWereActive = true;
 			$(this).text(GetRestTimeFormat(remaining));
 		}
 	});

--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -1127,21 +1127,25 @@ table.tablesorter thead tr .headerSortDown {
     }
 
     .galaxy-system-table tr {
-        margin-bottom: 10px;
+        margin-bottom: 3px;
         border: 1px solid var(--color-border);
-        border-radius: 8px;
-        padding: 8px;
+        border-radius: 4px;
+        padding: 3px 5px;
         background: var(--color-bg-surface);
     }
 
     .galaxy-system-table tr:not(.galaxy-planet-row) {
         display: block;
+        margin-bottom: 4px;
+        padding: 4px 6px;
+        font-size: 12px;
+        line-height: 1.3;
     }
 
     .galaxy-system-table tr:not(.galaxy-planet-row) td {
         display: block;
         text-align: left;
-        padding: 4px 0;
+        padding: 2px 0;
         border: none;
     }
 
@@ -1149,8 +1153,8 @@ table.tablesorter thead tr .headerSortDown {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
-        column-gap: 8px;
-        row-gap: 4px;
+        column-gap: 4px;
+        row-gap: 0;
         width: 100%;
     }
 
@@ -1168,40 +1172,50 @@ table.tablesorter thead tr .headerSortDown {
 
     .galaxy-planet-row td:nth-child(1) {
         order: 0;
-        flex: 0 0 26px;
+        flex: 0 0 18px;
         font-weight: bold;
+        font-size: 12px;
         text-align: center;
-        line-height: 36px;
+        line-height: 28px;
     }
 
     .galaxy-planet-row td:nth-child(2) {
         order: 1;
-        flex: 0 0 36px;
-        align-self: flex-start;
-        padding-top: 2px;
+        flex: 0 0 28px;
+        align-self: center;
+        padding-top: 0;
     }
 
     .galaxy-planet-row td:nth-child(2) img {
         display: block;
-        width: 36px;
-        height: 36px;
+        width: 28px;
+        height: 28px;
     }
 
     .galaxy-planet-row td:nth-child(3) {
         order: 2;
-        flex: 1 1 8rem;
+        flex: 1 1 4rem;
         min-width: 0;
         font-weight: bold;
-        line-height: 1.3;
-        white-space: normal;
+        font-size: 12px;
+        line-height: 1.2;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 
     .galaxy-planet-row td:nth-child(6) {
-        order: 7;
-        flex: 1 1 100%;
-        padding-left: 70px;
-        line-height: 1.3;
-        white-space: normal;
+        order: 2;
+        flex: 0 1 auto;
+        min-width: 0;
+        max-width: 42%;
+        padding-left: 0;
+        font-size: 11px;
+        line-height: 1.2;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        opacity: 0.85;
     }
 
     .galaxy-planet-row td:nth-child(4),
@@ -1231,53 +1245,72 @@ table.tablesorter thead tr .headerSortDown {
     .galaxy-planet-row td:nth-child(4) img,
     .galaxy-planet-row td:nth-child(5) img {
         display: block;
-        width: 28px;
-        height: 28px;
+        width: 22px;
+        height: 22px;
     }
 
     .galaxy-planet-row .galaxy-card-actions-cell {
         display: inline-flex;
         flex-wrap: nowrap;
         align-items: center;
-        gap: 2px;
+        gap: 0;
     }
 
     .galaxy-planet-row .galaxy-card-actions-cell img {
-        min-width: 32px;
-        min-height: 32px;
-        width: 32px;
-        height: 32px;
-        padding: 4px;
+        min-width: 24px;
+        min-height: 24px;
+        width: 24px;
+        height: 24px;
+        padding: 2px;
     }
 
     .galaxy-coords-picker {
         width: 100%;
         min-width: 0;
-        grid-template-columns: 1fr;
-        gap: 10px;
-        margin-bottom: 12px;
+        grid-template-columns: 1fr 1fr;
+        gap: 4px 6px;
+        margin-bottom: 6px;
+    }
+
+    .galaxy-coords-title {
+        padding: 2px 4px;
+        font-size: 11px;
     }
 
     .galaxy-coords-controls {
-        grid-template-columns: minmax(56px, auto) 1fr minmax(56px, auto);
-        gap: 10px;
+        grid-template-columns: 36px 1fr 36px;
+        gap: 4px;
         padding: 0;
     }
 
     .galaxy-coords-controls .galaxy-coords-step {
-        min-height: 56px;
-        min-width: 56px;
-        font-size: 30px;
+        min-height: 36px;
+        min-width: 36px;
+        font-size: 18px;
     }
 
     .galaxy-coords-controls input[type="text"] {
-        min-height: 56px;
-        font-size: 24px;
+        min-height: 36px;
+        font-size: 16px;
+        padding: 2px 4px;
+    }
+
+    .galaxy-coords-submit {
+        padding: 2px 0 0;
     }
 
     .galaxy-coords-submit input[type="submit"] {
         width: 100%;
-        min-height: 44px;
+        min-height: 36px;
+        padding: 4px 8px;
+        font-size: 14px;
+    }
+
+    .galaxy-coords-warning {
+        font-size: 10px;
+        line-height: 1.2;
+        padding: 2px 4px 0;
+        text-align: center;
     }
 
     .fleet-table-desktop {

--- a/styles/templates/game/layout.bare.tpl
+++ b/styles/templates/game/layout.bare.tpl
@@ -1,0 +1,6 @@
+{include file="main.header.tpl" bodyclass="popup"}
+
+<div id="content">{block name="content"}{/block}</div>
+{include file="main.footer.tpl" nocache}
+</body>
+</html>

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -50,9 +50,9 @@ $("#tn3").hide();
 {/if}
 {if $buildInfo.buildings || $buildInfo.tech || $buildInfo.fleet}
 <div class="overview-command-timers">
-	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
-	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</span></div>{/if}
-	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
+	{if $buildInfo.buildings}<div><a href="game.php?page=buildings">{$LNG.lm_buildings}:</a> {$LNG.tech[$buildInfo.buildings['id']]} <span class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</span></div>{/if}
+	{if $buildInfo.tech}<div><a href="game.php?page=research">{$LNG.lm_research}:</a> {$LNG.tech[$buildInfo.tech['id']]} <span class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</span></div>{/if}
+	{if $buildInfo.fleet}<div><a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}:</a> {$LNG.tech[$buildInfo.fleet['id']]} <span class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</span></div>{/if}
 </div>
 {/if}
 	{if $messages}
@@ -115,9 +115,9 @@ $("#tn3").hide();
 			{$planetname}<br>
 
 			<div class="no-mobile">
-			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['time']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['time']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
-			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['endtime']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
+			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
 			</div>
 </br>
 {$LNG.ov_diameter}: {$LNG.ov_distance_unit} (<a title="{$LNG.ov_developed_fields}">{$planet_field_current}</a> / <a title="{$LNG.ov_max_developed_fields}">{$planet_field_max}</a> {$LNG.ov_fields})

--- a/tests/Unit/GeneralFunctionsTest.php
+++ b/tests/Unit/GeneralFunctionsTest.php
@@ -23,6 +23,11 @@ class GeneralFunctionsTest extends TestCase
         $this->assertFalse(safe_unserialize(''));
     }
 
+    public function testSafeUnserializeFalseReturnsFalse(): void
+    {
+        $this->assertFalse(safe_unserialize(false));
+    }
+
     public function testSafeUnserializeValidArrayRoundtrips(): void
     {
         $data = ['foo' => 'bar', 'n' => 42];

--- a/tests/Unit/ResourceUpdateTest.php
+++ b/tests/Unit/ResourceUpdateTest.php
@@ -445,6 +445,24 @@ class ResourceUpdateTest extends TestCase
 		$this->assertSame('return 0;', $result);
 	}
 
+	public function testCalcResourceWithFalsePlanetDoesNotError(): void
+	{
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist();
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser();
+		$planet   = $this->makePlanet();
+
+		Config::setInstance($config, 1);
+		$eco = new ResourceUpdate(true, false);
+		$eco->setResourceData($resource, $reslist);
+
+		$result = $eco->CalcResource($user, false, false, $planet['last_update'] + 3600);
+
+		$this->assertIsArray($result);
+		$this->assertSame($user, $result[0]);
+	}
+
 	public function testReturnVarsReturnsArrayWhenNotGlobalMode(): void
 	{
 		$resource = $this->makeResource();


### PR DESCRIPTION
## Summary

- Compact galaxy page layout on mobile (≤699px): denser planet cards, smaller coord picker, 2-column coord grid.
- Fix overview build timers: use seconds-remaining for `data-time` (matches `base.js`), and prevent reload loop when shipyard timers are already at zero on load.
- Harden serialized queue handling in `ResourceUpdate` and `ShowOverviewPage` (corrupt/missing planet entries, invalid hangar/building blobs); show shipyard as "Ready" when queue exists but `timeleft` is 0.
- Logout uses new `layout.bare.tpl` (no side nav / bottom nav on redirect page).

## Test plan

- [ ] On mobile (~390px), open galaxy: verify more rows visible, coords stepper usable, fleet/espionage icons tappable.
- [ ] Overview with active building/research/shipyard timers: countdown updates; page reloads once when a timer completes (no infinite reload).
- [ ] Overview with completed shipyard slot (`timeleft` 0, queue still in DB): shows Ready, no reload loop.
- [ ] Logout: minimal layout, redirects to login after 5s.
- [ ] CI: `./tests/run-ci-local.sh` (passes locally)