### PR TITLE
Hide sidebar menu on battle report popups

### DIFF
--- a/includes/pages/game/ShowRaportPage.php
+++ b/includes/pages/game/ShowRaportPage.php
@@ -132,7 +132,8 @@ class ShowRaportPage extends AbstractGamePage
 		$this->assign(array(
 			'Raport'	=> $combatReport,
 			'Info'		=> array($reportData["attacker"], $reportData["defender"]),
-			'pageTitle'	=> $LNG['lm_topkb']
+			'pageTitle'	=> $LNG['lm_topkb'],
+			'hideSidebarMenu' => true,
 		));
 		
 		$this->display('shared.mission.raport.tpl');
@@ -179,7 +180,8 @@ class ShowRaportPage extends AbstractGamePage
 
 		$this->assign(array(
 			'Raport'	=> $combatReport,
-			'pageTitle'	=> $LNG['sys_mess_attack_report']
+			'pageTitle'	=> $LNG['sys_mess_attack_report'],
+			'hideSidebarMenu' => true,
 		));
 		
 		$this->display('shared.mission.raport.tpl');

--- a/styles/templates/game/layout.popup.tpl
+++ b/styles/templates/game/layout.popup.tpl
@@ -1,11 +1,13 @@
 {include file="main.header.tpl" bodyclass="popup"}
 
 <input style="display:none;" type="checkbox" id="toggle-menu" role="button">
+{if empty($hideSidebarMenu)}
 <menu>
 	<div class="fixed">
 		{include file="main.navigation.tpl"}
 	</div>
 </menu>
+{/if}
 
 <div id="content">{block name="content"}{/block}</div>
 {include file="main.footer.tpl" nocache}


### PR DESCRIPTION
## Summary
- add a popup-layout toggle to skip rendering `main.navigation.tpl` when `hideSidebarMenu` is set
- set `hideSidebarMenu` for battle report views in `ShowRaportPage` (`battlehall()` and `show()`)
- keep default popup behavior unchanged for all other pages

## Test plan
- [x] Run `php -l includes/pages/game/ShowRaportPage.php`
- [ ] Open a battle report page and verify the left menu is not shown
- [ ] Open another popup page and verify the menu still appears