### PR TITLE
Improve overview planet panel and hide popup bottom nav

### DIFF
--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -134,6 +134,7 @@ $LNG['ov_security_confirm']					= 'Bitte bestätigen sie, dass sie den Planet %s
 $LNG['ov_password']						= 'Passwort';
 $LNG['ov_delete_planet']					= 'Aufgeben';
 $LNG['ov_planet_rename']					= 'Umbenennen';
+$LNG['ov_rename_short']						= 'umbenennen';
 $LNG['ov_rename_label']						= 'Neuer Name';
 $LNG['ov_fields']						= 'Felder';
 $LNG['ov_developed_fields']					= 'bebaute Felder';

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -143,6 +143,7 @@ $LNG['ov_security_confirm']					= 'Please confirm if you want to destroy the pla
 $LNG['ov_password']							= 'Password';
 $LNG['ov_delete_planet']					= 'Delete Planet';
 $LNG['ov_planet_rename']					= 'Rename Planet';
+$LNG['ov_rename_short']						= 'rename';
 $LNG['ov_rename_label']						= 'New name';
 $LNG['ov_fields']							= 'Fields';
 $LNG['ov_developed_fields']					= 'Fields used';

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -132,6 +132,7 @@ $LNG['ov_security_confirm']					= 'Por favor, Confirme que desea eliminar el Pla
 $LNG['ov_password']							= 'Contraseña';
 $LNG['ov_delete_planet']					= 'Abandonar';
 $LNG['ov_planet_rename']					= 'Renombrar';
+$LNG['ov_rename_short']						= 'renombrar';
 $LNG['ov_rename_label']						= 'Nombre Nuevo';
 $LNG['ov_fields']							= 'Campos';
 $LNG['ov_developed_fields']                = 'Campos desarrollados';

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -122,6 +122,7 @@ $LNG['ov_security_confirm']					= 'S\'il vous plaît confirmer que la planète';
 $LNG['ov_password']							= 'Mot de passe';
 $LNG['ov_delete_planet']					= 'Abandonner planète';
 $LNG['ov_planet_rename']					= 'Renommer';
+$LNG['ov_rename_short']						= 'renommer';
 $LNG['ov_rename_label']						= 'Nouveau nom';
 $LNG['ov_fields']							= 'Cases';
 $LNG['ov_developed_fields']                = 'Cases occupées';

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -135,6 +135,7 @@ $LNG['ov_security_confirm']					= 'Potwierdź, że chcesz porzucić planetę %s 
 $LNG['ov_password']							= 'Hasło';
 $LNG['ov_delete_planet']					= 'Porzuć';
 $LNG['ov_planet_rename']					= 'Zmień nazwę';
+$LNG['ov_rename_short']						= 'zmień';
 $LNG['ov_rename_label']						= 'Nowa nazwa';
 $LNG['ov_fields']							= 'Pola';
 $LNG['ov_developed_fields']					= 'zabudowane pola';

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -136,6 +136,7 @@ $LNG['ov_security_confirm']					= 'Por favor, confirma se queres destruir o plan
 $LNG['ov_password']							= 'Senha';
 $LNG['ov_delete_planet']					= 'Apagar Planeta';
 $LNG['ov_planet_rename']					= 'Renomear Planeta';
+$LNG['ov_rename_short']						= 'renomear';
 $LNG['ov_rename_label']						= 'Novo nome';
 $LNG['ov_fields']							= 'Campos';
 $LNG['ov_developed_fields']					= 'Campos usados';

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -127,6 +127,7 @@ $LNG['ov_security_confirm']               = 'Подтвердите пароле
 $LNG['ov_password']                       = 'Пароль';
 $LNG['ov_delete_planet']                  = 'Удаление планеты';
 $LNG['ov_planet_rename']                  = 'Переименование планеты';
+$LNG['ov_rename_short']                   = 'переименовать';
 $LNG['ov_rename_label']                   = 'Новое название';
 $LNG['ov_fields']                         = 'Поля';
 $LNG['ov_developed_fields']               = 'застроенная территория';

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -139,6 +139,7 @@ $LNG['ov_security_confirm']					= ' %s gezegenini silme işlemini onaylayınız.
 $LNG['ov_password']							= 'Şifre';
 $LNG['ov_delete_planet']					= 'Gezegeni Sil';
 $LNG['ov_planet_rename']					= 'Yeniden Adlandır';
+$LNG['ov_rename_short']						= 'adlandır';
 $LNG['ov_rename_label']						= 'Yeni Isim';
 $LNG['ov_fields']							= 'Alanlar';
 $LNG['ov_developed_fields']					= 'Kullanılan Alan';

--- a/scripts/game/base.js
+++ b/scripts/game/base.js
@@ -232,8 +232,12 @@ var Dialog	= {
 		return Dialog.open('game.php?page=buddyList&mode=request&id='+ID, 650, 300);
 	},
 	
-	PlanetAction: function() {
-		return Dialog.open('game.php?page=overview&mode=actions', 400, 210);
+	PlanetAction: function(tab) {
+		var url = 'game.php?page=overview&mode=actions';
+		if (tab === 'delete') {
+			url += '&tab=delete';
+		}
+		return Dialog.open(url, 400, 210);
 	},
 	
 	AllianceChat: function() {

--- a/scripts/game/overview.actions.js
+++ b/scripts/game/overview.actions.js
@@ -1,5 +1,6 @@
 $(function() {
-	$('#tabs').tabs();
+	var activeTab = window.location.search.indexOf('tab=delete') !== -1 ? 1 : 0;
+	$('#tabs').tabs({ active: activeTab });
 });
 
 function checkrename()

--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -995,6 +995,114 @@ table.tablesorter thead tr .headerSortDown {
     display: none;
 }
 
+.overview-planet-details {
+    font-variant: normal;
+    font-variant-caps: normal;
+    line-height: 1.6;
+}
+
+.overview-planet-header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 10px;
+}
+
+.overview-planet-name {
+    font-variant: petite-caps;
+    font-weight: 600;
+    font-size: 1.15em;
+}
+
+.overview-planet-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    justify-content: center;
+}
+
+.overview-planet-action-btn {
+    font-variant: normal;
+    font-size: 0.85em;
+    padding: 4px 12px;
+    min-height: 32px;
+    min-width: auto;
+    line-height: 1.3;
+    border-radius: 999px;
+    background: var(--color-bg-surface-dark);
+    color: var(--color-text-bright);
+    cursor: pointer;
+}
+
+.overview-rename-btn {
+    border: 1px solid var(--color-accent);
+}
+
+.overview-rename-btn:hover {
+    background: var(--color-accent);
+    color: var(--color-text-bright);
+}
+
+.overview-delete-btn {
+    border: 1px solid var(--color-danger);
+}
+
+.overview-delete-btn:hover {
+    background: var(--color-danger);
+    color: var(--color-text-bright);
+}
+
+.overview-planet-queue {
+    margin-bottom: 4px;
+}
+
+.overview-planet-stats {
+    margin: 10px auto 0;
+    padding-top: 10px;
+    max-width: 320px;
+    border-top: 1px solid var(--color-border);
+    font-variant-caps: normal;
+}
+
+.overview-planet-stat {
+    display: grid;
+    grid-template-columns: minmax(100px, auto) 1fr;
+    gap: 4px 12px;
+    align-items: baseline;
+    padding: 6px 0;
+}
+
+.overview-planet-stat dt {
+    margin: 0;
+    font-size: 1.05em;
+    font-weight: 600;
+    font-variant-caps: normal;
+    text-align: left;
+    color: var(--color-text);
+    opacity: 0.9;
+}
+
+.overview-planet-stat dd {
+    margin: 0;
+    font-size: 1em;
+    font-variant-caps: normal;
+    text-align: right;
+    color: var(--color-text-bright);
+}
+
+.overview-planet-stat dd a {
+    color: inherit;
+    text-decoration: underline;
+    text-decoration-color: var(--color-accent);
+    text-underline-offset: 2px;
+}
+
+.overview-planet-stat dd a:hover {
+    color: var(--color-accent);
+}
+
 /* MEDIA */
 
 #bottom-nav,
@@ -1281,7 +1389,7 @@ table.tablesorter thead tr .headerSortDown {
 
     body.popup #content {
         padding: 8px;
-        padding-bottom: calc(64px + env(safe-area-inset-bottom, 0px));
+        padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     }
 
     .battle-report__players {

--- a/styles/templates/game/layout.popup.tpl
+++ b/styles/templates/game/layout.popup.tpl
@@ -11,6 +11,5 @@
 
 <div id="content">{block name="content"}{/block}</div>
 {include file="main.footer.tpl" nocache}
-{include file="main.bottomnav.tpl"}
 </body>
 </html>

--- a/styles/templates/game/page.overview.default.tpl
+++ b/styles/templates/game/page.overview.default.tpl
@@ -112,20 +112,40 @@ $("#tn3").hide();
 			<img src="{$dpath}planeten/{$planetimage}.jpg" width="200" height="200" alt="{$planetname}">
 		</div>
 		<div class="planeth overview-planet-details">
-			{$planetname}<br>
+			<div class="overview-planet-header">
+				<span class="overview-planet-name">{$planetname}</span>
+				<div class="overview-planet-actions">
+					<button type="button" class="overview-planet-action-btn overview-rename-btn" onclick="return Dialog.PlanetAction();" title="{$LNG.ov_planet_rename}">{$LNG.ov_rename_short}</button>
+					<button type="button" class="overview-planet-action-btn overview-delete-btn" onclick="return Dialog.PlanetAction('delete');" title="{$LNG.ov_delete_planet}">{$LNG.bu_delete|lower}</button>
+				</div>
+			</div>
 
-			<div class="no-mobile">
+			<div class="no-mobile overview-planet-queue">
 			{if $buildInfo.buildings}<a href="game.php?page=buildings">{$LNG.lm_buildings}: </a>{$LNG.tech[$buildInfo.buildings['id']]} ({$buildInfo.buildings['level']})<br><div class="timer" data-time="{$buildInfo.buildings['timeleft']}">{$buildInfo.buildings['starttime']}</div>{else}<a href="game.php?page=buildings">{$LNG.lm_buildings}: {$LNG.ov_free}</a><br>{/if}
 			{if $buildInfo.tech}<a href="game.php?page=research">{$LNG.lm_research}: </a>{$LNG.tech[$buildInfo.tech['id']]} ({$buildInfo.tech['level']})<br><div class="timer" data-time="{$buildInfo.tech['timeleft']}">{$buildInfo.tech['starttime']}</div>{else}<a href="game.php?page=research">{$LNG.lm_research}: {$LNG.ov_free}</a><br>{/if}
 			{if $buildInfo.fleet}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: </a>{$LNG.tech[$buildInfo.fleet['id']]} ({$buildInfo.fleet['level']})<br><div class="timer" data-time="{$buildInfo.fleet['timeleft']}">{$buildInfo.fleet['starttime']}</div>{else}<a href="game.php?page=shipyard&amp;mode=fleet">{$LNG.lm_shipshard}: {$LNG.ov_free}</a><br>{/if}
 			</div>
-</br>
-{$LNG.ov_diameter}: {$LNG.ov_distance_unit} (<a title="{$LNG.ov_developed_fields}">{$planet_field_current}</a> / <a title="{$LNG.ov_max_developed_fields}">{$planet_field_max}</a> {$LNG.ov_fields})
-<br>{$LNG.ov_temperature}: {$LNG.ov_aprox} {$planet_temp_min}{$LNG.ov_temp_unit} {$LNG.ov_to} {$planet_temp_max}{$LNG.ov_temp_unit}
-<br>{$LNG.ov_position}: <a href="game.php?page=galaxy&amp;galaxy={$galaxy}&amp;system={$system}">[{$galaxy}:{$system}:{$planet}]</a>
+
+			<dl class="overview-planet-stats">
+				<div class="overview-planet-stat">
+					<dt>{$LNG.ov_diameter}</dt>
+					<dd>{$planet_diameter} {$LNG.ov_distance_unit}</dd>
+				</div>
+				<div class="overview-planet-stat">
+					<dt>{$LNG.ov_fields}</dt>
+					<dd><a title="{$LNG.ov_developed_fields}">{$planet_field_current}</a> / <a title="{$LNG.ov_max_developed_fields}">{$planet_field_max}</a></dd>
+				</div>
+				<div class="overview-planet-stat">
+					<dt>{$LNG.ov_temperature}</dt>
+					<dd>{$planet_temp_min}{$LNG.ov_temp_unit} – {$planet_temp_max}{$LNG.ov_temp_unit}</dd>
+				</div>
+				<div class="overview-planet-stat">
+					<dt>{$LNG.ov_position}</dt>
+					<dd><a href="game.php?page=galaxy&amp;galaxy={$galaxy}&amp;system={$system}">[{$galaxy}:{$system}:{$planet}]</a></dd>
+				</div>
+			</dl>
 
 </div>
-&nbsp;</br>
 </div>
 <br>
 <div class="infos">		

--- a/tests/check-bottom-nav.php
+++ b/tests/check-bottom-nav.php
@@ -104,14 +104,14 @@ foreach ($popupPages as $query) {
         echo "[ SKIP ] popup layout leaves ingame: $label → $effectiveUrl\n";
         continue;
     }
-    if (strpos($body, 'id="bottom-nav"') === false) {
-        echo "[ FAIL ] popup layout missing bottom-nav: $label\n";
+    if (strpos($body, 'id="bottom-nav"') !== false) {
+        echo "[ FAIL ] popup layout must not include bottom-nav: $label\n";
         $fail++;
     }
 }
 
 if ($fail === 0) {
-    echo "All checked pages include #bottom-nav.\n";
+    echo "Bottom navigation present on full pages and absent on popup pages.\n";
     exit(0);
 }
 


### PR DESCRIPTION
## Summary
- Add **rename** and **delete** buttons beside the planet name on overview; delete opens the popup on the delete tab
- Restructure planet stats into label/value rows, fix missing diameter value, and improve mobile readability
- Remove mobile bottom nav from popup layout (rename/delete dialog and other modals)

## Test plan
- [ ] On overview (mobile width), confirm rename/delete buttons appear beside planet name and open the correct popup tab
- [ ] Verify stats show diameter, fields, temperature range, and galaxy link with aligned labels
- [ ] Open rename/delete popup and confirm bottom nav is hidden
- [ ] `./tests/run-ci-local.sh` passes (language, CSS, unit, smoke, bottom-nav)

## Notes
Same change set as #202, cherry-picked onto `master`.