### PR TITLE
Fix push subscription reassignment across universe accounts

### DIFF
--- a/includes/classes/PushNotificationService.php
+++ b/includes/classes/PushNotificationService.php
@@ -67,6 +67,13 @@ class PushNotificationService
 
 		if ($existingUserId !== false && $existingUserId !== null && $existingUserId !== '') {
 			// One browser endpoint per origin — reassign to whoever is logged in now.
+			// Same device switching accounts/universes must work; a stolen subscription
+			// object could re-point alerts (tradeoff vs hard block in #163).
+			$previousUserId = (int) $existingUserId;
+			if ($previousUserId !== $userId) {
+				self::setUserPreference($previousUserId, false);
+			}
+
 			$db->update(
 				'UPDATE %%PUSH_SUBSCRIPTIONS%% SET user_id = :userId, p256dh = :p256dh, auth = :auth, user_agent = :userAgent, created_at = :createdAt WHERE endpoint = :endpoint',
 				[

--- a/includes/classes/PushNotificationService.php
+++ b/includes/classes/PushNotificationService.php
@@ -26,7 +26,7 @@ class PushNotificationService
 	public static function isValidSubscription(array $subscription): bool
 	{
 		$endpoint = $subscription['endpoint'] ?? '';
-		if (!is_string($endpoint) || $endpoint === '' || strlen($endpoint) > 512) {
+		if (!is_string($endpoint) || $endpoint === '' || strlen($endpoint) > 2048) {
 			return false;
 		}
 		if (!filter_var($endpoint, FILTER_VALIDATE_URL) || stripos($endpoint, 'https://') !== 0) {

--- a/includes/classes/PushNotificationService.php
+++ b/includes/classes/PushNotificationService.php
@@ -61,17 +61,14 @@ class PushNotificationService
 			'user_id'
 		);
 
-		if ($existingUserId !== false && $existingUserId !== null && $existingUserId !== '' && (int) $existingUserId !== $userId) {
-			return false;
-		}
-
 		if ($userAgent !== null && strlen($userAgent) > 255) {
 			$userAgent = substr($userAgent, 0, 255);
 		}
 
 		if ($existingUserId !== false && $existingUserId !== null && $existingUserId !== '') {
+			// One browser endpoint per origin — reassign to whoever is logged in now.
 			$db->update(
-				'UPDATE %%PUSH_SUBSCRIPTIONS%% SET p256dh = :p256dh, auth = :auth, user_agent = :userAgent, created_at = :createdAt WHERE endpoint = :endpoint AND user_id = :userId',
+				'UPDATE %%PUSH_SUBSCRIPTIONS%% SET user_id = :userId, p256dh = :p256dh, auth = :auth, user_agent = :userAgent, created_at = :createdAt WHERE endpoint = :endpoint',
 				[
 					':userId'    => $userId,
 					':p256dh'    => $subscription['keys']['p256dh'],

--- a/includes/dbtables.php
+++ b/includes/dbtables.php
@@ -15,7 +15,7 @@
  * @link https://github.com/jkroepke/2Moons
  */
 
-defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 18);
+defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 19);
 defined('DB_NAME')             || define('DB_NAME',   $database['databasename']);
 defined('DB_PREFIX')           || define('DB_PREFIX', $database['tableprefix']);
 

--- a/includes/pages/game/ShowPushPage.php
+++ b/includes/pages/game/ShowPushPage.php
@@ -45,8 +45,8 @@ class ShowPushPage extends AbstractGamePage
 			return;
 		}
 
-		$raw = file_get_contents('php://input');
-		if (!is_string($raw) || trim($raw) === '') {
+		$raw = $this->readSubscribeBody();
+		if (trim($raw) === '') {
 			HTTP::sendHeader('HTTP/1.1 400 Bad Request');
 			$this->sendJSON(['error' => 'empty_body']);
 			return;
@@ -65,19 +65,22 @@ class ShowPushPage extends AbstractGamePage
 			return;
 		}
 
-		if (!PushNotificationService::saveSubscription(
+		PushNotificationService::saveSubscription(
 			(int) $USER['id'],
 			$data,
 			$_SERVER['HTTP_USER_AGENT'] ?? null
-		)) {
-			HTTP::sendHeader('HTTP/1.1 403 Forbidden');
-			$this->sendJSON(['error' => 'subscription_forbidden']);
-			return;
-		}
+		);
 
 		PushNotificationService::setUserPreference((int) $USER['id'], true);
 
 		$this->sendJSON(['ok' => true]);
+	}
+
+	protected function readSubscribeBody(): string
+	{
+		$raw = file_get_contents('php://input');
+
+		return is_string($raw) ? $raw : '';
 	}
 
 	public function unsubscribe()

--- a/includes/pages/game/ShowPushPage.php
+++ b/includes/pages/game/ShowPushPage.php
@@ -39,9 +39,27 @@ class ShowPushPage extends AbstractGamePage
 	{
 		global $USER;
 
+		if (($_SERVER['REQUEST_METHOD'] ?? 'GET') !== 'POST') {
+			HTTP::sendHeader('HTTP/1.1 405 Method Not Allowed');
+			$this->sendJSON(['error' => 'method_not_allowed']);
+			return;
+		}
+
 		$raw = file_get_contents('php://input');
-		$data = json_decode($raw ?: '', true);
-		if (!is_array($data) || !PushNotificationService::isValidSubscription($data)) {
+		if (!is_string($raw) || trim($raw) === '') {
+			HTTP::sendHeader('HTTP/1.1 400 Bad Request');
+			$this->sendJSON(['error' => 'empty_body']);
+			return;
+		}
+
+		$data = json_decode($raw, true);
+		if (!is_array($data)) {
+			HTTP::sendHeader('HTTP/1.1 400 Bad Request');
+			$this->sendJSON(['error' => 'invalid_json']);
+			return;
+		}
+
+		if (!PushNotificationService::isValidSubscription($data)) {
 			HTTP::sendHeader('HTTP/1.1 400 Bad Request');
 			$this->sendJSON(['error' => 'invalid_subscription']);
 			return;

--- a/install/migrations/migration_19.sql
+++ b/install/migrations/migration_19.sql
@@ -1,0 +1,3 @@
+ALTER TABLE `%PREFIX%push_subscriptions` MODIFY `endpoint` varchar(2048) NOT NULL;
+ALTER TABLE `%PREFIX%push_subscriptions` DROP INDEX `endpoint`;
+ALTER TABLE `%PREFIX%push_subscriptions` ADD UNIQUE KEY `endpoint` (`endpoint`(768));

--- a/scripts/game/push-subscribe.js
+++ b/scripts/game/push-subscribe.js
@@ -161,7 +161,7 @@
 				HiveNovaPush.disable();
 			} else {
 				HiveNovaPush.enable().catch(function (err) {
-					if (err && (err.message === 'denied' || err.message === 'not_configured' || err.message === 'subscribe_failed' || err.message === 'invalid_subscription' || err.message === 'subscription_forbidden')) {
+					if (err && (err.message === 'denied' || err.message === 'not_configured' || err.message === 'subscribe_failed' || err.message === 'invalid_subscription' || err.message === 'subscription_forbidden' || err.message === 'empty_body' || err.message === 'invalid_json' || err.message === 'method_not_allowed')) {
 						$('#pushAlerts').prop('checked', false);
 					}
 				});

--- a/scripts/game/push-subscribe.js
+++ b/scripts/game/push-subscribe.js
@@ -24,6 +24,26 @@
 			.then(function (r) { return r.json(); });
 	}
 
+	function postSubscribe(subscription) {
+		return fetch('game.php?page=push&mode=subscribe', {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(subscription.toJSON())
+		}).then(function (response) {
+			if (response.ok) {
+				return response.json();
+			}
+			return response.json().catch(function () {
+				return {};
+			}).then(function (body) {
+				var err = new Error(body.error || 'subscribe_failed');
+				err.status = response.status;
+				throw err;
+			});
+		});
+	}
+
 	function subscribeWithRegistration(reg, publicKey) {
 		return reg.pushManager.getSubscription().then(function (existing) {
 			if (existing) {
@@ -34,12 +54,7 @@
 				applicationServerKey: urlBase64ToUint8Array(publicKey)
 			});
 		}).then(function (subscription) {
-			return fetch('game.php?page=push&mode=subscribe', {
-				method: 'POST',
-				credentials: 'same-origin',
-				headers: { 'Content-Type': 'application/json' },
-				body: JSON.stringify(subscription.toJSON())
-			});
+			return postSubscribe(subscription);
 		});
 	}
 
@@ -146,10 +161,7 @@
 				HiveNovaPush.disable();
 			} else {
 				HiveNovaPush.enable().catch(function (err) {
-					if (err && err.message === 'denied') {
-						$('#pushAlerts').prop('checked', false);
-					}
-					if (err && err.message === 'not_configured') {
+					if (err && (err.message === 'denied' || err.message === 'not_configured' || err.message === 'subscribe_failed' || err.message === 'invalid_subscription' || err.message === 'subscription_forbidden')) {
 						$('#pushAlerts').prop('checked', false);
 					}
 				});

--- a/scripts/game/push-subscribe.js
+++ b/scripts/game/push-subscribe.js
@@ -10,6 +10,44 @@
 		return outputArray;
 	}
 
+	var SUBSCRIBE_FATAL_ERRORS = [
+		'subscribe_failed',
+		'invalid_subscription',
+		'empty_body',
+		'invalid_json',
+		'method_not_allowed'
+	];
+
+	function isSubscribeFatalError(err) {
+		return err && SUBSCRIBE_FATAL_ERRORS.indexOf(err.message) !== -1;
+	}
+
+	function syncServerPushPreferenceOff() {
+		return fetch('game.php?page=push&mode=unsubscribe', {
+			method: 'POST',
+			credentials: 'same-origin',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify({})
+		}).catch(function () {});
+	}
+
+	function handleSubscribeFailure(err, options) {
+		options = options || {};
+		if (!err) {
+			return Promise.resolve();
+		}
+		if (err.message === 'denied' || err.message === 'not_configured' || err.message === 'disabled') {
+			return Promise.resolve();
+		}
+		if (isSubscribeFatalError(err)) {
+			if (options.uncheckSettings && $('#pushAlerts').length) {
+				$('#pushAlerts').prop('checked', false);
+			}
+			return syncServerPushPreferenceOff();
+		}
+		return Promise.resolve();
+	}
+
 	function registerServiceWorker() {
 		if (!('serviceWorker' in navigator)) {
 			return Promise.resolve(null);
@@ -140,12 +178,7 @@
 				return HiveNovaPush.enable({
 					skipPermissionRequest: Notification.permission === 'granted'
 				}).catch(function (err) {
-					if (err && err.message === 'denied') {
-						return;
-					}
-					if (err && err.message === 'not_configured') {
-						return;
-					}
+					return handleSubscribeFailure(err, {});
 				});
 			});
 		}
@@ -161,9 +194,7 @@
 				HiveNovaPush.disable();
 			} else {
 				HiveNovaPush.enable().catch(function (err) {
-					if (err && (err.message === 'denied' || err.message === 'not_configured' || err.message === 'subscribe_failed' || err.message === 'invalid_subscription' || err.message === 'subscription_forbidden' || err.message === 'empty_body' || err.message === 'invalid_json' || err.message === 'method_not_allowed')) {
-						$('#pushAlerts').prop('checked', false);
-					}
+					handleSubscribeFailure(err, { uncheckSettings: true });
 				});
 			}
 		});

--- a/tests/Support/PushSubscriptionDatabaseStub.php
+++ b/tests/Support/PushSubscriptionDatabaseStub.php
@@ -1,0 +1,85 @@
+<?php
+
+use HiveNova\Core\DatabaseInterface;
+
+/**
+ * Tracks push subscription writes for push notification unit tests.
+ */
+class PushSubscriptionDatabaseStub implements DatabaseInterface
+{
+	/** @var array<string, array{user_id: int, endpoint: string, p256dh: string, auth: string}> */
+	public array $subscriptionsByEndpoint = [];
+
+	public array $updates = [];
+	public array $inserts = [];
+	/** @var array<int, int> */
+	public array $settingsPushByUser = [];
+
+	public function selectSingle($qry, array $params = [], $field = false)
+	{
+		if (str_contains($qry, '%%PUSH_SUBSCRIPTIONS%%') && str_contains($qry, 'endpoint')) {
+			$endpoint = $params[':endpoint'] ?? '';
+			$row = $this->subscriptionsByEndpoint[$endpoint] ?? null;
+			if ($row === null) {
+				return false;
+			}
+
+			return $field === false ? $row : ($row[$field] ?? false);
+		}
+
+		if (str_contains($qry, '%%USERS%%') && str_contains($qry, 'settings_push')) {
+			$userId = (int) ($params[':userId'] ?? 0);
+
+			return $this->settingsPushByUser[$userId] ?? 1;
+		}
+
+		return false;
+	}
+
+	public function select($qry, array $params = []) { return []; }
+	public function delete($qry, array $params = []) { return 0; }
+	public function replace($qry, array $params = []) { return 0; }
+	public function query($qry) { return 0; }
+	public function nativeQuery($qry) { return false; }
+	public function lastInsertId() { return false; }
+	public function rowCount() { return false; }
+	public function getQueryCounter() { return 0; }
+	public function quote($str) { return "'" . addslashes((string) $str) . "'"; }
+	public function disconnect() {}
+	public function beginTransaction(): void {}
+	public function commit(): void {}
+	public function rollback(): void {}
+
+	public function insert($qry, array $params = [])
+	{
+		$this->inserts[] = $params;
+		$this->subscriptionsByEndpoint[$params[':endpoint']] = [
+			'user_id'  => (int) $params[':userId'],
+			'endpoint' => $params[':endpoint'],
+			'p256dh'   => $params[':p256dh'],
+			'auth'     => $params[':auth'],
+		];
+
+		return 1;
+	}
+
+	public function update($qry, array $params = [])
+	{
+		$this->updates[] = ['qry' => $qry, 'params' => $params];
+
+		if (str_contains($qry, 'settings_push')) {
+			$this->settingsPushByUser[(int) $params[':userId']] = (int) $params[':enabled'];
+		}
+
+		if (isset($params[':endpoint'])) {
+			$this->subscriptionsByEndpoint[$params[':endpoint']] = [
+				'user_id'  => (int) $params[':userId'],
+				'endpoint' => $params[':endpoint'],
+				'p256dh'   => $params[':p256dh'],
+				'auth'     => $params[':auth'],
+			];
+		}
+
+		return 1;
+	}
+}

--- a/tests/Unit/PushNotificationServiceTest.php
+++ b/tests/Unit/PushNotificationServiceTest.php
@@ -78,17 +78,27 @@ class PushSubscriptionDatabaseStub implements DatabaseInterface
 
 class PushNotificationServiceTest extends TestCase
 {
-	private ?DatabaseInterface $previousDb = null;
-
-	protected function setUp(): void
+	/**
+	 * @param callable(PushSubscriptionDatabaseStub): void $callback
+	 */
+	private function withDatabaseStub(callable $callback): void
 	{
-		$this->previousDb = Database::get();
-	}
+		$ref = new ReflectionClass(Database::class);
+		$prop = $ref->getProperty('instance');
+		$prop->setAccessible(true);
+		$previous = $prop->getValue();
 
-	protected function tearDown(): void
-	{
-		if ($this->previousDb !== null) {
-			Database::setInstance($this->previousDb);
+		$stub = new PushSubscriptionDatabaseStub();
+		Database::setInstance($stub);
+
+		try {
+			$callback($stub);
+		} finally {
+			if ($previous instanceof DatabaseInterface) {
+				Database::setInstance($previous);
+			} else {
+				$prop->setValue(null);
+			}
 		}
 	}
 
@@ -105,49 +115,48 @@ class PushNotificationServiceTest extends TestCase
 
 	public function testSaveSubscriptionInsertsNewEndpoint(): void
 	{
-		$stub = new PushSubscriptionDatabaseStub();
-		Database::setInstance($stub);
-
-		$this->assertTrue(PushNotificationService::saveSubscription(42, $this->validSubscription()));
-		$this->assertCount(1, $stub->inserts);
-		$this->assertSame([], $stub->updates);
-		$this->assertSame(42, $stub->subscriptionsByEndpoint['https://fcm.googleapis.com/fcm/send/example']['user_id']);
+		$this->withDatabaseStub(function (PushSubscriptionDatabaseStub $stub): void {
+			$this->assertTrue(PushNotificationService::saveSubscription(42, $this->validSubscription()));
+			$this->assertCount(1, $stub->inserts);
+			$this->assertSame([], $stub->updates);
+			$this->assertSame(42, $stub->subscriptionsByEndpoint['https://fcm.googleapis.com/fcm/send/example']['user_id']);
+		});
 	}
 
 	public function testSaveSubscriptionReassignsEndpointFromAnotherUser(): void
 	{
 		$endpoint = 'https://fcm.googleapis.com/fcm/send/shared-device';
-		$stub = new PushSubscriptionDatabaseStub();
-		$stub->subscriptionsByEndpoint[$endpoint] = [
-			'user_id'  => 7,
-			'endpoint' => $endpoint,
-			'p256dh'   => 'old-key',
-			'auth'     => 'old-auth',
-		];
-		Database::setInstance($stub);
+		$this->withDatabaseStub(function (PushSubscriptionDatabaseStub $stub) use ($endpoint): void {
+			$stub->subscriptionsByEndpoint[$endpoint] = [
+				'user_id'  => 7,
+				'endpoint' => $endpoint,
+				'p256dh'   => 'old-key',
+				'auth'     => 'old-auth',
+			];
 
-		$this->assertTrue(PushNotificationService::saveSubscription(99, $this->validSubscription($endpoint)));
-		$this->assertCount(1, $stub->updates);
-		$this->assertSame([], $stub->inserts);
-		$this->assertSame(99, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
-		$this->assertSame(99, $stub->updates[0][':userId']);
+			$this->assertTrue(PushNotificationService::saveSubscription(99, $this->validSubscription($endpoint)));
+			$this->assertCount(1, $stub->updates);
+			$this->assertSame([], $stub->inserts);
+			$this->assertSame(99, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
+			$this->assertSame(99, $stub->updates[0][':userId']);
+		});
 	}
 
 	public function testSaveSubscriptionUpdatesExistingEndpointForSameUser(): void
 	{
 		$endpoint = 'https://fcm.googleapis.com/fcm/send/same-user';
-		$stub = new PushSubscriptionDatabaseStub();
-		$stub->subscriptionsByEndpoint[$endpoint] = [
-			'user_id'  => 5,
-			'endpoint' => $endpoint,
-			'p256dh'   => 'old-key',
-			'auth'     => 'old-auth',
-		];
-		Database::setInstance($stub);
+		$this->withDatabaseStub(function (PushSubscriptionDatabaseStub $stub) use ($endpoint): void {
+			$stub->subscriptionsByEndpoint[$endpoint] = [
+				'user_id'  => 5,
+				'endpoint' => $endpoint,
+				'p256dh'   => 'old-key',
+				'auth'     => 'old-auth',
+			];
 
-		$this->assertTrue(PushNotificationService::saveSubscription(5, $this->validSubscription($endpoint)));
-		$this->assertCount(1, $stub->updates);
-		$this->assertSame(5, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
+			$this->assertTrue(PushNotificationService::saveSubscription(5, $this->validSubscription($endpoint)));
+			$this->assertCount(1, $stub->updates);
+			$this->assertSame(5, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
+		});
 	}
 
 	public function testIsValidSubscriptionAcceptsWellFormedPayload(): void

--- a/tests/Unit/PushNotificationServiceTest.php
+++ b/tests/Unit/PushNotificationServiceTest.php
@@ -1,10 +1,155 @@
 <?php
 
+use HiveNova\Core\Database;
+use HiveNova\Core\DatabaseInterface;
 use HiveNova\Core\PushNotificationService;
 use PHPUnit\Framework\TestCase;
 
+if (!defined('TIMESTAMP')) {
+	define('TIMESTAMP', 1_700_000_000);
+}
+
+/**
+ * Tracks push subscription writes for saveSubscription tests.
+ */
+class PushSubscriptionDatabaseStub implements DatabaseInterface
+{
+	/** @var array<string, array{user_id: int, endpoint: string, p256dh: string, auth: string}> */
+	public array $subscriptionsByEndpoint = [];
+
+	public array $updates = [];
+	public array $inserts = [];
+
+	public function selectSingle($qry, array $params = [], $field = false)
+	{
+		if (str_contains($qry, '%%PUSH_SUBSCRIPTIONS%%') && str_contains($qry, 'endpoint')) {
+			$endpoint = $params[':endpoint'] ?? '';
+			$row = $this->subscriptionsByEndpoint[$endpoint] ?? null;
+			if ($row === null) {
+				return false;
+			}
+
+			return $field === false ? $row : ($row[$field] ?? false);
+		}
+
+		return false;
+	}
+
+	public function select($qry, array $params = []) { return []; }
+	public function delete($qry, array $params = []) { return 0; }
+	public function replace($qry, array $params = []) { return 0; }
+	public function query($qry) { return 0; }
+	public function nativeQuery($qry) { return false; }
+	public function lastInsertId() { return false; }
+	public function rowCount() { return false; }
+	public function getQueryCounter() { return 0; }
+	public function quote($str) { return "'" . addslashes((string) $str) . "'"; }
+	public function disconnect() {}
+	public function beginTransaction(): void {}
+	public function commit(): void {}
+	public function rollback(): void {}
+
+	public function insert($qry, array $params = [])
+	{
+		$this->inserts[] = $params;
+		$this->subscriptionsByEndpoint[$params[':endpoint']] = [
+			'user_id'  => (int) $params[':userId'],
+			'endpoint' => $params[':endpoint'],
+			'p256dh'   => $params[':p256dh'],
+			'auth'     => $params[':auth'],
+		];
+
+		return 1;
+	}
+
+	public function update($qry, array $params = [])
+	{
+		$this->updates[] = $params;
+		$this->subscriptionsByEndpoint[$params[':endpoint']] = [
+			'user_id'  => (int) $params[':userId'],
+			'endpoint' => $params[':endpoint'],
+			'p256dh'   => $params[':p256dh'],
+			'auth'     => $params[':auth'],
+		];
+
+		return 1;
+	}
+}
+
 class PushNotificationServiceTest extends TestCase
 {
+	private ?DatabaseInterface $previousDb = null;
+
+	protected function setUp(): void
+	{
+		$this->previousDb = Database::get();
+	}
+
+	protected function tearDown(): void
+	{
+		if ($this->previousDb !== null) {
+			Database::setInstance($this->previousDb);
+		}
+	}
+
+	private function validSubscription(string $endpoint = 'https://fcm.googleapis.com/fcm/send/example'): array
+	{
+		return [
+			'endpoint' => $endpoint,
+			'keys'     => [
+				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		];
+	}
+
+	public function testSaveSubscriptionInsertsNewEndpoint(): void
+	{
+		$stub = new PushSubscriptionDatabaseStub();
+		Database::setInstance($stub);
+
+		$this->assertTrue(PushNotificationService::saveSubscription(42, $this->validSubscription()));
+		$this->assertCount(1, $stub->inserts);
+		$this->assertSame([], $stub->updates);
+		$this->assertSame(42, $stub->subscriptionsByEndpoint['https://fcm.googleapis.com/fcm/send/example']['user_id']);
+	}
+
+	public function testSaveSubscriptionReassignsEndpointFromAnotherUser(): void
+	{
+		$endpoint = 'https://fcm.googleapis.com/fcm/send/shared-device';
+		$stub = new PushSubscriptionDatabaseStub();
+		$stub->subscriptionsByEndpoint[$endpoint] = [
+			'user_id'  => 7,
+			'endpoint' => $endpoint,
+			'p256dh'   => 'old-key',
+			'auth'     => 'old-auth',
+		];
+		Database::setInstance($stub);
+
+		$this->assertTrue(PushNotificationService::saveSubscription(99, $this->validSubscription($endpoint)));
+		$this->assertCount(1, $stub->updates);
+		$this->assertSame([], $stub->inserts);
+		$this->assertSame(99, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
+		$this->assertSame(99, $stub->updates[0][':userId']);
+	}
+
+	public function testSaveSubscriptionUpdatesExistingEndpointForSameUser(): void
+	{
+		$endpoint = 'https://fcm.googleapis.com/fcm/send/same-user';
+		$stub = new PushSubscriptionDatabaseStub();
+		$stub->subscriptionsByEndpoint[$endpoint] = [
+			'user_id'  => 5,
+			'endpoint' => $endpoint,
+			'p256dh'   => 'old-key',
+			'auth'     => 'old-auth',
+		];
+		Database::setInstance($stub);
+
+		$this->assertTrue(PushNotificationService::saveSubscription(5, $this->validSubscription($endpoint)));
+		$this->assertCount(1, $stub->updates);
+		$this->assertSame(5, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
+	}
+
 	public function testIsValidSubscriptionAcceptsWellFormedPayload(): void
 	{
 		$this->assertTrue(PushNotificationService::isValidSubscription([

--- a/tests/Unit/PushNotificationServiceTest.php
+++ b/tests/Unit/PushNotificationServiceTest.php
@@ -5,75 +5,10 @@ use HiveNova\Core\DatabaseInterface;
 use HiveNova\Core\PushNotificationService;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../Support/PushSubscriptionDatabaseStub.php';
+
 if (!defined('TIMESTAMP')) {
 	define('TIMESTAMP', 1_700_000_000);
-}
-
-/**
- * Tracks push subscription writes for saveSubscription tests.
- */
-class PushSubscriptionDatabaseStub implements DatabaseInterface
-{
-	/** @var array<string, array{user_id: int, endpoint: string, p256dh: string, auth: string}> */
-	public array $subscriptionsByEndpoint = [];
-
-	public array $updates = [];
-	public array $inserts = [];
-
-	public function selectSingle($qry, array $params = [], $field = false)
-	{
-		if (str_contains($qry, '%%PUSH_SUBSCRIPTIONS%%') && str_contains($qry, 'endpoint')) {
-			$endpoint = $params[':endpoint'] ?? '';
-			$row = $this->subscriptionsByEndpoint[$endpoint] ?? null;
-			if ($row === null) {
-				return false;
-			}
-
-			return $field === false ? $row : ($row[$field] ?? false);
-		}
-
-		return false;
-	}
-
-	public function select($qry, array $params = []) { return []; }
-	public function delete($qry, array $params = []) { return 0; }
-	public function replace($qry, array $params = []) { return 0; }
-	public function query($qry) { return 0; }
-	public function nativeQuery($qry) { return false; }
-	public function lastInsertId() { return false; }
-	public function rowCount() { return false; }
-	public function getQueryCounter() { return 0; }
-	public function quote($str) { return "'" . addslashes((string) $str) . "'"; }
-	public function disconnect() {}
-	public function beginTransaction(): void {}
-	public function commit(): void {}
-	public function rollback(): void {}
-
-	public function insert($qry, array $params = [])
-	{
-		$this->inserts[] = $params;
-		$this->subscriptionsByEndpoint[$params[':endpoint']] = [
-			'user_id'  => (int) $params[':userId'],
-			'endpoint' => $params[':endpoint'],
-			'p256dh'   => $params[':p256dh'],
-			'auth'     => $params[':auth'],
-		];
-
-		return 1;
-	}
-
-	public function update($qry, array $params = [])
-	{
-		$this->updates[] = $params;
-		$this->subscriptionsByEndpoint[$params[':endpoint']] = [
-			'user_id'  => (int) $params[':userId'],
-			'endpoint' => $params[':endpoint'],
-			'p256dh'   => $params[':p256dh'],
-			'auth'     => $params[':auth'],
-		];
-
-		return 1;
-	}
 }
 
 class PushNotificationServiceTest extends TestCase
@@ -133,12 +68,14 @@ class PushNotificationServiceTest extends TestCase
 				'p256dh'   => 'old-key',
 				'auth'     => 'old-auth',
 			];
+			$stub->settingsPushByUser[7] = 1;
+			$stub->settingsPushByUser[99] = 1;
 
 			$this->assertTrue(PushNotificationService::saveSubscription(99, $this->validSubscription($endpoint)));
-			$this->assertCount(1, $stub->updates);
+			$this->assertCount(1, array_filter($stub->updates, static fn (array $row): bool => str_contains($row['qry'], '%%PUSH_SUBSCRIPTIONS%%')));
 			$this->assertSame([], $stub->inserts);
 			$this->assertSame(99, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
-			$this->assertSame(99, $stub->updates[0][':userId']);
+			$this->assertSame(0, $stub->settingsPushByUser[7]);
 		});
 	}
 

--- a/tests/Unit/PushNotificationServiceTest.php
+++ b/tests/Unit/PushNotificationServiceTest.php
@@ -192,10 +192,23 @@ class PushNotificationServiceTest extends TestCase
 		]));
 	}
 
+	public function testIsValidSubscriptionAcceptsLongFcmEndpoint(): void
+	{
+		$endpoint = 'https://fcm.googleapis.com/fcm/send/abc:APA91b' . str_repeat('x', 500);
+		$this->assertGreaterThan(512, strlen($endpoint));
+		$this->assertTrue(PushNotificationService::isValidSubscription([
+			'endpoint' => $endpoint,
+			'keys'     => [
+				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		]));
+	}
+
 	public function testIsValidSubscriptionRejectsOversizedEndpoint(): void
 	{
 		$this->assertFalse(PushNotificationService::isValidSubscription([
-			'endpoint' => 'https://example.com/' . str_repeat('a', 512),
+			'endpoint' => 'https://example.com/' . str_repeat('a', 2048),
 			'keys'     => [
 				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
 				'auth'   => 'tBHItJI5svbpez7KI4CCXg',

--- a/tests/Unit/ShowPushPageTest.php
+++ b/tests/Unit/ShowPushPageTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+use HiveNova\Core\Database;
+use HiveNova\Core\DatabaseInterface;
+use HiveNova\Page\Game\ShowPushPage;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/PushSubscriptionDatabaseStub.php';
+
+if (!defined('TIMESTAMP')) {
+	define('TIMESTAMP', 1_700_000_000);
+}
+
+/**
+ * @internal
+ */
+final class TestableShowPushPage extends ShowPushPage
+{
+	public ?array $jsonResponse = null;
+
+	public string $testBody = '';
+
+	public function __construct()
+	{
+	}
+
+	protected function sendJSON($data): void
+	{
+		$this->jsonResponse = $data;
+	}
+
+	protected function save(): void
+	{
+	}
+
+	protected function readSubscribeBody(): string
+	{
+		return $this->testBody;
+	}
+}
+
+class ShowPushPageTest extends TestCase
+{
+	private ?DatabaseInterface $previousDb = null;
+
+	private array $previousServer = [];
+
+	protected function setUp(): void
+	{
+		global $USER;
+
+		$this->previousServer = $_SERVER;
+		$USER = ['id' => 42];
+
+		$ref = new ReflectionClass(Database::class);
+		$prop = $ref->getProperty('instance');
+		$prop->setAccessible(true);
+		$this->previousDb = $prop->getValue();
+	}
+
+	protected function tearDown(): void
+	{
+		global $USER;
+
+		$_SERVER = $this->previousServer;
+		unset($USER);
+
+		$ref = new ReflectionClass(Database::class);
+		$prop = $ref->getProperty('instance');
+		$prop->setAccessible(true);
+		if ($this->previousDb instanceof DatabaseInterface) {
+			Database::setInstance($this->previousDb);
+		} else {
+			$prop->setValue(null);
+		}
+	}
+
+	private function validSubscriptionJson(): string
+	{
+		return json_encode([
+			'endpoint' => 'https://fcm.googleapis.com/fcm/send/example-endpoint',
+			'keys'     => [
+				'p256dh' => 'BNcRdreALRFXTkOOUHK1EtK2wtaz5Ry4YfYCA_0QTpY',
+				'auth'   => 'tBHItJI5svbpez7KI4CCXg',
+			],
+		], JSON_THROW_ON_ERROR);
+	}
+
+	private function invokeSubscribe(TestableShowPushPage $page): void
+	{
+		$method = new ReflectionMethod(ShowPushPage::class, 'subscribe');
+		$method->invoke($page);
+	}
+
+	public function testSubscribeRejectsGetRequest(): void
+	{
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$page = new TestableShowPushPage();
+
+		$this->invokeSubscribe($page);
+
+		$this->assertSame(['error' => 'method_not_allowed'], $page->jsonResponse);
+	}
+
+	public function testSubscribeRejectsEmptyBody(): void
+	{
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$page = new TestableShowPushPage();
+		$page->testBody = '';
+
+		$this->invokeSubscribe($page);
+
+		$this->assertSame(['error' => 'empty_body'], $page->jsonResponse);
+	}
+
+	public function testSubscribeRejectsInvalidJson(): void
+	{
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$page = new TestableShowPushPage();
+		$page->testBody = '{not json';
+
+		$this->invokeSubscribe($page);
+
+		$this->assertSame(['error' => 'invalid_json'], $page->jsonResponse);
+	}
+
+	public function testSubscribeRejectsInvalidSubscription(): void
+	{
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$page = new TestableShowPushPage();
+		$page->testBody = '{"endpoint":"http://insecure.test","keys":{"p256dh":"x","auth":"y"}}';
+
+		$this->invokeSubscribe($page);
+
+		$this->assertSame(['error' => 'invalid_subscription'], $page->jsonResponse);
+	}
+
+	public function testSubscribeAcceptsValidSubscription(): void
+	{
+		$stub = new PushSubscriptionDatabaseStub();
+		Database::setInstance($stub);
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$page = new TestableShowPushPage();
+		$page->testBody = $this->validSubscriptionJson();
+
+		$this->invokeSubscribe($page);
+
+		$this->assertSame(['ok' => true], $page->jsonResponse);
+		$this->assertCount(1, $stub->inserts);
+		$this->assertSame(1, $stub->settingsPushByUser[42] ?? 0);
+	}
+}


### PR DESCRIPTION
## Summary
- **Reassign push endpoints** to the currently logged-in user when the same browser subscribes under a different account (fixes Universe 2 alerts failing when Universe 1 already owned the endpoint on that device).
- **Clear previous owner's `settings_push`** when an endpoint is reassigned so stale "alerts enabled" state does not linger.
- **Allow longer push endpoint URLs** (up to 2048 chars) — FCM/Brave URLs can exceed the old 512-char limit and were rejected as `invalid_subscription`.
- **Clearer subscribe API errors:** `method_not_allowed`, `empty_body`, `invalid_json`, `invalid_subscription` (instead of one generic error for everything).
- **Client:** check subscribe response status; uncheck Settings on failure; call `unsubscribe` to sync server preference when auto-subscribe fails fatally.
- **Migration 19:** widen `push_subscriptions.endpoint` to `varchar(2048)` and extend unique index prefix to 768.

## Security note
This intentionally reverses the hard cross-user block from #163. Browsers expose one push endpoint per origin, so reassignment is required for multi-account / multi-universe use on the same device. Tradeoff: a stolen subscription payload (endpoint + keys) could re-point alerts; keys are browser-bound secrets and the prior block caused silent U2 failures.

## Deploy
Run DB migration **19** after merge (install upgrade or apply `install/migrations/migration_19.sql`).

## Test plan
- [ ] Run migration 19 on staging/prod
- [ ] Universe 1 account on a browser → enable alerts → subscribe POST returns 200
- [ ] Universe 2 account, same browser → reload or toggle alerts → subscribe POST returns 200 (not 403)
- [ ] Previous U1 account shows alerts disabled in Settings after U2 subscribes
- [ ] Launch hostile fleet toward U2 defender → browser push notification arrives
- [ ] `php vendor/bin/phpunit tests/Unit/PushNotificationServiceTest.php tests/Unit/ShowPushPageTest.php --no-coverage`