### PR TITLE
Include universe in PIZZA deposit memo

### DIFF
--- a/includes/pages/game/ShowSettingsPage.php
+++ b/includes/pages/game/ShowSettingsPage.php
@@ -71,6 +71,7 @@ class ShowSettingsPage extends AbstractGamePage
 				'email'				=> $USER['email'],
 				'permaEmail'		=> $USER['email_2'],
 				'hiveAccount'		=> $USER['hive_account'],
+				'universe'			=> $USER['universe'],
 				'isHiveKeychainAct' => (str_ends_with((string) $USER['email'], '@hive.blog')),
 				'disableDepositButton' => ($USER['universe'] === "1"),
 				'userLang'			=> $USER['lang'],

--- a/scripts/game/base.js
+++ b/scripts/game/base.js
@@ -364,7 +364,7 @@ const HiveKeychainLogin = async () => {
 	}
 }
 
-const DepositPizzaTokens = async (hiveaccount) => {
+const DepositPizzaTokens = async (hiveaccount, universe) => {
 	if (typeof(hive_keychain) == "undefined") {
 		alert('You must install HiveKeychain extension first');
 		return;
@@ -373,8 +373,11 @@ const DepositPizzaTokens = async (hiveaccount) => {
 	try
 	{
 		const amount = parseFloat(prompt("Enter $PIZZA amount: "));
+		if (isNaN(amount) || amount <= 0) {
+			return;
+		}
 		const depositWallet = 'moon.deposit';
-		const memo = '';
+		const memo = 'u' + universe;
 		const tokenSymbol = 'PIZZA';
 		hive_keychain.requestSendToken(hiveaccount, depositWallet, amount.toFixed(3), memo, tokenSymbol, (response) => {
 			console.debug(JSON.stringify(response));

--- a/styles/templates/game/page.settings.default.tpl
+++ b/styles/templates/game/page.settings.default.tpl
@@ -51,7 +51,7 @@
 	</tr>
 	<tr>
 		<td style="height:22px;">1 PIZZA = 10 Pizzabits</td>
-		<td><button type="button" onclick="DepositPizzaTokens('{$hiveAccount}')" class="login-button button_standard" title="Deposit Pizza Tokens" {if $disableDepositButton}disabled{/if}>Deposit $PIZZA</button></td>
+		<td><button type="button" onclick="DepositPizzaTokens('{$hiveAccount}', '{$universe}')" class="login-button button_standard" title="Deposit Pizza Tokens" {if $disableDepositButton}disabled{/if}>Deposit $PIZZA</button></td>
 	</tr>
 		<tr>
 			<th colspan="2">{$LNG.op_general_settings}</th>


### PR DESCRIPTION
## Summary
- Pass the player's universe into `DepositPizzaTokens` from the settings page
- Set Hive-Engine transfer memo to `u{N}` (e.g. `u2`) so deposit processors can route credits to the correct universe
- Reject invalid, zero, or negative amounts before calling `requestSendToken`

## Test plan
- [ ] Open Settings on a non-universe-1 account with a linked Hive account
- [ ] Click Deposit $PIZZA and confirm Keychain shows memo like `u2` for universe 2
- [ ] Cancel the amount prompt and confirm no transfer is initiated
- [ ] Enter 0 or a negative amount and confirm no transfer is initiated