### PR TITLE
Login perf: vanilla JS, drop jQuery and unused login CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ includes/config.php
 includes/push.config.php
 includes/error.log
 .worktrees/
+reports/

--- a/docs/lighthouse-login-vanilla.md
+++ b/docs/lighthouse-login-vanilla.md
@@ -1,0 +1,25 @@
+# Lighthouse — login (`index.php`) on `feat/login-vanilla`
+
+**URL:** `http://localhost:8000/index.php`  
+**Run:** Lighthouse 12.6 CLI, mobile perf preset, headless, extensions disabled  
+**Branch:** `feat/login-vanilla` (jQuery removed, icon-font/Fancybox dropped from header)
+
+| Metric | Value |
+|--------|-------|
+| Performance | **99** |
+| FCP | 1.8 s |
+| LCP | 1.8 s |
+| TBT | 0 ms |
+| CLS | **0** |
+
+## Top opportunities (localhost, no compression)
+
+1. **Render-blocking resources** — est. ~1.1 s (theme `formate.css`, `main.css`, `register.css` on index append)
+2. **Unused CSS** — ~34 KiB
+3. **Text compression** — enable gzip/brotli in prod (not `php -S`)
+
+## Compare to prior login audit (with jQuery)
+
+Earlier run on same stack had **CLS ~0.101** on login (uni-stats JS toggle). This branch targets **CLS 0** via server-rendered active uni row + lighter JS payload.
+
+Raw JSON: `reports/lighthouse-login-vanilla.json` (local only, not committed).

--- a/scripts/login/main.js
+++ b/scripts/login/main.js
@@ -1,76 +1,102 @@
-$(function() {
-	$('.flags').on('click', function(e) {
-		e.preventDefault();
-		var langKey = $(this).attr('class').replace(/flags(.*)/, "$1").trim();
-		Login.setLanguage(langKey);
-		return false;
-	});
-	
-	$('.fancybox').fancybox({
-		'type' : 'iframe',
-		'padding' : 1,
-	});
-	
-	if(LoginConfig.isMultiUniverse)
-	{
-		$('.changeAction')
-		.each(function() {
-			updateUrls($(this));
-		})
-		.on('change', function() {
-			updateUrls($(this));
-		});
-		
-		// $('.changeUni').on('change', function() {
-		// 	document.location.href = LoginConfig.basePath+'uni'+$(this).val()+'/index.php'+document.location.search;
-		// });
-	}
-	else
-	{
-		$('.fb_login').attr('href', function(i, old) {
-			return LoginConfig.basePath+$(this).data('href');
-		});
-	}
-});
+/**
+ * Login site scripts (no jQuery): language cookie, multi-universe form actions, Hive Keychain.
+ */
+(function () {
+	'use strict';
 
-var updateUrls = function(that, universe) {
-	var universe = that.val();
-	if (LoginConfig.unisWildcast) {
-		var basePathWithSubdomain = LoginConfig.basePath.replace('://', '://uni' + universe + '.');
-		that.parents('form').attr('action', function(i, old) {
-			return basePathWithSubdomain+$(this).data('action');
-		});
-		$('.fb_login').attr('href', function(i, old) {
-			return basePathWithSubdomain+$(this).data('href');
-		});
-	} else {
-		that.parents('form').attr('action', function(i, old) {
-			return LoginConfig.basePath+'uni'+universe+'/'+$(this).data('action');
-		});
-		$('.fb_login').attr('href', function(i, old) {
-			return LoginConfig.basePath+'uni'+universe+'/'+$(this).data('href');
-		});
+	function setCookie(name, value, days) {
+		var expires = '';
+		if (typeof days === 'number') {
+			var date = new Date();
+			date.setTime(date.getTime() + days * 86400000);
+			expires = '; expires=' + date.toUTCString();
+		}
+		document.cookie = name + '=' + encodeURIComponent(value) + expires + '; path=/; SameSite=Lax';
 	}
-}
 
-var Login = {
-	setLanguage : function (LNG, Query) {
-		$.cookie('lang', LNG);
-		if(typeof Query === "undefined")
-			document.location.href = document.location.href
-		else
-			document.location.href = document.location.href+Query;
+	function universeFromSelect(select) {
+		return select && select.value ? String(select.value) : '';
 	}
-};
+
+	function updateUrls(select) {
+		if (!select || typeof LoginConfig === 'undefined') {
+			return;
+		}
+		var universe = universeFromSelect(select);
+		var basePath = LoginConfig.basePath || '';
+		var form = select.closest('form');
+		if (form) {
+			var action = form.getAttribute('data-action') || form.getAttribute('action') || '';
+			if (LoginConfig.unisWildcast) {
+				var wildBase = basePath.replace('://', '://uni' + universe + '.');
+				form.setAttribute('action', wildBase + action);
+			} else {
+				form.setAttribute('action', basePath + 'uni' + universe + '/' + action);
+			}
+		}
+		document.querySelectorAll('.fb_login').forEach(function (el) {
+			var href = el.getAttribute('data-href');
+			if (!href) {
+				return;
+			}
+			if (LoginConfig.unisWildcast) {
+				el.setAttribute('href', basePath.replace('://', '://uni' + universe + '.') + href);
+			} else {
+				el.setAttribute('href', basePath + 'uni' + universe + '/' + href);
+			}
+		});
+	}
+
+	window.Login = {
+		setLanguage: function (lang, query) {
+			setCookie('lang', lang, 365);
+			if (typeof query === 'undefined') {
+				window.location.href = window.location.href;
+			} else {
+				window.location.href = window.location.href + query;
+			}
+		}
+	};
+
+	document.addEventListener('DOMContentLoaded', function () {
+		document.querySelectorAll('#language .flags').forEach(function (flag) {
+			flag.addEventListener('click', function (e) {
+				e.preventDefault();
+				var link = flag.closest('a');
+				var href = link ? link.getAttribute('href') || '' : '';
+				var match = href.match(/[?&]lang=([^&]+)/);
+				if (match && match[1]) {
+					Login.setLanguage(match[1]);
+				}
+			});
+		});
+
+		if (typeof LoginConfig !== 'undefined' && LoginConfig.isMultiUniverse) {
+			document.querySelectorAll('.changeAction').forEach(function (select) {
+				updateUrls(select);
+				select.addEventListener('change', function () {
+					updateUrls(select);
+				});
+			});
+		} else {
+			document.querySelectorAll('.fb_login').forEach(function (el) {
+				var href = el.getAttribute('data-href');
+				if (href && LoginConfig && LoginConfig.basePath) {
+					el.setAttribute('href', LoginConfig.basePath + href);
+				}
+			});
+		}
+	});
+})();
 
 const HiveKeychainLogin = async () => {
-	if (typeof(hive_keychain) == "undefined") {
+	if (typeof hive_keychain === 'undefined') {
 		alert('You must install Hive Keychain extension first.');
 		return;
 	}
 
 	var usernameInput = document.getElementById('loginHive-username');
-	if (!usernameInput || usernameInput.value.length == 0 || usernameInput.value.length > 16) {
+	if (!usernameInput || usernameInput.value.length === 0 || usernameInput.value.length > 16) {
 		alert('You must enter a valid Hive account name first.');
 		return;
 	}
@@ -80,8 +106,8 @@ const HiveKeychainLogin = async () => {
 	try {
 		await hive_keychain.requestSignBuffer(
 			hiveaccount,
-			`${hiveaccount} is my account.`,
-			"Posting",
+			hiveaccount + ' is my account.',
+			'Posting',
 			(response) => {
 				if (response.success) {
 					document.getElementById('loginHive-hiveAccount').value = hiveaccount;
@@ -97,5 +123,4 @@ const HiveKeychainLogin = async () => {
 	} catch (error) {
 		console.error({ error });
 	}
-}
-
+};

--- a/styles/templates/login/main.header.tpl
+++ b/styles/templates/login/main.header.tpl
@@ -7,8 +7,6 @@
 	<link rel="stylesheet" type="text/css" href="styles/resource/css/tokens.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="styles/theme/{$dpath|default:'nova'}/formate.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="styles/resource/css/login/main.css?v={$REV}">
-	<link rel="stylesheet" type="text/css" href="styles/resource/css/base/jquery.fancybox.css?v={$REV}">
-	<link rel="stylesheet" type="text/css" href="styles/resource/css/login/icon-font/style.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="styles/resource/css/login/hivekeychain_button.css?v={$REV}">
 	<link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">
 	<title>{block name="title"} - {$gameName}{/block}</title>
@@ -27,9 +25,6 @@
 	<meta name="twitter:title" content="{$gameName}">
 	<meta name="twitter:description" content="Multiplayer Orbiting Optimization Network (MOON) game. Space themed empire building game in the browser. Free-to-play. Come get mooned!">
 	<meta name="twitter:image" content="{$basepath}styles/resource/images/login/HiveNova.png">
-	<script src="scripts/base/jquery.js?v={$REV}" defer></script>
-	<script src="scripts/base/jquery.cookie.js?v={$REV}" defer></script>
-	<script src="scripts/base/jquery.fancybox.js?v={$REV}" defer></script>
 	<script src="scripts/login/main.js" defer></script>
 	<script>{if isset($code)}var loginError = {$code|json};{/if}</script>
 	{block name="script"}{/block}

--- a/styles/templates/login/page.index.default.tpl
+++ b/styles/templates/login/page.index.default.tpl
@@ -62,7 +62,7 @@
 
 		<div id="uni-stats" class="uni-stats">
 			{foreach $universeStats as $uniId => $stats}
-			<div class="contentbox uni-stats-row" data-uni="{$uniId}">
+			<div class="contentbox uni-stats-row{if $uniId == $defaultUniverse} active{/if}" data-uni="{$uniId}">
 				<h2>{$stats.name|escape}</h2>
 				{if !$stats.open || !$stats.reg_open}
 				<ul class="uni-stats-badges">

--- a/styles/templates/login/page.screens.default.tpl
+++ b/styles/templates/login/page.screens.default.tpl
@@ -4,18 +4,11 @@
 	{foreach $screenshots as $screenshot}
 		{if ($screenshot@iteration % 2) === 1}<tr>{/if}
 		<td style="padding-top:13px;">
-			<a class="gallery" href="{$screenshot.path}" target="_blank" rel="gallery">
+			<a href="{$screenshot.path}" target="_blank" rel="noopener noreferrer">
 				<img src="{$screenshot.thumbnail}" alt="">
 			</a>
 		</td>
 		{if ($screenshot@iteration % 2) === 0}</tr>{/if}
 	{/foreach}
 </table>
-{/block}
-{block name="script"}
-<script>
-$(function() {
-	$(".gallery").fancybox();
-});
-</script>
 {/block}


### PR DESCRIPTION
## Summary
- Remove jQuery, jquery.cookie, Fancybox, and unused `icon-font` from the global login header (~90KB+ less JS on every login/register page)
- Rewrite `scripts/login/main.js` in vanilla JS (language cookie, multi-universe form URLs, Hive Keychain unchanged)
- Server-render the active universe stats row on the login index to prevent register-box CLS on first paint
- Screens page: plain links (no Fancybox/jQuery); thumbnails already open full images in a new tab

## Test plan
- [x] `./tests/run-ci-local.sh`
- [ ] Load `index.php` — login form, universe tabs, uni stats, Hive Keychain tab
- [ ] `index.php?page=screens` — screenshot thumbnails still open
- [ ] Optional: re-run Lighthouse on login (`node scripts/lighthouse/audit.mjs --pages login` if tooling present on branch)