### PR TITLE
Extend inactivity thresholds

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -221,10 +221,10 @@ define('FACTOR_CANCEL_SHIPYARD'		, 0.6);
 // =============================================================================
 
 // Seconds until (i) marker appears on galaxy map
-define('INACTIVE'					, 604800);
+define('INACTIVE'					, 1209600); // 14 days
 
 // Seconds until (i I) long-inactive marker appears on galaxy map
-define('INACTIVE_LONG'				, 2419200);
+define('INACTIVE_LONG'				, 5184000); // 60 days
 
 // Cooldown in seconds before a player can change their username again
 define('USERNAME_CHANGETIME'		, 604800);


### PR DESCRIPTION
## Summary
- Change INACTIVE from 7 days to 14 days (galaxy map (i) marker)
- Change INACTIVE_LONG from 28 days to 60 days (galaxy map (i I) marker + vacation mode protection expiry)

## Motivation
Players need more time before being flagged as inactive and losing vacation mode protections.