### PR TITLE
Fix push endpoint reassignment deleting subscription row

### DIFF
--- a/includes/classes/PushNotificationService.php
+++ b/includes/classes/PushNotificationService.php
@@ -69,11 +69,6 @@ class PushNotificationService
 			// One browser endpoint per origin — reassign to whoever is logged in now.
 			// Same device switching accounts/universes must work; a stolen subscription
 			// object could re-point alerts (tradeoff vs hard block in #163).
-			$previousUserId = (int) $existingUserId;
-			if ($previousUserId !== $userId) {
-				self::setUserPreference($previousUserId, false);
-			}
-
 			$db->update(
 				'UPDATE %%PUSH_SUBSCRIPTIONS%% SET user_id = :userId, p256dh = :p256dh, auth = :auth, user_agent = :userAgent, created_at = :createdAt WHERE endpoint = :endpoint',
 				[

--- a/scripts/game/push-subscribe.js
+++ b/scripts/game/push-subscribe.js
@@ -36,7 +36,13 @@
 		if (!err) {
 			return Promise.resolve();
 		}
-		if (err.message === 'denied' || err.message === 'not_configured' || err.message === 'disabled') {
+		if (err.message === 'denied' || err.message === 'disabled') {
+			return Promise.resolve();
+		}
+		if (err.message === 'not_configured') {
+			if (options.uncheckSettings && $('#pushAlerts').length) {
+				$('#pushAlerts').prop('checked', false);
+			}
 			return Promise.resolve();
 		}
 		if (isSubscribeFatalError(err)) {

--- a/tests/Support/PushSubscriptionDatabaseStub.php
+++ b/tests/Support/PushSubscriptionDatabaseStub.php
@@ -12,6 +12,7 @@ class PushSubscriptionDatabaseStub implements DatabaseInterface
 
 	public array $updates = [];
 	public array $inserts = [];
+	public array $deletes = [];
 	/** @var array<int, int> */
 	public array $settingsPushByUser = [];
 
@@ -37,7 +38,27 @@ class PushSubscriptionDatabaseStub implements DatabaseInterface
 	}
 
 	public function select($qry, array $params = []) { return []; }
-	public function delete($qry, array $params = []) { return 0; }
+
+	public function delete($qry, array $params = [])
+	{
+		$this->deletes[] = ['qry' => $qry, 'params' => $params];
+
+		if (str_contains($qry, '%%PUSH_SUBSCRIPTIONS%%') && isset($params[':userId'])) {
+			$userId = (int) $params[':userId'];
+			foreach ($this->subscriptionsByEndpoint as $endpoint => $row) {
+				if ((int) $row['user_id'] === $userId) {
+					unset($this->subscriptionsByEndpoint[$endpoint]);
+				}
+			}
+		}
+
+		if (str_contains($qry, '%%PUSH_SUBSCRIPTIONS%%') && isset($params[':endpoint']) && !isset($params[':userId'])) {
+			unset($this->subscriptionsByEndpoint[$params[':endpoint']]);
+		}
+
+		return 1;
+	}
+
 	public function replace($qry, array $params = []) { return 0; }
 	public function query($qry) { return 0; }
 	public function nativeQuery($qry) { return false; }

--- a/tests/Unit/PushNotificationServiceTest.php
+++ b/tests/Unit/PushNotificationServiceTest.php
@@ -69,13 +69,39 @@ class PushNotificationServiceTest extends TestCase
 				'auth'     => 'old-auth',
 			];
 			$stub->settingsPushByUser[7] = 1;
-			$stub->settingsPushByUser[99] = 1;
 
 			$this->assertTrue(PushNotificationService::saveSubscription(99, $this->validSubscription($endpoint)));
 			$this->assertCount(1, array_filter($stub->updates, static fn (array $row): bool => str_contains($row['qry'], '%%PUSH_SUBSCRIPTIONS%%')));
 			$this->assertSame([], $stub->inserts);
+			$this->assertSame([], $stub->deletes);
 			$this->assertSame(99, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
-			$this->assertSame(0, $stub->settingsPushByUser[7]);
+			$this->assertSame(1, $stub->settingsPushByUser[7]);
+		});
+	}
+
+	public function testSaveSubscriptionReassignSurvivesPreviousOwnerDisableSideEffects(): void
+	{
+		$endpoint = 'https://fcm.googleapis.com/fcm/send/shared-device';
+		$otherEndpoint = 'https://fcm.googleapis.com/fcm/send/other-device';
+		$this->withDatabaseStub(function (PushSubscriptionDatabaseStub $stub) use ($endpoint, $otherEndpoint): void {
+			$stub->subscriptionsByEndpoint[$endpoint] = [
+				'user_id'  => 7,
+				'endpoint' => $endpoint,
+				'p256dh'   => 'old-key',
+				'auth'     => 'old-auth',
+			];
+			$stub->subscriptionsByEndpoint[$otherEndpoint] = [
+				'user_id'  => 7,
+				'endpoint' => $otherEndpoint,
+				'p256dh'   => 'other-key',
+				'auth'     => 'other-auth',
+			];
+
+			$this->assertTrue(PushNotificationService::saveSubscription(99, $this->validSubscription($endpoint)));
+
+			$this->assertSame(99, $stub->subscriptionsByEndpoint[$endpoint]['user_id']);
+			$this->assertSame(7, $stub->subscriptionsByEndpoint[$otherEndpoint]['user_id']);
+			$this->assertSame([], $stub->deletes);
 		});
 	}
 


### PR DESCRIPTION
## Summary
- Fixes a regression from #211 where `saveSubscription()` called `setUserPreference($previousUserId, false)` **before** reassigning the endpoint. That triggered `removeSubscriptionsForUser()` while the row still belonged to the previous user, deleting it before the `UPDATE` could run — leaving the new user with `settings_push = 1` but no subscription row (same silent failure as the original U2 bug).
- Reassignment now only runs the `UPDATE` (no preference wipe on the previous owner, which also avoids disabling push globally for users who still have other devices subscribed).
- Test stub `delete()` now removes subscription rows so tests reflect production behavior; added coverage for multi-device previous owner.
- Restore Settings checkbox uncheck when push is `not_configured`.

## Test plan
- [ ] User A enables alerts on a browser, then user B logs in on the same browser (different account/universe) and enables alerts — subscribe POST returns `{ok:true}` and `push_subscriptions` row has B's `user_id`.
- [ ] User A with a second device subscription keeps that row after B takes over A's browser endpoint.
- [ ] `php vendor/bin/phpunit tests/Unit/PushNotificationServiceTest.php tests/Unit/ShowPushPageTest.php --no-coverage`