### PR TITLE
Ingame Font Awesome subset (~59KB → ~1.6KB CSS)

### DIFF
--- a/scripts/dev/build-ingame-icon-subset.mjs
+++ b/scripts/dev/build-ingame-icon-subset.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+/**
+ * Verify ingame Font Awesome subset matches template usage.
+ * Usage: node scripts/dev/build-ingame-icon-subset.mjs
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '../..');
+const SUBSET = path.join(ROOT, 'styles/resource/css/fontawesome/css/ingame-icons.css');
+const TEMPLATE_DIR = path.join(ROOT, 'styles/templates/game');
+
+const ICON_RE = /\b(?:fa[srb]?|fa)\s+fa-([a-z0-9-]+)/g;
+
+function collectIconsFromFile(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const icons = new Set();
+  let match;
+  while ((match = ICON_RE.exec(text)) !== null) {
+    icons.add(match[1]);
+  }
+  return icons;
+}
+
+function walkTemplates(dir, files = []) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkTemplates(full, files);
+    } else if (entry.name.endsWith('.tpl')) {
+      files.push(full);
+    }
+  }
+  return files;
+}
+
+function iconsInSubset(css) {
+  const found = new Set();
+  const re = /\.fa-([a-z0-9-]+):before/g;
+  let match;
+  while ((match = re.exec(css)) !== null) {
+    found.add(match[1]);
+  }
+  return found;
+}
+
+const templates = walkTemplates(TEMPLATE_DIR, []);
+const used = new Set();
+for (const tpl of templates) {
+  for (const icon of collectIconsFromFile(tpl)) {
+    used.add(icon);
+  }
+}
+
+const subsetCss = fs.readFileSync(SUBSET, 'utf8');
+const subsetIcons = iconsInSubset(subsetCss);
+const missing = [...used].filter((icon) => !subsetIcons.has(icon)).sort();
+const extra = [...subsetIcons].filter((icon) => !used.has(icon)).sort();
+
+console.log('Ingame FA icons in templates:', [...used].sort().join(', ') || '(none)');
+console.log('Subset defines:', [...subsetIcons].sort().join(', '));
+
+if (missing.length) {
+  console.error('Missing from ingame-icons.css:', missing.join(', '));
+  process.exit(1);
+}
+
+if (extra.length) {
+  console.warn('Unused in templates (kept for stability):', extra.join(', '));
+}
+
+console.log('OK — subset covers all ingame template icons.');

--- a/styles/resource/css/fontawesome/css/ingame-icons.css
+++ b/styles/resource/css/fontawesome/css/ingame-icons.css
@@ -1,0 +1,55 @@
+/*!
+ * HiveNova ingame Font Awesome subset — icons used in game templates only.
+ * Replaces all.min.css (~59KB) on ingame pages. See scripts/dev/build-ingame-icon-subset.mjs
+ */
+@font-face {
+  font-family: 'Font Awesome 5 Free';
+  font-style: normal;
+  font-weight: 900;
+  font-display: block;
+  src: url('../webfonts/fa-solid-900.eot');
+  src: url('../webfonts/fa-solid-900.eot?#iefix') format('embedded-opentype'),
+    url('../webfonts/fa-solid-900.woff2') format('woff2'),
+    url('../webfonts/fa-solid-900.woff') format('woff'),
+    url('../webfonts/fa-solid-900.ttf') format('truetype'),
+    url('../webfonts/fa-solid-900.svg#fontawesome') format('svg');
+}
+
+.fa,
+.fas {
+  -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  display: inline-block;
+  font-style: normal;
+  font-variant: normal;
+  text-rendering: auto;
+  line-height: 1;
+  font-family: 'Font Awesome 5 Free';
+  font-weight: 900;
+}
+
+.fa-lg {
+  font-size: 1.33333em;
+  line-height: 0.75em;
+  vertical-align: -0.0667em;
+}
+
+.fa-fw {
+  text-align: center;
+  width: 1.25em;
+}
+
+.fa-home:before { content: '\f015'; }
+.fa-industry:before { content: '\f275'; }
+.fa-rocket:before { content: '\f135'; }
+.fa-star:before { content: '\f005'; }
+.fa-ellipsis-h:before { content: '\f141'; }
+.fa-bars:before { content: '\f0c9'; }
+.fa-angle-double-right:before { content: '\f101'; }
+.fa-chevron-circle-up:before { content: '\f139'; }
+.fa-dollar-sign:before { content: '\f155'; }
+.fa-reply:before { content: '\f3e5'; }
+.fa-trash:before { content: '\f1f8'; }
+.fa-trophy:before { content: '\f091'; }
+.fa-plus:before { content: '\f067'; }
+.fa-minus:before { content: '\f068'; }

--- a/styles/templates/game/main.header.tpl
+++ b/styles/templates/game/main.header.tpl
@@ -22,7 +22,7 @@
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/base/jquery.fancybox.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/base/validationEngine.jquery.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="{$dpath}formate.css?v={$REV}">
-	<link rel="stylesheet" type="text/css" href="./styles/resource/css/fontawesome/css/all.min.css">
+	<link rel="stylesheet" type="text/css" href="./styles/resource/css/fontawesome/css/ingame-icons.css?v={$REV}">
 	<link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">
 	<script type="text/javascript">
 	var ServerTimezoneOffset = {$Offset};


### PR DESCRIPTION
## Summary
- Replace global `all.min.css` (~59KB) with `ingame-icons.css` (~1.6KB) containing only the Font Awesome glyphs used in game templates
- Add `scripts/dev/build-ingame-icon-subset.mjs` to verify template icon usage stays covered by the subset

## Why
Lighthouse flagged large unused CSS on every ingame page. The full FA bundle ships thousands of icons; HiveNova uses ~15 in six templates (bottom nav, top nav, sidebar, messages, statistics, tech tree).

## Test plan
- [x] `./tests/run-ci-local.sh`
- [x] `node scripts/dev/build-ingame-icon-subset.mjs`
- [ ] Spot-check bottom nav, messages reply/trash, statistics trophy, tech tree +/- on a local ingame session