### PR TITLE
Translate marketplace trade resources and cap history

### DIFF
--- a/includes/classes/MarketPlaceResource.php
+++ b/includes/classes/MarketPlaceResource.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace HiveNova\Core;
+
+/**
+ * Maps marketplace ex_resource_type (1–3) onto tech IDs 901–903.
+ */
+class MarketPlaceResource
+{
+	public static function techId(int $exResourceType): ?int
+	{
+		return match ($exResourceType) {
+			1 => 901,
+			2 => 902,
+			3 => 903,
+			default => null,
+		};
+	}
+
+	/**
+	 * @param array<int|string, string> $techNames $LNG['tech']
+	 */
+	public static function label(int $exResourceType, array $techNames): string
+	{
+		$id = self::techId($exResourceType);
+		if ($id === null || !isset($techNames[$id])) {
+			return '';
+		}
+
+		return (string) $techNames[$id];
+	}
+
+	/**
+	 * @return array{901: int|float, 902: int|float, 903: int|float}
+	 */
+	public static function amounts(int $exResourceType, $amount): array
+	{
+		return [
+			901 => $exResourceType === 1 ? $amount : 0,
+			902 => $exResourceType === 2 ? $amount : 0,
+			903 => $exResourceType === 3 ? $amount : 0,
+		];
+	}
+
+	public static function historyLimit(?int $requested = null): int
+	{
+		$limit = $requested ?? MARKET_TRADE_HISTORY_LIMIT;
+		return max(1, min(200, $limit));
+	}
+}

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -259,6 +259,9 @@ define('MESSAGES_PER_PAGE'			, 10);
 // Banned users shown per page in the ban list
 define('BANNED_USERS_PER_PAGE'		, 25);
 
+// Marketplace resource/fleet trade history rows
+define('MARKET_TRADE_HISTORY_LIMIT'	, 40);
+
 // Show one-click simulation link on spy reports
 define('ENABLE_SIMULATOR_LINK'		, true);
 

--- a/includes/pages/game/ShowMarketPlacePage.php
+++ b/includes/pages/game/ShowMarketPlacePage.php
@@ -6,6 +6,7 @@ use HiveNova\Core\Database;
 use HiveNova\Core\HTTP;
 use HiveNova\Core\PlayerUtil;
 use HiveNova\Core\FleetFunctions;
+use HiveNova\Core\MarketPlaceResource;
 
 /**
  *  Steemnova
@@ -89,9 +90,9 @@ class ShowMarketPlacePage extends AbstractGamePage
 			FROM %%TRADES%%
 			JOIN %%LOG_FLEETS%% seller ON seller.fleet_id = seller_fleet_id
 			JOIN %%LOG_FLEETS%% buyer ON buyer.fleet_id = buyer_fleet_id
-			WHERE transaction_type = 0 ORDER BY time DESC LIMIT 40;';
+			WHERE transaction_type = 0 ORDER BY time DESC LIMIT :limit;';
 		$trades = $db->select($sql, array(
-			//TODO LIMIT
+			':limit' => MarketPlaceResource::historyLimit(),
 		));
 		return $trades;
 	}
@@ -107,9 +108,9 @@ class ShowMarketPlacePage extends AbstractGamePage
 			FROM %%TRADES%%
 			JOIN %%LOG_FLEETS%% seller ON seller.fleet_id = seller_fleet_id
 			JOIN %%LOG_FLEETS%% buyer ON buyer.fleet_id = buyer_fleet_id
-			WHERE transaction_type = 1 ORDER BY time DESC LIMIT 40;';
+			WHERE transaction_type = 1 ORDER BY time DESC LIMIT :limit;';
 		$trades = $db->select($sql, array(
-			//TODO LIMIT
+			':limit' => MarketPlaceResource::historyLimit(),
 		));
 		for($i =0; $i< count($trades);$i++){
 			$fleet =  FleetFunctions::unserialize($trades[$i]['fleet']);
@@ -235,21 +236,7 @@ class ShowMarketPlacePage extends AbstractGamePage
 		$fleetStayTime		= $fleetStartTime;
 		$fleetEndTime		= $fleetStayTime + $Duration;
 
-		$met = 0;
-		$cry = 0;
-		$deu = 0;
-		if ($fleetResult['ex_resource_type'] == 1)
-			$met = $amount;
-		elseif ($fleetResult['ex_resource_type'] == 2)
-			$cry = $amount;
-		elseif ($fleetResult['ex_resource_type'] == 3)
-			$deu = $amount;
-
-		$fleetResource	= array(
-			901	=> $met,
-			902	=> $cry,
-			903	=> $deu,
-		);
+		$fleetResource	= MarketPlaceResource::amounts((int) $fleetResult['ex_resource_type'], $amount);
 
 		if($PLANET[$resource[901]]-$fleetResource[901] < 0 ||
 			$PLANET[$resource[902]]	-$fleetResource[902] <0 ||
@@ -378,21 +365,7 @@ class ShowMarketPlacePage extends AbstractGamePage
 
 		foreach ($fleetResult as $fleetsRow)
 		{
-			$resourceN = " ";
-			//TODO TRANSLATION
-			switch($fleetsRow['ex_resource_type']) {
-				case 1:
-					$resourceN = $LNG['tech'][901];
-					break;
-				case 2:
-					$resourceN = $LNG['tech'][902];
-					break;
-				case 3:
-					$resourceN = $LNG['tech'][903];
-					break;
-				default:
-					break;
-			}
+			$resourceN = MarketPlaceResource::label((int) $fleetsRow['ex_resource_type'], $LNG['tech']);
 
 			//Level of diplo
 			if($fleetsRow['accept'] == 0){

--- a/tests/Unit/MarketPlaceResourceTest.php
+++ b/tests/Unit/MarketPlaceResourceTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use HiveNova\Core\MarketPlaceResource;
+use PHPUnit\Framework\TestCase;
+
+class MarketPlaceResourceTest extends TestCase
+{
+    public function testTechIdMapsMetalCrystalDeuterium(): void
+    {
+        $this->assertSame(901, MarketPlaceResource::techId(1));
+        $this->assertSame(902, MarketPlaceResource::techId(2));
+        $this->assertSame(903, MarketPlaceResource::techId(3));
+        $this->assertNull(MarketPlaceResource::techId(0));
+        $this->assertNull(MarketPlaceResource::techId(4));
+    }
+
+    public function testLabelUsesTechLanguageKeys(): void
+    {
+        $tech = [901 => 'Metal', 902 => 'Crystal', 903 => 'Deuterium'];
+        $this->assertSame('Metal', MarketPlaceResource::label(1, $tech));
+        $this->assertSame('Crystal', MarketPlaceResource::label(2, $tech));
+        $this->assertSame('', MarketPlaceResource::label(9, $tech));
+    }
+
+    public function testAmountsPutsValueOnMatchingResource(): void
+    {
+        $this->assertSame([901 => 50, 902 => 0, 903 => 0], MarketPlaceResource::amounts(1, 50));
+        $this->assertSame([901 => 0, 902 => 12, 903 => 0], MarketPlaceResource::amounts(2, 12));
+        $this->assertSame([901 => 0, 902 => 0, 903 => 7], MarketPlaceResource::amounts(3, 7));
+        $this->assertSame([901 => 0, 902 => 0, 903 => 0], MarketPlaceResource::amounts(0, 99));
+    }
+
+    public function testHistoryLimitUsesConstantAndCaps(): void
+    {
+        $this->assertSame(MARKET_TRADE_HISTORY_LIMIT, MarketPlaceResource::historyLimit());
+        $this->assertSame(1, MarketPlaceResource::historyLimit(0));
+        $this->assertSame(200, MarketPlaceResource::historyLimit(999));
+        $this->assertSame(25, MarketPlaceResource::historyLimit(25));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,7 @@ if (!defined('TIMESTAMP'))     define('TIMESTAMP',      time());
 if (!defined('MODE'))          define('MODE',           'INSTALL');
 if (!defined('DEFAULT_LANG'))  define('DEFAULT_LANG',   'en');
 if (!defined('MIN_FLEET_TIME')) define('MIN_FLEET_TIME', 10);
+if (!defined('MARKET_TRADE_HISTORY_LIMIT')) define('MARKET_TRADE_HISTORY_LIMIT', 40);
 if (!defined('INACTIVE'))      define('INACTIVE',       7 * 86400);
 if (!defined('INACTIVE_LONG')) define('INACTIVE_LONG',  28 * 86400);
 if (!defined('ROOT_UNI'))      define('ROOT_UNI',        1);


### PR DESCRIPTION
## Summary
- Closes #157: fleet-trade resource names use `$LNG['tech']` via `MarketPlaceResource`.
- Closes #156: trade history uses `MARKET_TRADE_HISTORY_LIMIT` (default 40, capped 1–200) as a bound query parameter instead of a hard-coded `LIMIT 40`.

## Test plan
- [ ] Open marketplace fleet trades and confirm wanted resource names match the current language.
- [ ] Confirm resource/fleet history still lists recent trades (up to 40).
- [ ] `php vendor/bin/phpunit tests/Unit/MarketPlaceResourceTest.php`