### PR TITLE
Fix undefined userId warning on public battle report pages

### DIFF
--- a/includes/classes/Session.php
+++ b/includes/classes/Session.php
@@ -287,11 +287,12 @@ class Session
 	    // sessions require an valid user.
 	    if(empty($this->data['userId'])) {
 	        $this->delete();
+	        return;
 	    }
 
         $userIpAddress = '127.0.0.1';
 
-	if(!(isset($_GET['page']) && $_GET['page']=="raport" && isset($_GET['raport']) && count($_GET)==2 && MODE === 'INGAME')) {
+	if(!(isset($_GET['page']) && $_GET['page']=="raport" && isset($_GET['raport']) && count($_GET)>=2 && MODE === 'INGAME')) {
 		$sql	= 'REPLACE INTO %%SESSION%% SET
 		sessionID	= :sessionId,
 		userID		= :userId,
@@ -393,7 +394,7 @@ class Session
 			// return false;
 		// }
 
-		if(isset($_GET['page']) && $_GET['page']=="raport" && isset($_GET['raport']) && count($_GET)==2 && MODE === 'INGAME') {
+		if(isset($_GET['page']) && $_GET['page']=="raport" && isset($_GET['raport']) && count($_GET)>=2 && MODE === 'INGAME') {
 		$this->data['lastActivity']=time(); } elseif (!isset($_SESSION['obj']) && empty($this->data['userId'])) { return false; }
 
 		

--- a/tests/Support/SessionDatabaseStub.php
+++ b/tests/Support/SessionDatabaseStub.php
@@ -15,6 +15,8 @@ class SessionDatabaseStub implements DatabaseInterface
 
     public int $sessionCount = 0;
 
+    public int $replaceCalls = 0;
+
     public function selectSingle($qry, array $params = [], $field = false)
     {
         if (str_contains($qry, '%%SESSION%%') && str_contains($qry, 'lastonline')) {
@@ -65,6 +67,7 @@ class SessionDatabaseStub implements DatabaseInterface
 
     public function replace($qry, array $params = [])
     {
+        $this->replaceCalls++;
         return 0;
     }
 

--- a/tests/Unit/SessionTest.php
+++ b/tests/Unit/SessionTest.php
@@ -199,6 +199,24 @@ class SessionTest extends TestCase
         $this->assertFalse($session->isValidSession());
     }
 
+    public function testSaveReturnsEarlyWhenUserIdMissing(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            session_write_close();
+        }
+        session_id('no-user-session');
+        session_start();
+
+        $session = $this->newSession();
+        $this->setSessionData($session, [
+            'lastActivity' => TIMESTAMP,
+        ]);
+
+        $session->save();
+
+        $this->assertSame(0, $this->dbStub->replaceCalls);
+    }
+
     public function testIsValidSessionReturnsTrueWhenObjMissingButUserIdSetAndDbRowExists(): void
     {
         if (session_status() === PHP_SESSION_ACTIVE) {


### PR DESCRIPTION
## Summary
- Return early from `Session::save()` after deleting sessions that have no `userId`, preventing access to an undefined array key during fleet event processing
- Align raport page detection in `Session.php` with `common.php` (`count($_GET) >= 2`) so battle hall report URLs with `mode=battlehall` correctly skip session persistence
- Add unit test covering the early-return path

## Test plan
- [x] `./vendor/bin/phpunit tests/Unit/SessionTest.php`
- [ ] Open a public battle report URL (e.g. `game.php?mode=battlehall&page=raport&raport=...`) without a logged-in session and confirm no PHP warning is logged
- [ ] Verify logged-in users can still view battle reports normally