### PR TITLE
Register Smarty strstr modifier

### DIFF
--- a/includes/classes/Template.php
+++ b/includes/classes/Template.php
@@ -59,6 +59,7 @@ class Template extends Smarty
 		$this->registerPlugin('modifier', 'sprintf',    'sprintf');
 		$this->registerPlugin('modifier', 'in_array',        'in_array');
 		$this->registerPlugin('modifier', 'is_numeric',      'is_numeric');
+		$this->registerPlugin('modifier', 'strstr',          'strstr');
 		$this->registerPlugin('modifier', 'pretty_fly_time', 'pretty_fly_time');
 		$this->registerPlugin('modifier', 'php_date',   function($ts, $fmt) { return date($fmt, $ts); });
 	}

--- a/tests/Unit/TemplateTest.php
+++ b/tests/Unit/TemplateTest.php
@@ -119,8 +119,11 @@ class TemplateTest extends TestCase
         $this->assertArrayHasKey('array_key_first', $modifiers);
         $this->assertArrayHasKey('abs', $modifiers);
         $this->assertArrayHasKey('pretty_fly_time', $modifiers);
+        $this->assertArrayHasKey('strstr', $modifiers);
         $this->assertSame(5, $modifiers['abs'][0](-5));
         $this->assertSame(3.14, $modifiers['floatval'][0]('3.14abc'));
+        $this->assertSame('/hive/', $modifiers['strstr'][0]('./styles/theme/hive/', '/hive/'));
+        $this->assertFalse($modifiers['strstr'][0]('./styles/theme/nova/', '/hive/'));
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Register PHP `strstr` as an explicit Smarty modifier so galaxy templates can keep using `$dpath|strstr:'/hive/'` without the Smarty 4 deprecation.
- Cover registration (and hive vs nova path checks) in `TemplateTest`.

## Test plan
- [ ] `./vendor/bin/phpunit tests/Unit/TemplateTest.php --filter testSmartySettingsRegistersModifierPlugins`
- [ ] Load the galaxy page on the hive theme and confirm planet/moon preview classes still apply
- [ ] Confirm `includes/error.log` no longer logs `Using unregistered function "strstr"`