### PR TITLE
Fix header planet selector on overview

### DIFF
--- a/scripts/game/base.js
+++ b/scripts/game/base.js
@@ -279,20 +279,38 @@ function UhrzeitAnzeigen() {
    $(".servertime").text(getFormatedDate(serverTime.getTime(), tdformat));
 }
 
-
-$.widget("custom.catcomplete", $.ui.autocomplete, {
-	_renderMenu: function( ul, items ) {
-		var self = this,
-			currentCategory = "";
-		$.each( items, function( index, item ) {
-			if ( item.category != currentCategory ) {
-				ul.append( "<li class='ui-autocomplete-category'>" + item.category + "</li>" );
-				currentCategory = item.category;
-			}
-			self._renderItem( ul, item );
+(function() {
+	function initPlanetSelector() {
+		var selector = document.getElementById('planetSelector');
+		if (!selector) {
+			return;
+		}
+		selector.addEventListener('change', function() {
+			document.location = '?' + queryString + '&cp=' + selector.value;
 		});
 	}
-});
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', initPlanetSelector);
+	} else {
+		initPlanetSelector();
+	}
+})();
+
+if ($.ui && $.ui.autocomplete) {
+	$.widget("custom.catcomplete", $.ui.autocomplete, {
+		_renderMenu: function( ul, items ) {
+			var self = this,
+				currentCategory = "";
+			$.each( items, function( index, item ) {
+				if ( item.category != currentCategory ) {
+					ul.append( "<li class='ui-autocomplete-category'>" + item.category + "</li>" );
+					currentCategory = item.category;
+				}
+				self._renderItem( ul, item );
+			});
+		}
+	});
+}
 
 $(function() {
 	$('#drop-admin').on('click', function() {
@@ -318,10 +336,6 @@ $(function() {
 			}
 		});
 	}, 1000);
-	
-	$('#planetSelector').on('change', function() {
-		document.location = '?'+queryString+'&cp='+$(this).val();
-	});
 
 	UhrzeitAnzeigen();
 	setInterval(UhrzeitAnzeigen, 1000);

--- a/styles/templates/game/main.header.tpl
+++ b/styles/templates/game/main.header.tpl
@@ -24,7 +24,7 @@
 	<link rel="stylesheet" type="text/css" href="{$dpath}formate.css?v={$REV}">
 	<link rel="stylesheet" type="text/css" href="./styles/resource/css/fontawesome/css/ingame-icons.css?v={$REV}">
 	<link rel="shortcut icon" href="./favicon.ico" type="image/x-icon">
-	{assign var="ingamePage" value=$smarty.get.page|default:''}
+	{assign var="ingamePage" value=$smarty.get.page|default:'overview'}
 	<script type="text/javascript">
 	var ServerTimezoneOffset = {$Offset};
 	var serverTime 	= new Date({$date.0}, {$date.1 - 1}, {$date.2}, {$date.3}, {$date.4}, {$date.5});


### PR DESCRIPTION
## Summary
- Fix the header planet selector dropdown stopping work on overview after PR #209 skipped loading `jquery.ui.js`
- Register planet switching with vanilla JS so it no longer depends on jQuery UI or `$(function())` running successfully
- Guard the `catcomplete` widget behind `$.ui` availability and default `ingamePage` to `overview` to match `game.php` routing

## Test plan
- [x] `./tests/run-ci-local.sh` (language, CSS, JS tests, unit tests, smoke, bottom-nav, error log)
- [ ] On overview (`game.php` and `game.php?page=overview`), change planet in header dropdown and confirm navigation to the selected colony
- [ ] On a non-overview page (e.g. galaxy), confirm planet selector still works with jQuery UI loaded