### PR TITLE
Retry Hive RPC calls across multiple public nodes

### DIFF
--- a/includes/classes/HiveUtil.php
+++ b/includes/classes/HiveUtil.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace HiveNova\Core;
+
+use Hive\Hive;
+
+$hivePhp = __DIR__.'/../../vendor/mahdiyari/hive-php/lib/Hive.php';
+if (file_exists($hivePhp)) {
+	require_once $hivePhp;
+}
+
+class HiveUtil
+{
+	static public function getRpcNodes(): array
+	{
+		return HIVE_RPC_NODES;
+	}
+
+	static public function isRpcError(mixed $result): bool
+	{
+		if (!is_array($result)) {
+			return true;
+		}
+
+		return array_key_exists('code', $result) && array_key_exists('message', $result);
+	}
+
+	static public function rpcCall(string $method, string $params): mixed
+	{
+		foreach (HiveUtil::getRpcNodes() as $rpcNode) {
+			try {
+				$hive = new Hive([
+					'rpcNodes' => [$rpcNode],
+					'timeout'  => HIVE_RPC_TIMEOUT,
+				]);
+				$result = $hive->call($method, $params);
+			} catch (\Throwable $e) {
+				continue;
+			}
+
+			if (!HiveUtil::isRpcError($result)) {
+				return $result;
+			}
+		}
+
+		return null;
+	}
+
+	static public function isAccountValid($hiveaccount): bool
+	{
+		if (is_null($hiveaccount) || strlen($hiveaccount) == 0 || strlen((string) $hiveaccount) > 16) {
+			return false;
+		}
+
+		return (bool) preg_match('/^[a-z][-a-z0-9]+[a-z0-9](\.[a-z][-a-z0-9]+[a-z0-9])*$/', (string) $hiveaccount);
+	}
+
+	static public function isSignValid($hiveaccount, $signedblob): bool
+	{
+		if (!HiveUtil::isAccountValid($hiveaccount)) {
+			return false;
+		}
+
+		if (is_null($signedblob) || strlen($signedblob) < 32 || strlen($signedblob) > 132) {
+			return false;
+		}
+
+		if (!PlayerUtil::isNameValid($signedblob)) {
+			return false;
+		}
+
+		$result = HiveUtil::rpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
+
+		if (!is_array($result) || count($result) == 0 || !isset($result[0]) || !array_key_exists('posting', $result[0])) {
+			return false;
+		}
+
+		$publicKeyString = $result[0]['posting']['key_auths'][0][0];
+		$publicKey = (new Hive())->publicKeyFrom($publicKeyString);
+
+		if (is_null($publicKey)) {
+			return false;
+		}
+
+		$message = hash('sha256', $hiveaccount.' is my account.');
+		try {
+			$verified = $publicKey->verify($message, $signedblob);
+		} catch (\Throwable $e) {
+			return false;
+		}
+
+		return (bool) $verified;
+	}
+
+	static public function accountExists($hiveaccount): bool
+	{
+		$hiveaccount = strtolower((string) $hiveaccount);
+
+		if (!HiveUtil::isAccountValid($hiveaccount)) {
+			return false;
+		}
+
+		$result = HiveUtil::rpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
+
+		return is_array($result) && count($result) > 0;
+	}
+}

--- a/includes/classes/PlayerUtil.php
+++ b/includes/classes/PlayerUtil.php
@@ -8,7 +8,6 @@ use HiveNova\Core\Cache;
 use HiveNova\Core\Universe;
 use HiveNova\Core\FleetFunctions;
 use Exception;
-use Hive\Hive;
 
 /**
  *  2Moons 
@@ -25,49 +24,8 @@ use Hive\Hive;
  * @link https://github.com/jkroepke/2Moons
  */
 
-// import hive-php and instantiate $hive
-$hivePhp = __DIR__.'/../../vendor/mahdiyari/hive-php/lib/Hive.php';
-if (file_exists($hivePhp)) {
-    require_once $hivePhp;
-}
-
 class PlayerUtil
 {
-	static public function getHiveRpcNodes(): array
-	{
-		return HIVE_RPC_NODES;
-	}
-
-	static public function isHiveRpcError(mixed $result): bool
-	{
-		if (!is_array($result)) {
-			return true;
-		}
-
-		return array_key_exists('code', $result) && array_key_exists('message', $result);
-	}
-
-	static public function hiveRpcCall(string $method, string $params): mixed
-	{
-		foreach (PlayerUtil::getHiveRpcNodes() as $rpcNode) {
-			try {
-				$hive = new Hive([
-					'rpcNodes' => [$rpcNode],
-					'timeout'  => HIVE_RPC_TIMEOUT,
-				]);
-				$result = $hive->call($method, $params);
-			} catch (\Throwable $e) {
-				continue;
-			}
-
-			if (!PlayerUtil::isHiveRpcError($result)) {
-				return $result;
-			}
-		}
-
-		return null;
-	}
-
 	static public function cryptPassword($password)
 	{
 		return password_hash((string) $password, PASSWORD_BCRYPT, ['cost' => 13]);
@@ -104,76 +62,9 @@ class PlayerUtil
 		}
 	}
 
-	static public function isHiveAccountValid($hiveaccount)
-	{
-		if (is_null($hiveaccount) || strlen($hiveaccount) == 0 || strlen((string) $hiveaccount) > 16) {
-			return false;
-		}
-		return preg_match('/^[a-z][-a-z0-9]+[a-z0-9](\.[a-z][-a-z0-9]+[a-z0-9])*$/', (string) $hiveaccount);
-	}
-
-	static public function isHiveSignValid($hiveaccount, $signedblob)
-	{
-		// verify account
-		if (!PlayerUtil::isHiveAccountValid($hiveaccount)) {
-			return false;
-		}
-
-		// verify length
-		if (is_null($signedblob) || strlen($signedblob) < 32 || strlen($signedblob) > 132) {
-			return false;
-		}
-		// verify content
-		if (!PlayerUtil::isNameValid($signedblob)) {
-			return false;
-		}
-
-		$result = PlayerUtil::hiveRpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
-
-		if(!is_array($result) || count($result) == 0 || !isset($result[0]) || !array_key_exists('posting',$result[0])) {
-			return false;
-		}
-
-		$publicKeyString = $result[0]['posting']['key_auths'][0][0];
-		$publicKey = (new Hive())->publicKeyFrom($publicKeyString);
-
-		if (is_null($publicKey)) {
-			return false;
-		}
-
-		$message = hash('sha256', $hiveaccount.' is my account.');
-		try {
-			$verified = $publicKey->verify($message, $signedblob);
-		} catch (\Throwable $e) {
-			return false;
-		}
-		if ($verified) {
-			return true;
-		}
-
-		return false;
-	}
-
-	static public function isHiveAccountExists($hiveaccount) {
-		$hiveaccount = strtolower((string) $hiveaccount); // force lower case
-
-		// verify account
-		if (!PlayerUtil::isHiveAccountValid($hiveaccount)) {
-			return false;
-		}
-
-		$result = PlayerUtil::hiveRpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
-
-		if(is_array($result) && count($result) > 0) {
-			return true;
-		}
-
-		return false;
-	}
-
 	static public function getPlayerAvatarURL($USER){
 		$usernameLower = strtolower((string) $USER['username']);
-		if (PlayerUtil::isHiveAccountValid($usernameLower) && isset($USER['hive_account']) && $usernameLower === $USER['hive_account']) {
+		if (HiveUtil::isAccountValid($usernameLower) && isset($USER['hive_account']) && $usernameLower === $USER['hive_account']) {
 			return 'https://images.hive.blog/u/'.$usernameLower.'/avatar';
 		}
 
@@ -182,7 +73,7 @@ class PlayerUtil
 
 	static public function getPlayerBadges($USER){
 		$usernameLower = strtolower((string) $USER['username']);
-		if (PlayerUtil::isHiveAccountValid($usernameLower) && isset($USER['hive_account']) && $usernameLower === $USER['hive_account']) {
+		if (HiveUtil::isAccountValid($usernameLower) && isset($USER['hive_account']) && $usernameLower === $USER['hive_account']) {
 			return '<a href="https://peakd.com/@'.$USER['hive_account'].'" target="_blank">♦️</a>';
 		}
 

--- a/includes/classes/PlayerUtil.php
+++ b/includes/classes/PlayerUtil.php
@@ -33,6 +33,41 @@ if (file_exists($hivePhp)) {
 
 class PlayerUtil
 {
+	static public function getHiveRpcNodes(): array
+	{
+		return HIVE_RPC_NODES;
+	}
+
+	static public function isHiveRpcError(mixed $result): bool
+	{
+		if (!is_array($result)) {
+			return true;
+		}
+
+		return array_key_exists('code', $result) && array_key_exists('message', $result);
+	}
+
+	static public function hiveRpcCall(string $method, string $params): mixed
+	{
+		foreach (PlayerUtil::getHiveRpcNodes() as $rpcNode) {
+			try {
+				$hive = new Hive([
+					'rpcNodes' => [$rpcNode],
+					'timeout'  => HIVE_RPC_TIMEOUT,
+				]);
+				$result = $hive->call($method, $params);
+			} catch (\Throwable $e) {
+				continue;
+			}
+
+			if (!PlayerUtil::isHiveRpcError($result)) {
+				return $result;
+			}
+		}
+
+		return null;
+	}
+
 	static public function cryptPassword($password)
 	{
 		return password_hash((string) $password, PASSWORD_BCRYPT, ['cost' => 13]);
@@ -93,17 +128,14 @@ class PlayerUtil
 			return false;
 		}
 
-		$hive = new Hive();
-
-		// verify signature using hive-php
-		$result = $hive->call('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
+		$result = PlayerUtil::hiveRpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
 
 		if(!is_array($result) || count($result) == 0 || !isset($result[0]) || !array_key_exists('posting',$result[0])) {
 			return false;
 		}
 
 		$publicKeyString = $result[0]['posting']['key_auths'][0][0];
-		$publicKey = $hive->publicKeyFrom($publicKeyString);
+		$publicKey = (new Hive())->publicKeyFrom($publicKeyString);
 
 		if (is_null($publicKey)) {
 			return false;
@@ -130,10 +162,7 @@ class PlayerUtil
 			return false;
 		}
 
-		$hive = new Hive();
-
-		// check existence using hive-php
-		$result = $hive->call('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
+		$result = PlayerUtil::hiveRpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
 
 		if(is_array($result) && count($result) > 0) {
 			return true;

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -65,6 +65,23 @@ if(!defined('CACHE_PATH')) {
 
 define('DISCORD_URL'				, 'https://discord.gg/BWqmGbtuDn');
 
+// Hive RPC — tried in order; each node gets HIVE_RPC_TIMEOUT seconds before the next.
+define('HIVE_RPC_TIMEOUT'			, 5);
+define('HIVE_RPC_NODES'				, [
+	'https://api.openhive.network',
+	'https://hapi.ecency.com',
+	'https://api.deathwing.me',
+	'https://rpc.mahdiyari.info',
+	'https://api.c0ff33a.uk',
+	'https://techcoderx.com',
+	'https://hiveapi.actifit.io',
+	'https://hive.atexoras.com:2096',
+	'https://rpc.ausbit.dev',
+	'https://rpc.ecency.com',
+	'https://api.pharesim.me',
+	'https://api.hive.blog',
+]);
+
 // =============================================================================
 // GAME ENGINE
 // =============================================================================

--- a/includes/pages/game/ShowSettingsPage.php
+++ b/includes/pages/game/ShowSettingsPage.php
@@ -8,6 +8,7 @@ use HiveNova\Core\HTTP;
 use HiveNova\Core\Session;
 use HiveNova\Core\Universe;
 use HiveNova\Core\PlayerUtil;
+use HiveNova\Core\HiveUtil;
 use HiveNova\Core\Theme;
 use HiveNova\Core\PushNotificationService;
 
@@ -410,13 +411,13 @@ class ShowSettingsPage extends AbstractGamePage
 
 		if(!empty($hivesign) && !empty($hiveAccount) && $USER['hive_account'] != $hiveAccount) {
 			// validate signature before saving hive account in DB
-			if (!PlayerUtil::isHiveAccountValid($hiveAccount))
+			if (!HiveUtil::isAccountValid($hiveAccount))
 			{
 				$this->printMessage($LNG['op_user_name_no_alphanumeric'], array(array(
 					'label'	=> $LNG['sys_back'],
 					'url'	=> 'game.php?page=settings'
 				)));
-			} else if (!PlayerUtil::isHiveSignValid($hiveAccount, $hivesign)) {
+			} else if (!HiveUtil::isSignValid($hiveAccount, $hivesign)) {
 				$this->printMessage($LNG['op_user_name_no_alphanumeric'], array(array(
 					'label'	=> $LNG['sys_back'],
 					'url'	=> 'game.php?page=settings'

--- a/includes/pages/login/ShowLoginPage.php
+++ b/includes/pages/login/ShowLoginPage.php
@@ -7,6 +7,7 @@ use HiveNova\Core\HTTP;
 use HiveNova\Core\Session;
 use HiveNova\Core\Universe;
 use HiveNova\Core\PlayerUtil;
+use HiveNova\Core\HiveUtil;
 
 /**
  *  2Moons 
@@ -70,7 +71,7 @@ class ShowLoginPage extends AbstractLoginPage
 		{
 			$verify = "false";
 
-			if (PlayerUtil::isHiveAccountValid($loginData['hive_account']) && PlayerUtil::isHiveSignValid($loginData['hive_account'],$password)) {
+			if (HiveUtil::isAccountValid($loginData['hive_account']) && HiveUtil::isSignValid($loginData['hive_account'],$password)) {
 				$verify = "true";
 			} else if (password_verify((string) $password, (string) $loginData['password'])) {
 				$verify = "true";

--- a/includes/pages/login/ShowRegisterPage.php
+++ b/includes/pages/login/ShowRegisterPage.php
@@ -8,6 +8,7 @@ use HiveNova\Core\HTTP;
 use HiveNova\Core\Session;
 use HiveNova\Core\Universe;
 use HiveNova\Core\PlayerUtil;
+use HiveNova\Core\HiveUtil;
 use HiveNova\Core\Mail;
 
 /**
@@ -149,7 +150,7 @@ class ShowRegisterPage extends AbstractLoginPage
 
 		if ($hiveAccount !== '') {
 			// validate hive signature
-			if (!PlayerUtil::isHiveSignValid($hiveAccount,$password)) {
+			if (!HiveUtil::isSignValid($hiveAccount,$password)) {
 				$errors[]	= $LNG['registerErrorPasswordSame'];
 			}
 		}
@@ -188,7 +189,7 @@ class ShowRegisterPage extends AbstractLoginPage
 			$errors[]	= $LNG['registerErrorRules'];
 		}
 
-		if(!empty($hiveAccount) && !PlayerUtil::isHiveAccountValid($hiveAccount)) {
+		if(!empty($hiveAccount) && !HiveUtil::isAccountValid($hiveAccount)) {
 			$errors[]	= $LNG['registerErrorHiveAccountInvalid'];
 		}
 		
@@ -252,7 +253,7 @@ class ShowRegisterPage extends AbstractLoginPage
 			$errors[]	= $LNG['registerErrorUsernameExist'];
 		}
 
-		if(PlayerUtil::isHiveAccountExists($userName) && empty($hiveAccount)) {
+		if(HiveUtil::accountExists($userName) && empty($hiveAccount)) {
 			// disallow registering a non-hive account with same name as an existing hive account
 			// to avoid collisions
 			$errors[]	= $LNG['registerErrorUsernameExist'];

--- a/tests/Unit/HiveUtilTest.php
+++ b/tests/Unit/HiveUtilTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use HiveNova\Core\HiveUtil;
+
+use PHPUnit\Framework\TestCase;
+
+class HiveUtilTest extends TestCase
+{
+    /** @dataProvider rpcErrorProvider */
+    public function testIsRpcErrorDetectsRpcFailures(mixed $result, bool $expected): void
+    {
+        $this->assertSame($expected, HiveUtil::isRpcError($result));
+    }
+
+    public static function rpcErrorProvider(): array
+    {
+        return [
+            'json-rpc error object' => [['code' => -32000, 'message' => 'Internal Error'], true],
+            'account list result'   => [[['name' => 'alice', 'posting' => []]], false],
+            'empty account list'    => [[], false],
+            'null result'           => [null, true],
+            'string result'         => ['error', true],
+        ];
+    }
+
+    /** @dataProvider validHiveAccountProvider */
+    public function testIsAccountValidAcceptsValidAccounts(string $account): void
+    {
+        $this->assertTrue(HiveUtil::isAccountValid($account), "Expected '$account' to be valid");
+    }
+
+    public static function validHiveAccountProvider(): array
+    {
+        return [
+            'simple lowercase'        => ['tor'],
+            'with hyphen'             => ['hive-nova'],
+            'with numbers'            => ['player1'],
+            'with dot separator'      => ['first.last'],
+            'mixed alphanumeric'      => ['abc123'],
+            'min length (3 chars)'    => ['abc'],
+        ];
+    }
+
+    /** @dataProvider invalidHiveAccountProvider */
+    public function testIsAccountValidRejectsInvalidAccounts($account): void
+    {
+        $this->assertFalse(HiveUtil::isAccountValid($account), "Expected '$account' to be invalid");
+    }
+
+    public static function invalidHiveAccountProvider(): array
+    {
+        return [
+            'null value'              => [null],
+            'empty string'            => [''],
+            'too long (17 chars)'     => ['averylonghiveaccountname'],
+            'starts with number'      => ['1player'],
+            'starts with hyphen'      => ['-player'],
+            'ends with hyphen'        => ['player-'],
+            'uppercase letters'       => ['Player'],
+            'contains space'          => ['hive nova'],
+            'contains special chars'  => ['hive@nova'],
+        ];
+    }
+}

--- a/tests/Unit/PlayerUtilTest.php
+++ b/tests/Unit/PlayerUtilTest.php
@@ -8,66 +8,6 @@ use PHPUnit\Framework\TestCase;
 class PlayerUtilTest extends TestCase
 {
     // -------------------------------------------------------------------------
-    // isHiveAccountValid
-    // -------------------------------------------------------------------------
-
-    /** @dataProvider hiveRpcErrorProvider */
-    public function testIsHiveRpcErrorDetectsRpcFailures(mixed $result, bool $expected): void
-    {
-        $this->assertSame($expected, PlayerUtil::isHiveRpcError($result));
-    }
-
-    public static function hiveRpcErrorProvider(): array
-    {
-        return [
-            'json-rpc error object' => [['code' => -32000, 'message' => 'Internal Error'], true],
-            'account list result'   => [[['name' => 'alice', 'posting' => []]], false],
-            'empty account list'    => [[], false],
-            'null result'           => [null, true],
-            'string result'         => ['error', true],
-        ];
-    }
-
-    /** @dataProvider validHiveAccountProvider */
-    public function testIsHiveAccountValidAcceptsValidAccounts(string $account): void
-    {
-        $this->assertNotFalse(PlayerUtil::isHiveAccountValid($account), "Expected '$account' to be valid");
-    }
-
-    public static function validHiveAccountProvider(): array
-    {
-        return [
-            'simple lowercase'        => ['tor'],
-            'with hyphen'             => ['hive-nova'],
-            'with numbers'            => ['player1'],
-            'with dot separator'      => ['first.last'],
-            'mixed alphanumeric'      => ['abc123'],
-            'min length (3 chars)'    => ['abc'],
-        ];
-    }
-
-    /** @dataProvider invalidHiveAccountProvider */
-    public function testIsHiveAccountValidRejectsInvalidAccounts($account): void
-    {
-        $this->assertFalse((bool) PlayerUtil::isHiveAccountValid($account), "Expected '$account' to be invalid");
-    }
-
-    public static function invalidHiveAccountProvider(): array
-    {
-        return [
-            'null value'              => [null],
-            'empty string'            => [''],
-            'too long (17 chars)'     => ['averylonghiveaccountname'],
-            'starts with number'      => ['1player'],
-            'starts with hyphen'      => ['-player'],
-            'ends with hyphen'        => ['player-'],
-            'uppercase letters'       => ['Player'],
-            'contains space'          => ['hive nova'],
-            'contains special chars'  => ['hive@nova'],
-        ];
-    }
-
-    // -------------------------------------------------------------------------
     // isMailValid
     // -------------------------------------------------------------------------
 

--- a/tests/Unit/PlayerUtilTest.php
+++ b/tests/Unit/PlayerUtilTest.php
@@ -11,6 +11,23 @@ class PlayerUtilTest extends TestCase
     // isHiveAccountValid
     // -------------------------------------------------------------------------
 
+    /** @dataProvider hiveRpcErrorProvider */
+    public function testIsHiveRpcErrorDetectsRpcFailures(mixed $result, bool $expected): void
+    {
+        $this->assertSame($expected, PlayerUtil::isHiveRpcError($result));
+    }
+
+    public static function hiveRpcErrorProvider(): array
+    {
+        return [
+            'json-rpc error object' => [['code' => -32000, 'message' => 'Internal Error'], true],
+            'account list result'   => [[['name' => 'alice', 'posting' => []]], false],
+            'empty account list'    => [[], false],
+            'null result'           => [null, true],
+            'string result'         => ['error', true],
+        ];
+    }
+
     /** @dataProvider validHiveAccountProvider */
     public function testIsHiveAccountValidAcceptsValidAccounts(string $account): void
     {


### PR DESCRIPTION
## Summary
- Add configurable `HIVE_RPC_NODES` and `HIVE_RPC_TIMEOUT` constants with 12 public Hive API endpoints (`api.hive.blog` last).
- Add `PlayerUtil::hiveRpcCall()` to try nodes one at a time, retrying on network failures and JSON-RPC errors (not just hard connection failures like hive-php's built-in fallback).
- Route Hive login signature verification and account existence checks through the new wrapper.

## Test plan
- [x] `./tests/run-ci-local.sh` passes (unit, smoke, CSS lint)
- [ ] Hive Keychain login succeeds when `api.hive.blog` is down but another node responds
- [ ] Registration with Hive account validates account existence reliably