### PR TITLE
Fix PHP 8.5 PDO::MYSQL_ATTR_* deprecation warnings

### DIFF
--- a/includes/classes/Database.php
+++ b/includes/classes/Database.php
@@ -57,13 +57,22 @@ class Database implements DatabaseInterface
 	{
 		$database = array();
 		require 'includes/config.php';
+		// PHP 8.5+ deprecates PDO::MYSQL_ATTR_*; Pdo\Mysql exists since 8.4
+		$usePdoMysql = class_exists(\Pdo\Mysql::class);
+		$mysqlInitCommand = $usePdoMysql
+			? \Pdo\Mysql::ATTR_INIT_COMMAND
+			: PDO::MYSQL_ATTR_INIT_COMMAND;
+		$mysqlBufferedQuery = $usePdoMysql
+			? \Pdo\Mysql::ATTR_USE_BUFFERED_QUERY
+			: PDO::MYSQL_ATTR_USE_BUFFERED_QUERY;
+
 		//Connect
 		$db = new PDO("mysql:host=".$database['host'].";port=".$database['port'].";dbname=".$database['databasename'], $database['user'], $database['userpw'], array(
-		    PDO::MYSQL_ATTR_INIT_COMMAND => "SET CHARACTER SET utf8mb4, NAMES utf8mb4, sql_mode = 'STRICT_ALL_TABLES'"
+		    $mysqlInitCommand => "SET CHARACTER SET utf8mb4, NAMES utf8mb4, sql_mode = 'STRICT_ALL_TABLES'"
 		));
 		//error behaviour
 		$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-		$db->setAttribute(PDO::MYSQL_ATTR_USE_BUFFERED_QUERY, true);
+		$db->setAttribute($mysqlBufferedQuery, true);
 		// $db->query("set character set utf8");
 		// $db->query("set names utf8");
 		// $db->query("SET sql_mode = 'STRICT_ALL_TABLES'");

--- a/migrate.php
+++ b/migrate.php
@@ -31,11 +31,15 @@ require 'vendor/autoload.php';
 use HiveNova\Core\Migrator;
 
 try {
+    // PHP 8.5+ deprecates PDO::MYSQL_ATTR_*; Pdo\Mysql exists since 8.4
+    $mysqlInitCommand = class_exists(\Pdo\Mysql::class)
+        ? \Pdo\Mysql::ATTR_INIT_COMMAND
+        : PDO::MYSQL_ATTR_INIT_COMMAND;
     $pdo = new PDO(
         "mysql:host={$database['host']};port={$database['port']};dbname={$database['databasename']}",
         $database['user'],
         $database['userpw'],
-        [PDO::MYSQL_ATTR_INIT_COMMAND => "SET CHARACTER SET utf8mb4, NAMES utf8mb4, sql_mode = 'STRICT_ALL_TABLES'"]
+        [$mysqlInitCommand => "SET CHARACTER SET utf8mb4, NAMES utf8mb4, sql_mode = 'STRICT_ALL_TABLES'"]
     );
     $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {

--- a/tests/ci-install.php
+++ b/tests/ci-install.php
@@ -62,11 +62,15 @@ restore_error_handler();
 
 // Open a raw PDO connection for bulk SQL execution (PDO::exec does not reliably
 // handle multi-statement strings; we split and execute statement by statement).
+// PHP 8.5+ deprecates PDO::MYSQL_ATTR_*; Pdo\Mysql exists since 8.4
+$mysqlInitCommand = class_exists(\Pdo\Mysql::class)
+    ? \Pdo\Mysql::ATTR_INIT_COMMAND
+    : PDO::MYSQL_ATTR_INIT_COMMAND;
 $pdo = new PDO(
     "mysql:host={$dbHost};port={$dbPort};dbname={$dbName}",
     $dbUser,
     $dbPass,
-    [PDO::MYSQL_ATTR_INIT_COMMAND => "SET CHARACTER SET utf8mb4, NAMES utf8mb4"]
+    [$mysqlInitCommand => "SET CHARACTER SET utf8mb4, NAMES utf8mb4"]
 );
 $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 


### PR DESCRIPTION
## Summary
- Replace deprecated `PDO::MYSQL_ATTR_INIT_COMMAND` and `PDO::MYSQL_ATTR_USE_BUFFERED_QUERY` with `Pdo\Mysql::*` on PHP 8.4+.
- Keep a `class_exists` fallback so PHP 8.3 CI continues to work.
- Apply the same fix in `Database.php`, `migrate.php`, and `tests/ci-install.php`.

## Test plan
- [ ] Confirm deprecation log lines no longer appear on PHP 8.5 when connecting to MySQL
- [ ] CI passes on PHP 8.3
- [ ] Spot-check login / a DB-backed page after deploy