### PR TITLE
Default login/register to newest open universe

### DIFF
--- a/includes/pages/login/AbstractLoginPage.php
+++ b/includes/pages/login/AbstractLoginPage.php
@@ -56,6 +56,32 @@ abstract class AbstractLoginPage
 		return $universeSelect;
 	}
 
+	/**
+	 * Newest open universe for login/register dropdown default.
+	 * Skips closed universes (and registration-closed when registering).
+	 */
+	protected function getDefaultUniverseId($forRegistration = false)
+	{
+		foreach(array_reverse(Universe::availableUniverses()) as $uniId)
+		{
+			$config = Config::get($uniId);
+			if($config->game_disable == 0)
+			{
+				continue;
+			}
+
+			if($forRegistration && $config->reg_closed == 1)
+			{
+				continue;
+			}
+
+			return $uniId;
+		}
+
+		$universes = array_reverse(Universe::availableUniverses());
+		return $universes ? $universes[0] : ROOT_UNI;
+	}
+
 	protected function initTemplate()
 	{
 		if(isset($this->tplObj))

--- a/includes/pages/login/ShowIndexPage.php
+++ b/includes/pages/login/ShowIndexPage.php
@@ -72,6 +72,7 @@ class ShowIndexPage extends AbstractLoginPage
 		$config				= Config::get();
 		$this->assign(array(
 			'universeSelect'		=> $universeSelect,
+			'defaultUniverse'		=> $this->getDefaultUniverseId(),
 			'universeStats'			=> $universeStats,
 			'code'					=> $loginErrorMessage,
 			'verkey'			=> $verkey,

--- a/includes/pages/login/ShowRegisterPage.php
+++ b/includes/pages/login/ShowRegisterPage.php
@@ -101,6 +101,7 @@ class ShowRegisterPage extends AbstractLoginPage
 			'accountName'		=> $accountName,
 			'externalAuth'		=> $externalAuth,
 			'universeSelect'	=> $universeSelect,
+			'defaultUniverse'	=> $this->getDefaultUniverseId(true),
 			'registerPasswordDesc'		=> sprintf($LNG['registerPasswordDesc'], 6),
 			'registerRulesDesc'			=> sprintf($LNG['registerRulesDesc'], '<a href="index.php?page=rules">'.$LNG['menu_rules'].'</a>'),
 			'registerTabEmail'			=> $LNG['registerTabEmail'],

--- a/styles/templates/login/page.index.default.tpl
+++ b/styles/templates/login/page.index.default.tpl
@@ -21,7 +21,7 @@
 				<h2>{$LNG.loginPassword} {$LNG.loginHeader}</h2>
 				<form id="login" name="login" action="index.php?page=login" data-action="index.php?page=login" method="post">
 					<div class="row">
-					<select name="uni" id="universe" class="changeAction">{html_options options=$universeSelect|default:[] selected=$universeSelect|array_key_first}</select>
+					<select name="uni" id="universe" class="changeAction">{html_options options=$universeSelect|default:[] selected=$defaultUniverse}</select>
 						<input name="username" id="username" type="text" placeholder="{$LNG.loginUsername}">
 						<input name="password" id="password" type="password" placeholder="{$LNG.loginPassword}">
 					{$verkeySafe = $verkey|default:[]}
@@ -44,7 +44,7 @@
 			<div class="contentbox">
 				<h2>{$LNG.loginHiveAccount} {$LNG.loginHeader}</h2>
 				<form id="loginHive" action="index.php?page=login" data-action="index.php?page=login" method="post" onsubmit="return false;">
-					<select name="uni" id="loginHive-universe" class="changeAction">{html_options options=$universeSelect|default:[] selected=$universeSelect|array_key_first}</select>
+					<select name="uni" id="loginHive-universe" class="changeAction">{html_options options=$universeSelect|default:[] selected=$defaultUniverse}</select>
 					<input name="username" id="loginHive-username" type="text" maxlength="16" placeholder="{$LNG.loginHiveAccount}">
 					<input name="password" id="loginHive-password" type="hidden">
 					<input name="hiveAccount" id="loginHive-hiveAccount" type="hidden">

--- a/styles/templates/login/page.register.default.tpl
+++ b/styles/templates/login/page.register.default.tpl
@@ -19,7 +19,7 @@
 		<input type="hidden" value="{$referralData.id}" name="referralID">
 			<div class="rowForm">
 				<label for="universe">{$LNG.universe}</label>
-				<select name="uni" id="universe" class="changeAction">{html_options options=$universeSelect selected=$universeSelect|array_key_first}</select>
+				<select name="uni" id="universe" class="changeAction">{html_options options=$universeSelect selected=$defaultUniverse}</select>
 				{if !empty($error.uni)}<span class="error errorUni"></span>{/if}
 			</div>
 			{if !empty($externalAuth.account)}
@@ -114,7 +114,7 @@
 			</div>
 			<div class="rowForm">
 				<label for="reg-hive-universe">{$LNG.universe}</label>
-				<select name="uni" id="reg-hive-universe" class="changeAction">{html_options options=$universeSelect selected=$universeSelect|array_key_first}</select>
+				<select name="uni" id="reg-hive-universe" class="changeAction">{html_options options=$universeSelect selected=$defaultUniverse}</select>
 				{if !empty($error.uni)}<span class="error errorUni"></span>{/if}
 			</div>
 			<div class="rowForm">


### PR DESCRIPTION
## Summary
- Add `getDefaultUniverseId()` on login pages to pick the newest universe that is not closed (`game_disable == 1`).
- For registration, also skip universes with closed registration (`reg_closed == 1`).
- Pass `defaultUniverse` to login/register templates so closed Uni2 is no longer pre-selected when Uni1 is open.

## Test plan
- [x] `./tests/run-ci-local.sh`
- [ ] Open login page with Uni2 closed and confirm Uni1 is selected by default in both password and Hive Keychain forms
- [ ] Open register page and confirm Uni1 is selected by default in both registration tabs
- [ ] Confirm closed universes still appear in the dropdown with the closed label