### PR TITLE
Show energy in build-fail messages when construction costs energy

### DIFF
--- a/includes/classes/ResourceUpdate.php
+++ b/includes/classes/ResourceUpdate.php
@@ -355,19 +355,7 @@ class ResourceUpdate
 					if ($HaveNoMoreLevel) {
 						$Message     = sprintf($LNG['sys_nomore_level'], $LNG['tech'][$Element]);
 					} else {
-						if(!isset($costResources[901])) { $costResources[901] = 0; }
-						if(!isset($costResources[902])) { $costResources[902] = 0; }
-						if(!isset($costResources[903])) { $costResources[903] = 0; }
-						
-						global $LNG;
-
-						if(empty($LNG)) {
-						// Fallback language
-							$LNG = new Language('en');
-							$LNG->includeData(array('L18N', 'INGAME', 'TECH', 'CUSTOM'));
-						}
-
-						$Message     = sprintf($LNG['sys_notenough_money'], $this->PLANET['name'], $this->PLANET['id'], $this->PLANET['galaxy'], $this->PLANET['system'], $this->PLANET['planet'], $LNG['tech'][$Element], pretty_number ($this->PLANET['metal']), $LNG['tech'][901], pretty_number($this->PLANET['crystal']), $LNG['tech'][902], pretty_number ($this->PLANET['deuterium']), $LNG['tech'][903], pretty_number($costResources[901]), $LNG['tech'][901], pretty_number ($costResources[902]), $LNG['tech'][902], pretty_number ($costResources[903]), $LNG['tech'][903]);
+						$Message     = self::formatNotEnoughResourcesMessage($this->PLANET, $Element, $costResources);
 					}
 
 					PlayerUtil::sendMessage($this->USER['id'], 0,$LNG['sys_buildlist'], 99,
@@ -399,6 +387,62 @@ class ResourceUpdate
 		$this->PLANET['b_building_id'] = $NewQueue;
 
 		return true;
+	}
+
+	/**
+	 * Build the "not enough resources" inbox message for a failed queue start.
+	 * When the element costs energy (911), append available vs required energy —
+	 * the base string only lists metal/crystal/deuterium and otherwise hides
+	 * energy shortfalls (e.g. Terraformer).
+	 */
+	public static function formatNotEnoughResourcesMessage(array $planet, $element, array $costResources): string
+	{
+		global $LNG;
+
+		if (empty($LNG)) {
+			$LNG = new Language('en');
+			$LNG->includeData(array('L18N', 'INGAME', 'TECH', 'CUSTOM'));
+		}
+
+		foreach ([901, 902, 903, 911] as $resId) {
+			if (!isset($costResources[$resId])) {
+				$costResources[$resId] = 0;
+			}
+		}
+
+		$Message = sprintf(
+			$LNG['sys_notenough_money'],
+			$planet['name'],
+			$planet['id'],
+			$planet['galaxy'],
+			$planet['system'],
+			$planet['planet'],
+			$LNG['tech'][$element],
+			pretty_number($planet['metal']),
+			$LNG['tech'][901],
+			pretty_number($planet['crystal']),
+			$LNG['tech'][902],
+			pretty_number($planet['deuterium']),
+			$LNG['tech'][903],
+			pretty_number($costResources[901]),
+			$LNG['tech'][901],
+			pretty_number($costResources[902]),
+			$LNG['tech'][902],
+			pretty_number($costResources[903]),
+			$LNG['tech'][903]
+		);
+
+		if ($costResources[911] > 0) {
+			$Message .= sprintf(
+				$LNG['sys_notenough_money_energy'],
+				pretty_number($planet['energy'] ?? 0),
+				$LNG['tech'][911],
+				pretty_number($costResources[911]),
+				$LNG['tech'][911]
+			);
+		}
+
+		return $Message;
 	}
 		
 	private function ResearchQueue()
@@ -520,19 +564,7 @@ class ResourceUpdate
 				$Loop                  			= false;
 			} else {
 				if($this->USER['hof'] == 1){
-					if(!isset($costResources[901])) { $costResources[901] = 0; }
-					if(!isset($costResources[902])) { $costResources[902] = 0; }
-					if(!isset($costResources[903])) { $costResources[903] = 0; }
-					
-					global $LNG;
-
-					if(empty($LNG)) {
-					// Fallback language
-						$LNG = new Language('en');
-						$LNG->includeData(array('L18N', 'INGAME', 'TECH', 'CUSTOM'));
-					}
-
-					$Message     = sprintf($LNG['sys_notenough_money'], $PLANET['name'], $PLANET['id'], $PLANET['galaxy'], $PLANET['system'], $PLANET['planet'], $LNG['tech'][$Element], pretty_number ($PLANET['metal']), $LNG['tech'][901], pretty_number($PLANET['crystal']), $LNG['tech'][902], pretty_number ($PLANET['deuterium']), $LNG['tech'][903], pretty_number($costResources[901]), $LNG['tech'][901], pretty_number ($costResources[902]), $LNG['tech'][902], pretty_number ($costResources[903]), $LNG['tech'][903]);
+					$Message = self::formatNotEnoughResourcesMessage($PLANET, $Element, $costResources);
 					PlayerUtil::sendMessage($this->USER['id'], 0,$LNG['sys_techlist'], 99, $LNG['sys_buildlist_fail'], $Message, $this->TIME);
 				}
 

--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -428,6 +428,7 @@ $LNG['bd_destroy_time'] 					= 'Dauer';
 $LNG['bd_max_ships'] 						= 'max';
 $LNG['bd_max_ships_long'] 					= 'Maximal baubare Einheiten';
 $LNG['sys_notenough_money'] 					= 'Sie verfügen auf Planet %s <a href="?page=buildings&amp;cp=%d&amp;re=0">[%d:%d:%d]</a> nicht über genügend Ressourcen, um mit dem Bau von %s zu beginnen. <br>Sie verfügen über %s %s , %s %s und %s %s. <br>Die Baukosten betragen %s %s , %s %s und %s %s.';
+$LNG['sys_notenough_money_energy']				= '<br>Ihre Energie beträgt: %s %s. <br>Die Energiekosten der Konstruktion betragen %s %s.';
 $LNG['sys_nomore_level'] 					= 'Sie versuchen, ein Gebäude zu zerstören, was sie nicht mehr besitzen( %s ).';
 $LNG['sys_buildlist'] 						= 'Bauliste';
 $LNG['sys_techlist'] 						= 'Forschungsliste';

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -446,6 +446,7 @@ $LNG['bd_destroy_time'] 					= 'Duration';
 $LNG['bd_max_ships']                        = 'max';
 $LNG['bd_max_ships_long']					= 'Maximum possible units to build';
 $LNG['sys_notenough_money'] 				= 'You dont have enough resources on %s <a href="./game.php?page=buildings&amp;cp=%d&amp;re=0">[%d:%d:%d]</a> to build %s. <br>Your ressources are: %s %s , %s %s and %s %s. <br>The cost of construction is %s %s , %s %s and %s %s.';
+$LNG['sys_notenough_money_energy']			= '<br>Your energy is: %s %s. <br>The energy cost of construction is %s %s.';
 $LNG['sys_nomore_level'] 					= "There's no building ( %s ) to demolish.";
 $LNG['sys_buildlist'] 						= "List of construction";
 $LNG['sys_techlist'] 						= 'Research list';

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -418,6 +418,7 @@ $LNG['bd_destroy_time'] 					= 'Duración';
 $LNG['bd_max_ships'] 						= 'Máx';
 $LNG['bd_max_ships_long'] 					= 'Máximo de unidades a construir';
 $LNG['sys_notenough_money'] 				= 'En el planeta %s <a href="?page=buildings&amp;cp=%d&amp;re=0">[%d:%d:%d]</a> no tienes suficientes recursos para construir %s . <br>Ahora tienes %s de %s , %s de %s y %s de %s. <br>El coste de la construcción es  %s %s , %s %s y %s %s.';
+$LNG['sys_notenough_money_energy']			= '<br>Tu energía es: %s %s. <br>El coste de energía de la construcción es %s %s.';
 $LNG['sys_nomore_level'] 					= 'Intentas destruir un edificio que ya no tiene más ( %s ).';
 $LNG['sys_buildlist'] 						= 'Lista de Construcción';
 $LNG['sys_techlist'] 						= 'Lista de Investigación';

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -409,6 +409,7 @@ $LNG['bd_destroy_time'] 					= 'Temps';
 $LNG['bd_max_ships']                        = 'Max';
 $LNG['bd_max_ships_long']                   = 'Maximum unités constructibles';
 $LNG['sys_notenough_money'] 				= 'Vous n\'avez pas assez d\'argent %s <a href="./game.php?page=buildings&cp=%d&re=0">[%d:%d:%d]</a> pour construire %s. <br>Vos ressources sont : %s %s , %s %s and %s %s. <br>Le coût de construction est de : %s %s , %s %s and %s %s.';
+$LNG['sys_notenough_money_energy']			= '<br>Votre énergie est : %s %s. <br>Le coût en énergie de la construction est de %s %s.';
 $LNG['sys_nomore_level'] 					= 'Vous tentez de détruire un bâtiment dont vous ne diposez plus ( %s ).';
 $LNG['sys_buildlist'] 						= 'Liste d\'ensemble';
 $LNG['sys_techlist'] 						= 'Liste de recherche';

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -430,6 +430,7 @@ $LNG['bd_destroy_time'] 					= 'Czas';
 $LNG['bd_max_ships']                        = 'Max';
 $LNG['bd_max_ships_long']                   = 'Maksimum jednostek do zbudowania';
 $LNG['sys_notenough_money'] 				= 'Na %s <a href="?page=buildings&amp;cp=%d&amp;re=0">[%d:%d:%d]</a> brakło środków do budowy %s. <br> Miałeś, %s %s , %s %s i %s %s. <br> a potrzebowałeś %s %s , %s %s i %s %s.';
+$LNG['sys_notenough_money_energy']			= '<br>Twoja energia to: %s %s. <br>Koszt energii budowy wynosi %s %s.';
 $LNG['sys_nomore_level'] 					= 'Próbujesz zniszczyć budynek, którego nie posiadasz( %s ).';
 $LNG['sys_buildlist'] 						= 'Lista budowy';
 $LNG['sys_techlist'] 						= 'Lista badań';

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -423,6 +423,7 @@ $LNG['bd_destroy_time'] 					= 'Duração';
 $LNG['bd_max_ships']                                            = 'max';
 $LNG['bd_max_ships_long']                                       = 'Máximo de unidades possiveis para construir';
 $LNG['sys_notenough_money'] 				= 'Não tem recursos desponíveis no %s <a href="./game.php?page=buildings&amp;cp=%d&amp;re=0">[%d:%d:%d]</a> para a construção que querias efetuar. <br>Recursos disponíveis para a construção da %s %s , %s %s e %s %s. <br>O custo de construção %s %s , %s %s e %s %s.';
+$LNG['sys_notenough_money_energy']			= '<br>A tua energia é: %s %s. <br>O custo de energia da construção é %s %s.';
 $LNG['sys_nomore_level'] 					= 'Está a tentar destruir um edifício que já não tem ( %s ).';
 $LNG['sys_buildlist'] 						= "Lista de construção";
 $LNG['sys_techlist'] 						= 'Lista de Pesquisa';

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -408,6 +408,7 @@ $LNG['bd_destroy_time']                   = 'Время';
 $LNG['bd_max_ships']                      = 'макс';
 $LNG['bd_max_ships_long']                 = 'Максимальное количество (по имеющимся ресурсам)';
 $LNG['sys_notenough_money']               = 'На планете %s <a href="?page=buildings&amp;cp=%d&amp;re=0">[%d:%d:%d]</a> недостаточно ресурсов для строительства %s. <br>В наличии: %s %s , %s %s и %s %s. <br>Стоимость строительства: %s %s , %s %s и %s %s.';
+$LNG['sys_notenough_money_energy']         = '<br>Ваша энергия: %s %s. <br>Стоимость энергии строительства: %s %s.';
 $LNG['sys_nomore_level']                  = 'Вы пытаетесь разрушить здание, которое уже разрушено ( %s ).';
 $LNG['sys_buildlist']                     = 'Список строительства';
 $LNG['sys_techlist']                      = 'Список исследований';

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -431,6 +431,7 @@ $LNG['bd_destroy_time'] 					= 'Yıkım Süresi';
 $LNG['bd_max_ships']                                            = 'max';
 $LNG['bd_max_ships_long']                                       = 'Uretime verilebilecek azami miktar';
 $LNG['sys_notenough_money'] 				= 'Hata %s <a href="./game.php?page=buildings&amp;cp=%d&amp;re=0">[%d:%d:%d]</a>de yeterli ham madde yok.  . <br> Inşa Edilmesi Emredilen Bina: %s. Sendeki mevcut ham madde %s %s , %s %s and %s %s. <br>Inşa için gereken ise  %s %s , %s %s ve %s %s.';
+$LNG['sys_notenough_money_energy']			= '<br>Enerjiniz: %s %s. <br>İnşa için gereken enerji: %s %s.';
 $LNG['sys_nomore_level'] 					= "Mevcut olmayan bir binayı yıkmaya çalışıyorsun ( %s ).";
 $LNG['sys_buildlist'] 						= "Inşa Listesi";
 $LNG['sys_techlist'] 						= 'Araştırma Listesi';

--- a/tests/Unit/BuildFunctionsTest.php
+++ b/tests/Unit/BuildFunctionsTest.php
@@ -54,9 +54,11 @@ class BuildFunctionsTest extends TestCase
 			'research_lab'            => 0,
 			'intergalactic_research'  => 0,
 			'intergalactic_research_inter' => 0,
+			'terraformer'             => 0,
 			'metal'                   => 100000,
 			'crystal'                 => 100000,
 			'deuterium'               => 100000,
+			'energy'                  => 10000,
 			'solar_plant'             => 0,
 			'light_fighter'           => 0,
 		], $overrides);
@@ -344,5 +346,85 @@ class BuildFunctionsTest extends TestCase
 		);
 
 		$this->assertEquals(0, $max);
+	}
+
+	// -----------------------------------------------------------------------
+	// Terraformer (33) — player report: "enough resources" but Impossible to build
+	//
+	// PR3 [4:80:13], Terraformer level 3 cost:
+	//   0 Metal, 200000 Silicon, 400000 Uranium, 4000 Energy
+	// Planet had: 556 / 200002 / 400079 and 4119 max energy.
+	// Failure message only lists metal/silicon/uranium (not energy), so a failed
+	// energy check looks like a resource bug. isElementBuyable must treat energy
+	// production as a cost and still allow the build when max energy >= cost.
+	// -----------------------------------------------------------------------
+
+	public function testTerraformerLevel3PriceMatchesInstallFormula(): void
+	{
+		Config::setInstance($this->makeConfig(), 1);
+		$user   = $this->makeUser();
+		$planet = $this->makePlanet(['terraformer' => 2]);
+
+		// Building to level 3: base * factor^(3-1) = base * 4
+		$price = BuildFunctions::getElementPrice($user, $planet, 33, false, 3);
+
+		$this->assertArrayNotHasKey(901, $price, 'Metal cost is 0 and must be omitted');
+		$this->assertEquals(200000, $price[902]);
+		$this->assertEquals(400000, $price[903]);
+		$this->assertEquals(4000, $price[911], 'Energy is part of Terraformer cost');
+	}
+
+	public function testTerraformerBuyableWithReportedPlayerResourcesAndEnergy(): void
+	{
+		Config::setInstance($this->makeConfig(), 1);
+		$user = $this->makeUser();
+		// Exact amounts from the 10 Jul 2026 player report (European thousands separators)
+		$planet = $this->makePlanet([
+			'terraformer' => 2,
+			'metal'       => 556,
+			'crystal'     => 200002,
+			'deuterium'   => 400079,
+			'energy'      => 4119,
+		]);
+
+		$price = BuildFunctions::getElementPrice($user, $planet, 33, false, 3);
+
+		$this->assertTrue(
+			BuildFunctions::isElementBuyable($user, $planet, 33, $price),
+			'Terraformer L3 must be buyable when listed resources and max energy meet cost'
+		);
+
+		$rest = BuildFunctions::getRestPrice($user, $planet, 33, $price);
+		$this->assertSame(0.0, (float) ($rest[902] ?? 0));
+		$this->assertSame(0.0, (float) ($rest[903] ?? 0));
+		$this->assertSame(0.0, (float) ($rest[911] ?? 0), 'No energy shortfall when max energy is 4119');
+	}
+
+	public function testTerraformerNotBuyableWhenEnergyBelowCostDespiteEnoughResources(): void
+	{
+		Config::setInstance($this->makeConfig(), 1);
+		$user = $this->makeUser();
+		// Same metal/silicon/uranium as the report, but energy production too low.
+		// This is the failure mode behind the misleading "not enough resources" message
+		// before sys_notenough_money_energy was added (base string only prints 901/902/903).
+		$planet = $this->makePlanet([
+			'terraformer' => 2,
+			'metal'       => 556,
+			'crystal'     => 200002,
+			'deuterium'   => 400079,
+			'energy'      => 3999,
+		]);
+
+		$price = BuildFunctions::getElementPrice($user, $planet, 33, false, 3);
+
+		$this->assertFalse(
+			BuildFunctions::isElementBuyable($user, $planet, 33, $price),
+			'Energy shortfall alone must block the build'
+		);
+
+		$rest = BuildFunctions::getRestPrice($user, $planet, 33, $price);
+		$this->assertSame(0.0, (float) ($rest[902] ?? 0), 'Silicon is sufficient');
+		$this->assertSame(0.0, (float) ($rest[903] ?? 0), 'Uranium is sufficient');
+		$this->assertSame(1.0, (float) $rest[911], 'Short by 1 energy vs cost 4000');
 	}
 }

--- a/tests/Unit/ResourceUpdateTest.php
+++ b/tests/Unit/ResourceUpdateTest.php
@@ -23,6 +23,8 @@ class ResourceUpdateTest extends TestCase
 			'storage_multiplier'     => 1,
 			'energySpeed'            => 1,
 			'max_overflow'           => 2,
+			'game_speed'             => 1,
+			'min_build_time'         => 0,
 		], $overrides);
 		return new Config($data);
 	}
@@ -35,10 +37,13 @@ class ResourceUpdateTest extends TestCase
 			903 => 'deuterium',
 			911 => 'energy',
 			921 => 'darkmatter',
+			14  => 'robotic_factory',
+			15  => 'nanite_factory',
 			22  => 'solar_plant',
 			23  => 'fusion_reactor',
 			24  => 'solar_satellite',
 			31  => 'intergalactic_research',
+			33  => 'terraformer',
 			113 => 'energy_tech',
 			123 => 'intergalactic_research',
 			131 => 'plasma_tech',
@@ -52,8 +57,14 @@ class ResourceUpdateTest extends TestCase
 		return [
 			'prod'     => [],
 			'storage'  => [],
+			'build'    => [1, 2, 3, 4, 6, 12, 14, 15, 21, 22, 23, 24, 31, 33, 34],
+			'fleet'    => [],
+			'defense'  => [],
+			'missile'  => [],
+			'tech'     => [],
 			'resstype' => [1 => [901, 902, 903], 2 => [911]],
 			'one'      => [],
+			'ressources' => [901, 902, 903, 911, 921],
 		];
 	}
 
@@ -74,6 +85,7 @@ class ResourceUpdateTest extends TestCase
 				'Resource'        => 0,
 				'Energy'          => 0,
 				'ResourceStorage' => 0,
+				'BuildTime'       => 0,
 			],
 			'plasma_tech'               => 0,
 			'graviton_tech'             => 0,
@@ -87,6 +99,10 @@ class ResourceUpdateTest extends TestCase
 	{
 		return array_merge([
 			'id'                => 1,
+			'name'              => 'PR3',
+			'galaxy'            => 4,
+			'system'            => 80,
+			'planet'            => 13,
 			'planet_type'       => 1,
 			'metal'             => 0,
 			'crystal'           => 0,
@@ -107,6 +123,9 @@ class ResourceUpdateTest extends TestCase
 			'b_hangar'          => 0,
 			'field_current'     => 0,
 			'temp_max'          => 30,
+			'terraformer'       => 0,
+			'robotic_factory'   => 0,
+			'nanite_factory'    => 0,
 			'solar_plant'       => 0,
 			'solar_plant_porcent'         => 100,
 			'fusion_reactor'              => 0,
@@ -481,5 +500,154 @@ class ResourceUpdateTest extends TestCase
 		$result = $eco->CalcResource($user, $planet, false, $planet['last_update']);
 		$this->assertIsArray($result);
 		$this->assertCount(2, $result);
+	}
+
+	/**
+	 * Player report (10 Jul 2026): Terraformer queued on PR3 with enough listed
+	 * resources (556/200002/400079) and 4119 max energy vs 4000 required, but
+	 * SetNextQueueElementOnTop rejected the build as "Impossible to build".
+	 *
+	 * With matching amounts the queue item must start and deduct silicon/uranium.
+	 */
+	public function testSetNextQueueStartsTerraformerWithReportedResources(): void
+	{
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist();
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser(['hof' => 0]);
+
+		$queue = [[33, 3, 0, 1000000, 'build']];
+		$planet = $this->makePlanet([
+			'terraformer'    => 2,
+			'metal'          => 556,
+			'crystal'        => 200002,
+			'deuterium'      => 400079,
+			'energy'         => 4119,
+			'b_building'     => 1000000,
+			'b_building_id'  => serialize($queue),
+		]);
+
+		Config::setInstance($config, 1);
+		$eco = new ResourceUpdate(false, false);
+		$eco->setResourceData($resource, $reslist);
+		$eco->setData($user, $planet);
+
+		$this->assertTrue($eco->SetNextQueueElementOnTop());
+
+		[, $updated] = $eco->getData();
+
+		$this->assertNotSame('', $updated['b_building_id'], 'Queue must keep the Terraformer once started');
+		$this->assertGreaterThan(1000000, $updated['b_building'], 'Build end time must be set in the future');
+		$this->assertEquals(556.0, $updated['metal']);
+		$this->assertEquals(2.0, $updated['crystal'], '200002 - 200000 silicon');
+		$this->assertEquals(79.0, $updated['deuterium'], '400079 - 400000 uranium');
+	}
+
+	/**
+	 * Same report scenario but energy production below the Terraformer cost:
+	 * metal/silicon/uranium look fine in the base message, yet the queue
+	 * item is dropped because isElementBuyable also checks energy (911).
+	 * formatNotEnoughResourcesMessage appends the energy shortfall.
+	 */
+	public function testSetNextQueueDropsTerraformerWhenEnergyTooLow(): void
+	{
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist();
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser(['hof' => 0]);
+
+		$queue = [[33, 3, 0, 1000000, 'build']];
+		$planet = $this->makePlanet([
+			'terraformer'    => 2,
+			'metal'          => 556,
+			'crystal'        => 200002,
+			'deuterium'      => 400079,
+			'energy'         => 3999,
+			'b_building'     => 1000000,
+			'b_building_id'  => serialize($queue),
+		]);
+
+		Config::setInstance($config, 1);
+		$eco = new ResourceUpdate(false, false);
+		$eco->setResourceData($resource, $reslist);
+		$eco->setData($user, $planet);
+
+		$this->assertTrue($eco->SetNextQueueElementOnTop());
+
+		[, $updated] = $eco->getData();
+
+		$this->assertSame('', $updated['b_building_id'], 'Queue item must be removed when energy blocks the build');
+		$this->assertSame(0, $updated['b_building']);
+		$this->assertEquals(200002.0, $updated['crystal'], 'Resources must not be deducted on failure');
+		$this->assertEquals(400079.0, $updated['deuterium']);
+	}
+
+	public function testFormatNotEnoughResourcesMessageIncludesEnergyWhenCostRequiresIt(): void
+	{
+		$GLOBALS['LNG'] = [
+			'sys_notenough_money'        => 'RES %s %d [%d:%d:%d] %s | have %s %s , %s %s and %s %s | need %s %s , %s %s and %s %s',
+			'sys_notenough_money_energy' => ' | energy have %s %s need %s %s',
+			'tech' => [
+				33  => 'Terraformer',
+				901 => 'Metal',
+				902 => 'Silicon',
+				903 => 'Uranium',
+				911 => 'Energy',
+			],
+		];
+
+		$planet = [
+			'name'      => 'PR3',
+			'id'        => 42,
+			'galaxy'    => 4,
+			'system'    => 80,
+			'planet'    => 13,
+			'metal'     => 556,
+			'crystal'   => 200002,
+			'deuterium' => 400079,
+			'energy'    => 3999,
+		];
+		$cost = [901 => 0, 902 => 200000, 903 => 400000, 911 => 4000];
+
+		$message = ResourceUpdate::formatNotEnoughResourcesMessage($planet, 33, $cost);
+
+		$this->assertStringContainsString('Terraformer', $message);
+		$this->assertStringContainsString('energy have', $message);
+		$this->assertStringContainsString('Energy', $message);
+		$this->assertStringContainsString('3.999', $message);
+		$this->assertStringContainsString('4.000', $message);
+	}
+
+	public function testFormatNotEnoughResourcesMessageOmitsEnergyWhenNotInCost(): void
+	{
+		$GLOBALS['LNG'] = [
+			'sys_notenough_money'        => 'RES %s %d [%d:%d:%d] %s | have %s %s , %s %s and %s %s | need %s %s , %s %s and %s %s',
+			'sys_notenough_money_energy' => ' | energy have %s %s need %s %s',
+			'tech' => [
+				1   => 'Metal Mine',
+				901 => 'Metal',
+				902 => 'Silicon',
+				903 => 'Uranium',
+				911 => 'Energy',
+			],
+		];
+
+		$planet = [
+			'name'      => 'Home',
+			'id'        => 1,
+			'galaxy'    => 1,
+			'system'    => 1,
+			'planet'    => 1,
+			'metal'     => 10,
+			'crystal'   => 10,
+			'deuterium' => 10,
+			'energy'    => 100,
+		];
+		$cost = [901 => 60, 902 => 15];
+
+		$message = ResourceUpdate::formatNotEnoughResourcesMessage($planet, 1, $cost);
+
+		$this->assertStringNotContainsString('energy have', $message);
+		$this->assertStringNotContainsString('Energy', $message);
 	}
 }

--- a/tests/fixtures/game_data.php
+++ b/tests/fixtures/game_data.php
@@ -45,6 +45,7 @@ $GLOBALS['resource'] = array_replace($GLOBALS['resource'] ?? [], [
 	902 => 'crystal',
 	903 => 'deuterium',
 	911 => 'energy',
+	921 => 'darkmatter',
 ]);
 
 // ---------------------------------------------------------------------------
@@ -60,7 +61,8 @@ $GLOBALS['reslist'] = array_replace($GLOBALS['reslist'] ?? [], [
 	'officier'  => [601, 602, 603, 604, 605, 606, 607, 608, 609, 610, 611, 612, 613, 614, 615],
 	'dmfunc'    => [701, 702, 703, 704, 705, 706, 707],
 	'one'       => [31],
-	'ressources'=> [901, 902, 903],
+	// Matches includes/vars.php — energy (911) is part of buyable checks
+	'ressources'=> [901, 902, 903, 911, 921],
 ]);
 
 // ---------------------------------------------------------------------------
@@ -72,6 +74,13 @@ $GLOBALS['pricelist'] = array_replace($GLOBALS['pricelist'] ?? [], [
 	1   => [
 		'cost'   => [901 => 60, 902 => 15, 903 => 0],
 		'factor' => 1.5,
+		'time'   => 1,
+	],
+	// Terraformer (33) — from install.sql: cost902=50000, cost903=100000, cost911=1000, factor=2
+	33  => [
+		'cost'   => [901 => 0, 902 => 50000, 903 => 100000, 911 => 1000, 921 => 0],
+		'factor' => 2.0,
+		'max'    => 255,
 		'time'   => 1,
 	],
 	// Light Fighter (202) — combustion-drive ship


### PR DESCRIPTION
## Summary
- Build/research queue failure messages now include available vs required energy when the element costs energy (e.g. Terraformer).
- Adds regression tests from a player report where metal/silicon/uranium looked sufficient but the build was rejected on energy.

## Test plan
- [ ] `./vendor/bin/phpunit tests/Unit/BuildFunctionsTest.php tests/Unit/ResourceUpdateTest.php`
- [ ] Queue a Terraformer with enough resources but energy production below cost; confirm the inbox "Impossible to build" message lists energy
- [ ] Queue a normal building (no energy cost) and confirm the message is unchanged (no energy lines)