### PR TITLE
Autoselect spy for probe-only fleet missions

### DIFF
--- a/includes/classes/FleetFunctions.php
+++ b/includes/classes/FleetFunctions.php
@@ -489,6 +489,39 @@ class FleetFunctions
 		return $availableMissions;
 	}
 
+	/**
+	 * Choose the pre-selected mission radio on fleet step 2.
+	 *
+	 * When coordinates were typed by hand (no target_mission), a probe-only
+	 * fleet defaults to Spying unless the target is an alliance member.
+	 *
+	 * @param int   $requestedMission Mission from the previous step (0 = none)
+	 * @param int[] $availableMissions
+	 * @param array $fleet            shipId => count
+	 */
+	public static function SuggestDefaultMission($requestedMission, array $availableMissions, array $fleet, $isAllianceMember)
+	{
+		$requestedMission = (int) $requestedMission;
+		$availableMissions = array_map('intval', $availableMissions);
+
+		if ($requestedMission !== 0 && in_array($requestedMission, $availableMissions, true)) {
+			return $requestedMission;
+		}
+
+		$probesOnly = isset($fleet[210]) && count($fleet) === 1;
+		if ($probesOnly && in_array(6, $availableMissions, true)) {
+			if ($isAllianceMember) {
+				if (in_array(3, $availableMissions, true)) {
+					return 3;
+				}
+			} else {
+				return 6;
+			}
+		}
+
+		return $requestedMission;
+	}
+
 	public static function CheckBash($Target)
 	{
 		global $USER;

--- a/includes/pages/game/ShowFleetStep2Page.php
+++ b/includes/pages/game/ShowFleetStep2Page.php
@@ -54,7 +54,7 @@ class ShowFleetStep2Page extends AbstractGamePage
 		$fleetArray    				= $_SESSION['fleet'][$token]['fleet'];
 
 		$db = Database::get();
-		$sql = "SELECT id, id_owner, der_metal, der_crystal FROM %%PLANETS%% WHERE universe = :universe AND galaxy = :targetGalaxy AND `system` = :targetSystem AND planet = :targetPlanet AND planet_type = '1';";
+		$sql = "SELECT p.id, p.id_owner, p.der_metal, p.der_crystal, u.ally_id FROM %%PLANETS%% p LEFT JOIN %%USERS%% u ON u.id = p.id_owner WHERE p.universe = :universe AND p.galaxy = :targetGalaxy AND p.`system` = :targetSystem AND p.planet = :targetPlanet AND p.planet_type = '1';";
 		$targetPlanetData = $db->selectSingle($sql, array(
 			':universe' => Universe::current(),
 			':targetGalaxy' => $targetGalaxy,
@@ -79,6 +79,19 @@ class ShowFleetStep2Page extends AbstractGamePage
 		$MisInfo['Ship'] 			= $fleetArray;
 
 		$MissionOutput	 			= FleetFunctions::GetFleetMissions($USER, $MisInfo, $targetPlanetData);
+
+		$isAllianceMember = is_array($targetPlanetData)
+			&& !empty($USER['ally_id'])
+			&& !empty($targetPlanetData['ally_id'])
+			&& (int) $USER['ally_id'] === (int) $targetPlanetData['ally_id']
+			&& (int) $targetPlanetData['id_owner'] !== (int) $USER['id'];
+
+		$targetMission = FleetFunctions::SuggestDefaultMission(
+			$targetMission,
+			$MissionOutput['MissionSelector'],
+			$fleetArray,
+			$isAllianceMember
+		);
 
 		if(empty($MissionOutput['MissionSelector']))
 		{

--- a/tests/Unit/FleetFunctionsTest.php
+++ b/tests/Unit/FleetFunctionsTest.php
@@ -410,6 +410,34 @@ class FleetFunctionsTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // SuggestDefaultMission — probe-only spy autoselect (issue #221)
+    // -------------------------------------------------------------------------
+
+    public function testSuggestDefaultMissionSelectsSpyForProbeOnlyFleet(): void
+    {
+        $available = [3, 6, 1, 5];
+        $this->assertSame(6, FleetFunctions::SuggestDefaultMission(0, $available, [210 => 5], false));
+    }
+
+    public function testSuggestDefaultMissionKeepsTransportForAllianceMember(): void
+    {
+        $available = [3, 6, 1, 5];
+        $this->assertSame(3, FleetFunctions::SuggestDefaultMission(0, $available, [210 => 5], true));
+    }
+
+    public function testSuggestDefaultMissionHonorsExplicitMissionFromGalaxy(): void
+    {
+        $available = [3, 6, 1, 5];
+        $this->assertSame(1, FleetFunctions::SuggestDefaultMission(1, $available, [210 => 5], false));
+    }
+
+    public function testSuggestDefaultMissionDoesNotAutoselectWhenFleetIsMixed(): void
+    {
+        $available = [3, 1, 5];
+        $this->assertSame(0, FleetFunctions::SuggestDefaultMission(0, $available, [210 => 5, 202 => 1], false));
+    }
+
+    // -------------------------------------------------------------------------
     // GetACSDuration — empty acsId short-circuit
     // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Closes #221: on fleet step 2, a probe-only fleet with no galaxy-map mission defaults to Spying.
- Alliance members stay on Transport so an accidental spy is not treated as aggression.
- Explicit missions from the galaxy map (attack, spy, etc.) are unchanged.

## Test plan
- [ ] Send only spy probes to a foreign planet using typed coordinates — Spying should be selected.
- [ ] Same fleet to an alliance member — Transport should be selected.
- [ ] Start from a galaxy attack/spy link — that mission should stay selected.
- [ ] Mixed fleet (probes + cargo) with typed coords — no auto-select.
- [ ] `php vendor/bin/phpunit tests/Unit/FleetFunctionsTest.php --filter SuggestDefaultMission`