### PR TITLE
Fix mobile fleet page blocking ship selection

### DIFF
--- a/scripts/game/fleet-mobile.js
+++ b/scripts/game/fleet-mobile.js
@@ -26,5 +26,12 @@
 			var step = parseInt($(this).data('step'), 10) || 1;
 			adjustShipInput($(this).data('target'), step);
 		});
+
+		$('#fleetMobileToggle').on('click', function () {
+			var $btn = $(this);
+			var expanded = $btn.attr('aria-expanded') === 'true';
+			$btn.attr('aria-expanded', expanded ? 'false' : 'true');
+			$('#fleetMobileList').toggleClass('is-expanded', !expanded);
+		});
 	});
 })(jQuery);

--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -1107,9 +1107,15 @@ table.tablesorter thead tr .headerSortDown {
 
 #bottom-nav,
 .fleet-mobile-list,
+.fleet-mobile-active-toggle,
 .overview-mobile-shortcuts,
 .overview-command-timers {
     display: none;
+}
+
+.fleet-page-layout {
+    display: flex;
+    flex-direction: column;
 }
 
 .galaxy-coords-picker {
@@ -1750,6 +1756,45 @@ table.tablesorter thead tr .headerSortDown {
 
     .fleet-table-desktop {
         display: none;
+    }
+
+    .fleet-page-layout {
+        display: flex;
+        flex-direction: column;
+    }
+
+    .fleet-dispatch-section {
+        order: 1;
+    }
+
+    .fleet-active-section {
+        order: 2;
+    }
+
+    .fleet-mobile-active-toggle {
+        display: block;
+        width: 100%;
+        margin-bottom: 10px;
+        padding: 10px 12px;
+        border: 1px solid var(--color-border);
+        border-radius: 8px;
+        background: var(--color-menu-bg);
+        color: var(--color-text);
+        font-size: 13px;
+        text-align: center;
+        cursor: pointer;
+    }
+
+    .fleet-mobile-active-toggle[aria-expanded="true"] {
+        margin-bottom: 6px;
+    }
+
+    .fleet-mobile-list.fleet-mobile-list--collapsed {
+        display: none;
+    }
+
+    .fleet-mobile-list.fleet-mobile-list--collapsed.is-expanded {
+        display: block;
     }
 
     .fleet-bonus-table {

--- a/styles/templates/game/page.fleetTable.default.tpl
+++ b/styles/templates/game/page.fleetTable.default.tpl
@@ -1,5 +1,7 @@
 {block name="title" prepend}{$LNG.lm_fleet}{/block}
 {block name="content"}
+<div class="fleet-page-layout">
+<div class="fleet-active-section">
 <table class="fleet-table-desktop">
 	<tr>
 		<th colspan="9">
@@ -75,7 +77,13 @@
 	<tr><td colspan="9">{$LNG.fl_no_more_slots}</td></tr>
 	{/if}
 </table>
-<div class="fleet-mobile-list">
+{if $activeFleetSlots > 0 && $activeFleetSlots < $maxFleetSlots}
+<button type="button" class="fleet-mobile-active-toggle" id="fleetMobileToggle" aria-controls="fleetMobileList" aria-expanded="false">
+	{$activeFleetSlots} / {$maxFleetSlots} {$LNG.fl_fleets}
+</button>
+{/if}
+{if $activeFleetSlots > 0}
+<div class="fleet-mobile-list{if $activeFleetSlots < $maxFleetSlots} fleet-mobile-list--collapsed{/if}" id="fleetMobileList">
 	{foreach name=FlyingFleetsMobile item=FlyingFleetRow from=$FlyingFleetList}
 	<div class="fleet-mobile-card">
 		<div class="fleet-mobile-row"><strong>#{$smarty.foreach.FlyingFleetsMobile.iteration}</strong> {$LNG["type_mission_{$FlyingFleetRow.mission}"]}{if $FlyingFleetRow.state == 1} ({$LNG.fl_r}){else} ({$LNG.fl_a}){/if}</div>
@@ -89,10 +97,11 @@
 		</form>
 		{/if}
 	</div>
-	{foreachelse}
-	<p>-</p>
 	{/foreach}
 </div>
+{/if}
+</div>
+<div class="fleet-dispatch-section">
 {if !empty($acsData)}
 {include file="shared.fleetTable.acsTable.tpl"}
 {/if}
@@ -153,6 +162,8 @@
 	<tr><th style="width:33%">{$LNG.tech.115}</th><th style="width:33%">{$LNG.tech.117}</th><th style="width:33%">{$LNG.tech.118}</th></tr>
 	<tr><td>+{$bonusCombustion} %</td><td>+{$bonusImpulse} %</td><td>+{$bonusHyperspace} %</td></tr>
 </table>
+</div>
+</div>
 {/block}
 {block name="script" append}
 <script src="scripts/game/fleetTable.js"></script>


### PR DESCRIPTION
## Summary
- On mobile, the fleet dispatch form (ship selection + Continue) now appears above active fleet movements.
- When the player has free fleet slots, in-flight fleet cards are collapsed by default so they no longer block the send flow.
- A compact "X / Y Fleet" toggle below the form lets players expand the list to recall fleets when needed.
- When all slots are full, active fleets remain visible since dispatch is unavailable anyway.

## Test plan
- [ ] On mobile (≤699px), open Fleet with active movements and free slots — ship selection should be visible immediately without scrolling
- [ ] Tap the fleet slot toggle — active movement cards expand with recall buttons
- [ ] Fill all fleet slots — active movements show by default
- [ ] Desktop layout unchanged (fleet table above dispatch form)