### PR TITLE
Enforce PR diff coverage on includes/classes/

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,12 @@ jobs:
           php_version: "8.3"
           php_extensions: "xdebug gmp"
           coverage_clover: "coverage/clover.xml"
+      - name: Upload unit coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: unit-coverage
+          path: coverage/clover.xml
+          if-no-files-found: error
 
   smoke:
     runs-on: ubuntu-latest
@@ -110,6 +116,12 @@ jobs:
         env:
           XDEBUG_MODE: coverage
         run: php vendor/bin/phpunit --configuration phpunit-integration.xml --coverage-clover coverage/integration-clover.xml --coverage-text
+      - name: Upload integration coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-coverage
+          path: coverage/integration-clover.xml
+          if-no-files-found: error
       - name: Check error log is empty
         run: |
           errors=$(grep -v '/vendor/' includes/error.log 2>/dev/null || true)
@@ -118,3 +130,27 @@ jobs:
             echo "$errors"
             exit 1
           fi
+
+  coverage-gate:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [test, integration]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Download coverage reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: "*-coverage"
+          merge-multiple: true
+          path: .
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install diff-cover
+      - name: Enforce diff coverage on includes/classes/
+        env:
+          DIFF_COVER_COMPARE_BRANCH: origin/${{ github.base_ref }}
+          DIFF_COVER_FAIL_UNDER: 80
+        run: bash tests/check-diff-coverage.sh --from-artifacts

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -142,9 +142,14 @@ jobs:
       - name: Download coverage reports
         uses: actions/download-artifact@v4
         with:
-          pattern: "*-coverage"
-          merge-multiple: true
-          path: .
+          name: unit-coverage
+          path: coverage
+      - uses: actions/download-artifact@v4
+        with:
+          name: integration-coverage
+          path: coverage
+      - name: List downloaded coverage files
+        run: find coverage -type f | sort
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .phpunit.cache/
+coverage/
 .claude/
 CLAUDE.md
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Run the full CI pipeline locally before pushing:
 ```bash
 ./tests/run-ci-local.sh               # unit tests + language check + smoke test
 ./tests/run-ci-local.sh --integration # also run integration tests (requires MySQL)
+./tests/run-ci-local.sh --coverage    # PR diff-coverage gate locally (pip install diff-cover; needs MySQL)
 ```
 
 This mirrors what GitHub Actions runs, including checking that `includes/error.log` is empty after the smoke test. Requires the local dev server to be running on `:8000`.
@@ -127,12 +128,27 @@ php .github/scripts/check-language-files.php  # language key validation
 php tests/smoke.php https://staging.moon.hive.pizza admin s3cr3t  # remote host
 ```
 
+#### Coverage (pull requests)
+
+PRs enforce **diff coverage** on `includes/classes/`: at least **80%** of changed lines in that tree must be covered by tests (unit + integration Clover reports merged). Page templates, language files, and other paths are not gated.
+
+Run the same check locally before opening a PR:
+
+```bash
+pip install diff-cover
+./tests/check-diff-coverage.sh --integration   # needs MySQL + php tests/ci-install.php
+```
+
+Compare branch defaults to `origin/develop`; override with `DIFF_COVER_COMPARE_BRANCH=origin/main` if needed.
+
 ### CI
 
 GitHub Actions runs on every push and pull request (`.github/workflows/ci.yaml`):
 
 - **language-check** — validates that all language files are syntactically valid PHP and that every key present in the English reference file exists in each translation
-- **test** — runs the PHPUnit unit test suite on PHP 8.3 with xdebug coverage; generates a Clover coverage report
+- **test** — runs the PHPUnit unit test suite on PHP 8.3 with xdebug coverage; uploads `coverage/clover.xml`
+- **integration** — MySQL + PHPUnit integration suite with coverage; uploads `coverage/integration-clover.xml`
+- **coverage-gate** (pull requests only) — `diff-cover` on merged reports; fails if changed `includes/classes/` lines are below 80% covered vs the PR base branch
 - **smoke** — spins up a MySQL 8 service container, installs the game via `tests/ci-install.php`, starts the PHP built-in server, then runs `tests/smoke.php` which logs in as the test admin and issues an HTTP request to every game page, failing on any PHP error or unexpected redirect
 
 ### Database Migrations

--- a/tests/check-diff-coverage.sh
+++ b/tests/check-diff-coverage.sh
@@ -52,6 +52,15 @@ if [[ "$FROM_ARTIFACTS" -eq 0 ]]; then
   fi
 fi
 
+# GitHub artifact layout may flatten paths (clover.xml at coverage/ root).
+if [[ ! -f coverage/clover.xml ]] && [[ -f coverage/coverage/clover.xml ]]; then
+  mv coverage/coverage/clover.xml coverage/clover.xml
+  rmdir coverage/coverage 2>/dev/null || true
+fi
+if [[ ! -f coverage/integration-clover.xml ]] && [[ -f coverage/coverage/integration-clover.xml ]]; then
+  mv coverage/coverage/integration-clover.xml coverage/integration-clover.xml
+fi
+
 if [[ ! -f coverage/clover.xml ]]; then
   echo "=== coverage/ contents ==="
   find coverage -type f 2>/dev/null || echo "(no coverage directory)"

--- a/tests/check-diff-coverage.sh
+++ b/tests/check-diff-coverage.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# check-diff-coverage.sh — fail if changed lines under includes/classes/ lack test coverage.
+#
+# Usage:
+#   ./tests/check-diff-coverage.sh                    # run unit (+ integration if RUN_INTEGRATION=1)
+#   ./tests/check-diff-coverage.sh --integration      # also run integration tests (needs MySQL)
+#   ./tests/check-diff-coverage.sh --from-artifacts   # only diff-cover (CI: clover files already present)
+#
+# Environment:
+#   DIFF_COVER_FAIL_UNDER=80          minimum % of changed lines covered (default 80)
+#   DIFF_COVER_COMPARE_BRANCH=...   git ref for PR base (default origin/develop)
+#   RUN_INTEGRATION=1               same as --integration
+#
+# Requires: pip install diff-cover  (https://github.com/Bachmann1234/diff_cover)
+
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+FAIL_UNDER="${DIFF_COVER_FAIL_UNDER:-80}"
+COMPARE_BRANCH="${DIFF_COVER_COMPARE_BRANCH:-origin/develop}"
+FROM_ARTIFACTS=0
+RUN_INTEGRATION="${RUN_INTEGRATION:-0}"
+
+for arg in "$@"; do
+  case "$arg" in
+    --from-artifacts) FROM_ARTIFACTS=1 ;;
+    --integration)    RUN_INTEGRATION=1 ;;
+    -h|--help)
+      sed -n '2,14p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+mkdir -p coverage
+
+if [[ "$FROM_ARTIFACTS" -eq 0 ]]; then
+  echo "=== Unit tests (with coverage) ==="
+  XDEBUG_MODE=coverage php vendor/bin/phpunit \
+    --configuration phpunit.xml \
+    --coverage-clover coverage/clover.xml
+
+  if [[ "$RUN_INTEGRATION" -eq 1 ]]; then
+    echo "=== Integration tests (with coverage) ==="
+    XDEBUG_MODE=coverage php vendor/bin/phpunit \
+      --configuration phpunit-integration.xml \
+      --coverage-clover coverage/integration-clover.xml
+  fi
+fi
+
+if [[ ! -f coverage/clover.xml ]]; then
+  echo "=== coverage/ contents ==="
+  find coverage -type f 2>/dev/null || echo "(no coverage directory)"
+  echo "Missing coverage/clover.xml — run unit tests with XDEBUG_MODE=coverage first." >&2
+  exit 1
+fi
+
+if ! command -v diff-cover >/dev/null 2>&1; then
+  echo "diff-cover is not installed. Install with: pip install diff-cover" >&2
+  exit 1
+fi
+
+# Ensure compare ref exists (best-effort for local runs).
+if [[ "$COMPARE_BRANCH" == origin/* ]]; then
+  remote="${COMPARE_BRANCH#origin/}"
+  git fetch origin "$remote" --depth=1 2>/dev/null || true
+fi
+
+COV_FILES=(coverage/clover.xml)
+if [[ -f coverage/integration-clover.xml ]]; then
+  COV_FILES+=(coverage/integration-clover.xml)
+fi
+
+echo "=== Diff coverage (includes/classes/, fail under ${FAIL_UNDER}%) ==="
+echo "Compare branch: ${COMPARE_BRANCH}"
+echo "Reports: ${COV_FILES[*]}"
+
+diff-cover "${COV_FILES[@]}" \
+  --compare-branch="$COMPARE_BRANCH" \
+  --fail-under="$FAIL_UNDER" \
+  --include='includes/classes/*' \
+  --show-uncovered

--- a/tests/run-ci-local.sh
+++ b/tests/run-ci-local.sh
@@ -4,6 +4,7 @@
 # Usage:
 #   ./tests/run-ci-local.sh               # unit tests + language check + smoke + bottom-nav check
 #   ./tests/run-ci-local.sh --integration # also run integration tests (requires MySQL)
+#   ./tests/run-ci-local.sh --coverage    # diff coverage gate (requires diff-cover + --integration)
 #
 # Prerequisites:
 #   - composer install
@@ -14,8 +15,10 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 
 INTEGRATION=0
+COVERAGE=0
 for arg in "$@"; do
   [[ "$arg" == "--integration" ]] && INTEGRATION=1
+  [[ "$arg" == "--coverage" ]]    && COVERAGE=1 && INTEGRATION=1
 done
 
 # Clear error.log so we only see errors from this run
@@ -51,12 +54,18 @@ check_error_log() {
 
 run "Language check"   php .github/scripts/check-language-files.php
 run "CSS check"        bash tests/check-css.sh
-run "Unit tests"       php vendor/bin/phpunit --configuration phpunit.xml
+
+if [[ $COVERAGE -ne 1 ]]; then
+  run "Unit tests" php vendor/bin/phpunit --configuration phpunit.xml
+fi
+
 run "Smoke test"       php tests/smoke.php
 run "Bottom nav check" php tests/check-bottom-nav.php
 run "Error log empty"  check_error_log
 
-if [[ $INTEGRATION -eq 1 ]]; then
+if [[ $COVERAGE -eq 1 ]]; then
+  run "Diff coverage (unit + integration)" bash tests/check-diff-coverage.sh --integration
+elif [[ $INTEGRATION -eq 1 ]]; then
   run "Integration tests" php vendor/bin/phpunit --configuration phpunit-integration.xml
   run "Error log empty (post-integration)" check_error_log
 fi


### PR DESCRIPTION
## Summary
- Adds a **coverage-gate** CI job (pull requests only) that runs `diff-cover` on merged unit + integration Clover reports.
- Requires **≥80%** coverage on changed lines under `includes/classes/` vs the PR base branch.
- Adds `tests/check-diff-coverage.sh` and documents local usage in README / `run-ci-local.sh --coverage`.

## Test plan
- [ ] CI **test** and **integration** jobs upload `coverage/clover.xml` and `coverage/integration-clover.xml`.
- [ ] CI **coverage-gate** job runs on this PR and passes (this PR has no `includes/classes/` changes — validates wiring only).
- [ ] On a follow-up PR with new class code, confirm the gate fails without tests and passes with adequate coverage.