### PR TITLE
feat: attack notification banner on all game pages (#99)

### DIFF
--- a/includes/classes/IncomingHostileFleetQuery.php
+++ b/includes/classes/IncomingHostileFleetQuery.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace HiveNova\Core;
+
+class IncomingHostileFleetQuery
+{
+	/** Attack, ACS, spy, destroy moon, missile — same set as hostile web push. */
+	public const HOSTILE_MISSIONS = [1, 2, 6, 9, 10];
+
+	public static function countForUser(int $userId): int
+	{
+		if ($userId <= 0) {
+			return 0;
+		}
+
+		$sql = 'SELECT COUNT(*) as incoming
+			FROM %%FLEETS%%
+			WHERE fleet_target_owner = :targetUserId
+			AND fleet_owner != :ownerId
+			AND fleet_mess = :outward
+			AND fleet_mission IN (1, 2, 6, 9, 10);';
+
+		$row = Database::get()->selectSingle($sql, [
+			':targetUserId' => $userId,
+			':ownerId'      => $userId,
+			':outward'      => FLEET_OUTWARD,
+		]);
+
+		return (int) ($row['incoming'] ?? 0);
+	}
+}

--- a/includes/pages/game/AbstractGamePage.php
+++ b/includes/pages/game/AbstractGamePage.php
@@ -5,6 +5,7 @@ namespace HiveNova\Page\Game;
 use HiveNova\Core\AchievementService;
 use HiveNova\Core\Cronjob;
 use HiveNova\Core\Config;
+use HiveNova\Core\IncomingHostileFleetQuery;
 use HiveNova\Core\PushNotificationService;
 use HiveNova\Core\HTTP;
 use HiveNova\Core\PlayerUtil;
@@ -187,6 +188,7 @@ abstract class AbstractGamePage
 			'badges'            => PlayerUtil::getPlayerBadges($USER),
 			'pushAlerts'		=> PushNotificationService::isEnabledForUser((int) $USER['id']) ? 1 : 0,
 			'pushConfigured'	=> PushNotificationService::isConfigured(),
+			'attackAlertCount'	=> IncomingHostileFleetQuery::countForUser((int) $USER['id']),
 		));
 
 		if (isModuleAvailable(MODULE_ACHIEVEMENTS) && AchievementService::isSchemaReady()) {

--- a/includes/pages/game/ShowAttackAlertPage.php
+++ b/includes/pages/game/ShowAttackAlertPage.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace HiveNova\Page\Game;
+
+use HiveNova\Core\IncomingHostileFleetQuery;
+
+class ShowAttackAlertPage extends AbstractGamePage
+{
+	public static $requireModule = 0;
+
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	public function show()
+	{
+		global $USER;
+
+		$this->sendJSON([
+			'count' => IncomingHostileFleetQuery::countForUser((int) $USER['id']),
+		]);
+	}
+}

--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -112,6 +112,7 @@ $LNG['ov_wrong_pass']						= 'Falsches Passwort. Versuchen sie es noch einmal!';
 $LNG['ov_wrong_name']						= 'Falsches Name. Versuchen sie es noch einmal!';
 $LNG['ov_have_new_message']					= 'Du hast eine neue Nachricht';
 $LNG['ov_have_new_messages']					= 'Du hast %d neue Nachrichten';
+$LNG['ov_attack_alert']						= 'Du wirst angegriffen!';
 $LNG['ov_planetmenu']						= 'Name ändern/Löschen';
 $LNG['ov_free']							= 'Frei';
 $LNG['ov_news']							= 'News';

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -121,6 +121,7 @@ $LNG['ov_wrong_pass']						= 'Password incorrect!';
 $LNG['ov_wrong_name']						= 'Name incorrect!';
 $LNG['ov_have_new_message']					= 'You have a new message';
 $LNG['ov_have_new_messages']				= 'You have %d new messages';
+$LNG['ov_attack_alert']						= 'You are under attack!';
 $LNG['ov_planetmenu']						= 'Rename or delete';
 $LNG['ov_free']								= 'Free';
 $LNG['ov_news']								= 'News';

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -111,6 +111,7 @@ $LNG['ov_wrong_pass']						= 'Contraseña incorrecta. Intentalo de nuevo!';
 $LNG['ov_wrong_name']						= 'Nombre incorrecta. Intentalo de nuevo!';
 $LNG['ov_have_new_message']					= 'Tienes 1 mensaje nuevo';
 $LNG['ov_have_new_messages']				= 'Tienes %d mensajes nuevos';
+$LNG['ov_attack_alert']						= '¡Estás bajo ataque!';
 $LNG['ov_planetmenu']						= 'Cambiar Nombre/Eliminar';
 $LNG['ov_free']								= 'Libre';
 $LNG['ov_news']								= 'Novedades';

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -101,6 +101,7 @@ $LNG['ov_wrong_pass']						= 'Mot de passe incorrect. Essayez à nouveau!';
 $LNG['ov_wrong_name']						= 'Mot de nom incorrect. Essayez à nouveau!';
 $LNG['ov_have_new_message']					= 'Vous avez un nouveau message';
 $LNG['ov_have_new_messages']				= 'Vous avez %d nouveaux messages';
+$LNG['ov_attack_alert']						= 'Vous êtes attaqué !';
 $LNG['ov_planetmenu']						= 'Nom Modifier/Abandonner';
 $LNG['ov_free']								= 'Libre';
 $LNG['ov_news']								= 'Actualités';

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -114,6 +114,7 @@ $LNG['ov_wrong_pass']						= 'Błędne hasło, spróbuj ponownie!';
 $LNG['ov_wrong_name']						= 'Błędna nazwa, spróbuj ponownie!';
 $LNG['ov_have_new_message']					= 'Masz wiadomość';
 $LNG['ov_have_new_messages']				= 'Masz %d nowych wiadomości';
+$LNG['ov_attack_alert']						= 'Jesteś atakowany!';
 $LNG['ov_planetmenu']						= 'Zmień nazwę / Porzuć planetę';
 $LNG['ov_free']								= 'Bezczynna';
 $LNG['ov_news']								= 'Nowości';

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -115,6 +115,7 @@ $LNG['ov_wrong_pass']						= 'Senha incorreta!';
 $LNG['ov_wrong_name']						= 'Nome incorreta!';
 $LNG['ov_have_new_message']					= 'Possui uma nova mensagem';
 $LNG['ov_have_new_messages']				= 'Possui %d novas mensagens';
+$LNG['ov_attack_alert']						= 'Estás sob ataque!';
 $LNG['ov_planetmenu']						= 'Alterar nome ou excluir';
 $LNG['ov_free']								= 'Livre';
 $LNG['ov_news']								= 'Noticias';

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -106,6 +106,7 @@ $LNG['ov_wrong_pass']                     = 'Неправильный парол
 $LNG['ov_wrong_name']                     = 'Неправильный название, попробуйте ввести заново!';
 $LNG['ov_have_new_message']               = 'Новых сообщений: 1';
 $LNG['ov_have_new_messages']              = 'Новых сообщений: %d';
+$LNG['ov_attack_alert']                   = 'На вас напали!';
 $LNG['ov_planetmenu']                     = 'Переименовать/удалить планету';
 $LNG['ov_free']                           = '';
 $LNG['ov_news']                           = 'Новости';

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -118,6 +118,7 @@ $LNG['ov_wrong_pass']						= 'Yanlış şifre girdiniz!';
 $LNG['ov_wrong_name']						= 'Yanlış isim girdiniz!';
 $LNG['ov_have_new_message']					= 'Yeni mesajınız var';
 $LNG['ov_have_new_messages']				= ' <b>(%d)</b> Adet Yeni Mesajınız Var';
+$LNG['ov_attack_alert']						= 'Saldırı altındasın!';
 $LNG['ov_planetmenu']						= 'Yeniden Adlandır ya da Sil';
 $LNG['ov_free']								= 'Uygun';
 $LNG['ov_news']								= 'Duyurular';

--- a/scripts/game/attack-alert.js
+++ b/scripts/game/attack-alert.js
@@ -1,0 +1,162 @@
+(function (root) {
+	'use strict';
+
+	var POLL_MS = 20000;
+
+	function applyCount(banner, count) {
+		if (!banner) {
+			return;
+		}
+		var n = parseInt(count, 10);
+		if (isNaN(n) || n < 0) {
+			return;
+		}
+		banner.setAttribute('data-count', String(n));
+		var countEl = banner.querySelector('[data-attack-alert-count]');
+		if (countEl) {
+			countEl.textContent = n > 0 ? ' (' + n + ')' : '';
+		}
+		if (n > 0) {
+			banner.removeAttribute('hidden');
+		} else {
+			banner.setAttribute('hidden', 'hidden');
+		}
+	}
+
+	function responseLooksLikeJson(response, bodyText) {
+		if (!response || !response.ok) {
+			return false;
+		}
+		var url = response.url || '';
+		if (url.indexOf('index.php') !== -1) {
+			return false;
+		}
+		var trimmed = (bodyText || '').replace(/^\s+/, '');
+		return trimmed.charAt(0) === '{' || trimmed.charAt(0) === '[';
+	}
+
+	function parseCount(bodyText) {
+		var data = JSON.parse(bodyText);
+		if (!data || typeof data.count === 'undefined') {
+			return null;
+		}
+		return data.count;
+	}
+
+	function createPoller(options) {
+		var banner = options.banner;
+		var fetchFn = options.fetchFn || fetch;
+		var hiddenFn = options.hiddenFn || function () {
+			return typeof document !== 'undefined' && document.hidden;
+		};
+		var intervalMs = options.intervalMs || POLL_MS;
+		var url = options.url || 'game.php?page=attackAlert&ajax=1';
+		var timer = null;
+		var stopped = false;
+
+		function poll() {
+			if (stopped || hiddenFn()) {
+				return Promise.resolve();
+			}
+			return fetchFn(url, { credentials: 'same-origin' }).then(function (response) {
+				return response.text().then(function (bodyText) {
+					if (!responseLooksLikeJson(response, bodyText)) {
+						stop();
+						return;
+					}
+					try {
+						var count = parseCount(bodyText);
+						if (count === null) {
+							return;
+						}
+						applyCount(banner, count);
+					} catch (e) {
+						stop();
+					}
+				});
+			}).catch(function () {
+				// Keep last banner state on network error.
+			});
+		}
+
+		function start() {
+			if (stopped) {
+				return;
+			}
+			poll();
+			if (timer) {
+				clearInterval(timer);
+			}
+			timer = setInterval(poll, intervalMs);
+		}
+
+		function stop() {
+			stopped = true;
+			if (timer) {
+				clearInterval(timer);
+				timer = null;
+			}
+		}
+
+		function onVisibility() {
+			if (stopped) {
+				return;
+			}
+			if (hiddenFn()) {
+				if (timer) {
+					clearInterval(timer);
+					timer = null;
+				}
+				return;
+			}
+			start();
+		}
+
+		return {
+			poll: poll,
+			start: start,
+			stop: stop,
+			onVisibility: onVisibility,
+			isStopped: function () { return stopped; }
+		};
+	}
+
+	function init(doc) {
+		doc = doc || (typeof document !== 'undefined' ? document : null);
+		if (!doc) {
+			return null;
+		}
+		var banner = doc.getElementById('attack-alert');
+		if (!banner) {
+			return null;
+		}
+		var poller = createPoller({ banner: banner });
+		if (typeof document !== 'undefined') {
+			document.addEventListener('visibilitychange', poller.onVisibility);
+		}
+		poller.start();
+		return poller;
+	}
+
+	var api = {
+		POLL_MS: POLL_MS,
+		applyCount: applyCount,
+		responseLooksLikeJson: responseLooksLikeJson,
+		parseCount: parseCount,
+		createPoller: createPoller,
+		init: init
+	};
+
+	root.HiveNovaAttackAlert = api;
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = api;
+	}
+
+	if (typeof document !== 'undefined') {
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', function () { init(document); });
+		} else {
+			init(document);
+		}
+	}
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/styles/resource/css/ingame/main.css
+++ b/styles/resource/css/ingame/main.css
@@ -658,6 +658,15 @@ div#disclamer {
     text-align: center;
 }
 
+.attack-notification {
+    background: color-mix(in srgb, var(--color-danger) 18%, var(--color-bg-surface));
+    font-weight: 700;
+}
+
+.attack-notification a {
+    color: inherit;
+}
+
 .shortcut-colum {
     position: relative;
 }

--- a/styles/templates/game/layout.full.tpl
+++ b/styles/templates/game/layout.full.tpl
@@ -39,6 +39,9 @@
 		{elseif $vacation}
 		<div class="infobox">{$LNG.tn_vacation_mode} {$vacation}</div>
 		{/if}
+		<div id="attack-alert" class="infobox attack-notification"{if $attackAlertCount <= 0} hidden{/if} data-count="{$attackAlertCount}">
+			<a href="game.php?page=overview">{$LNG.ov_attack_alert}</a><span data-attack-alert-count>{if $attackAlertCount > 0} ({$attackAlertCount}){/if}</span>
+		</div>
 		
 		{block name="content"}{/block}
 		<table class="hack"></table>
@@ -87,6 +90,7 @@
 	</div>
 </div>
 {include file="main.bottomnav.tpl"}
+<script src="scripts/game/attack-alert.js?v={$REV}"></script>
 
 </body>
 </html>

--- a/tests/Support/FakeFleetQueryHandler.php
+++ b/tests/Support/FakeFleetQueryHandler.php
@@ -95,6 +95,33 @@ trait FakeFleetQueryHandler
             return $field === false ? $count : ($count[$field] ?? false);
         }
 
+        if (str_contains($qry, '%%FLEETS%%')
+            && str_contains($qry, 'COUNT(*)')
+            && str_contains($qry, 'fleet_target_owner')) {
+            $targetId = (int) ($params[':targetUserId'] ?? 0);
+            $ownerId = (int) ($params[':ownerId'] ?? $targetId);
+            $outward = (int) ($params[':outward'] ?? 0);
+            $hostile = [1, 2, 6, 9, 10];
+            $incoming = 0;
+            foreach ($this->fleetRowsById as $row) {
+                if ((int) ($row['fleet_target_owner'] ?? 0) !== $targetId) {
+                    continue;
+                }
+                if ((int) ($row['fleet_owner'] ?? 0) === $ownerId) {
+                    continue;
+                }
+                if ((int) ($row['fleet_mess'] ?? 0) !== $outward) {
+                    continue;
+                }
+                if (!in_array((int) ($row['fleet_mission'] ?? 0), $hostile, true)) {
+                    continue;
+                }
+                $incoming++;
+            }
+            $count = ['incoming' => $incoming];
+            return $field === false ? $count : ($count[$field] ?? false);
+        }
+
         if (str_contains($qry, '%%FLEETS%%') && str_contains($qry, 'COUNT(*)')) {
             $count = ['state' => $this->fleetCountResult];
             return $field === false ? $count : $count[$field];

--- a/tests/Unit/IncomingHostileFleetQueryTest.php
+++ b/tests/Unit/IncomingHostileFleetQueryTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use HiveNova\Core\IncomingHostileFleetQuery;
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+class IncomingHostileFleetQueryTest extends TestCase
+{
+    use SwapDatabaseInstance;
+
+    private FakeDatabase $fake;
+
+    protected function setUp(): void
+    {
+        $this->fake = new FakeDatabase();
+        $this->swapDatabaseInstance($this->fake);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreDatabaseInstance();
+        parent::tearDown();
+    }
+
+    public function testZeroUserIdReturnsZeroWithoutQueryRows(): void
+    {
+        $this->assertSame(0, IncomingHostileFleetQuery::countForUser(0));
+    }
+
+    public function testOutwardAttackAtUserCountsOne(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet([
+            'fleet_owner' => 2,
+            'fleet_target_owner' => 99,
+            'fleet_mission' => 1,
+            'fleet_mess' => FLEET_OUTWARD,
+        ]);
+        $this->assertSame(1, IncomingHostileFleetQuery::countForUser(99));
+    }
+
+    public function testOwnFleetIsIgnored(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet([
+            'fleet_owner' => 99,
+            'fleet_target_owner' => 99,
+            'fleet_mission' => 1,
+            'fleet_mess' => FLEET_OUTWARD,
+        ]);
+        $this->assertSame(0, IncomingHostileFleetQuery::countForUser(99));
+    }
+
+    public function testReturningFleetIsIgnored(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet([
+            'fleet_owner' => 2,
+            'fleet_target_owner' => 99,
+            'fleet_mission' => 1,
+            'fleet_mess' => FLEET_RETURN,
+        ]);
+        $this->assertSame(0, IncomingHostileFleetQuery::countForUser(99));
+    }
+
+    public function testHarvestAndTransportAreIgnored(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet([
+            'fleet_owner' => 2,
+            'fleet_target_owner' => 99,
+            'fleet_mission' => 8,
+            'fleet_mess' => FLEET_OUTWARD,
+        ]);
+        $this->fake->fleetRowsById[2] = $this->fleet([
+            'fleet_owner' => 2,
+            'fleet_target_owner' => 99,
+            'fleet_mission' => 3,
+            'fleet_mess' => FLEET_OUTWARD,
+        ]);
+        $this->assertSame(0, IncomingHostileFleetQuery::countForUser(99));
+    }
+
+    public function testSpyAcsDestroyMissileAreCounted(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet(['fleet_mission' => 6]);
+        $this->fake->fleetRowsById[2] = $this->fleet(['fleet_mission' => 2]);
+        $this->fake->fleetRowsById[3] = $this->fleet(['fleet_mission' => 9]);
+        $this->fake->fleetRowsById[4] = $this->fleet(['fleet_mission' => 10]);
+        $this->assertSame(4, IncomingHostileFleetQuery::countForUser(99));
+    }
+
+    public function testAcsTargetingSomeoneElseIsIgnored(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet([
+            'fleet_owner' => 2,
+            'fleet_target_owner' => 50,
+            'fleet_mission' => 2,
+            'fleet_mess' => FLEET_OUTWARD,
+        ]);
+        $this->assertSame(0, IncomingHostileFleetQuery::countForUser(99));
+    }
+
+    public function testTwoInboundRowsCountTwo(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet(['fleet_mission' => 1]);
+        $this->fake->fleetRowsById[2] = $this->fleet(['fleet_mission' => 1]);
+        $this->assertSame(2, IncomingHostileFleetQuery::countForUser(99));
+    }
+
+    /**
+     * @param array<string, mixed> $overrides
+     * @return array<string, mixed>
+     */
+    private function fleet(array $overrides = []): array
+    {
+        return array_merge([
+            'fleet_owner' => 2,
+            'fleet_target_owner' => 99,
+            'fleet_mission' => 1,
+            'fleet_mess' => FLEET_OUTWARD,
+        ], $overrides);
+    }
+}

--- a/tests/js/attack-alert.test.js
+++ b/tests/js/attack-alert.test.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const alert = require('../../scripts/game/attack-alert.js');
+
+describe('HiveNovaAttackAlert', () => {
+	it('shows and hides the banner from count', () => {
+		const banner = {
+			attrs: { hidden: 'hidden', 'data-count': '0' },
+			countText: '',
+			setAttribute(name, value) { this.attrs[name] = value; },
+			removeAttribute(name) { delete this.attrs[name]; },
+			querySelector() {
+				const self = this;
+				return {
+					set textContent(v) { self.countText = v; },
+					get textContent() { return self.countText; }
+				};
+			}
+		};
+		alert.applyCount(banner, 2);
+		assert.equal(banner.attrs.hidden, undefined);
+		assert.equal(banner.attrs['data-count'], '2');
+		assert.equal(banner.countText, ' (2)');
+		alert.applyCount(banner, 0);
+		assert.equal(banner.attrs.hidden, 'hidden');
+		assert.equal(banner.countText, '');
+	});
+
+	it('rejects login redirects as JSON', () => {
+		assert.equal(alert.responseLooksLikeJson({ ok: true, url: 'https://x/index.php?code=3' }, '{}'), false);
+		assert.equal(alert.responseLooksLikeJson({ ok: true, url: 'https://x/game.php?page=attackAlert' }, '{"count":1}'), true);
+		assert.equal(alert.responseLooksLikeJson({ ok: false, url: 'https://x/game.php' }, '{"count":1}'), false);
+	});
+
+	it('stops polling when the body is not JSON', async () => {
+		const banner = {
+			attrs: {},
+			setAttribute() {},
+			removeAttribute() {},
+			querySelector() { return null; }
+		};
+		let calls = 0;
+		const poller = alert.createPoller({
+			banner,
+			hiddenFn: () => false,
+			fetchFn: async () => {
+				calls += 1;
+				return { ok: true, url: 'https://x/index.php?code=3', text: async () => '<html>login</html>' };
+			}
+		});
+		await poller.poll();
+		assert.equal(poller.isStopped(), true);
+		assert.equal(calls, 1);
+	});
+});


### PR DESCRIPTION
Closes #99

## Summary
- Shows a red incoming-hostile banner on every full game page (not just overview), with a count and a link to overview where fleet events already appear
- Polls `game.php?page=attackAlert&ajax=1` every 20s while the tab is visible so sitting on buildings/research/fleets still reveals a new inbound attack without a full refresh
- Counts outward hostile missions 1/2/6/9/10 targeting the player (same set as web push); ignores own fleets, returns, harvest, and transport

## Test plan
- [ ] PHPUnit: `php vendor/bin/phpunit --configuration phpunit.xml tests/Unit/IncomingHostileFleetQueryTest.php`
- [ ] JS: `node --test tests/js/attack-alert.test.js`
- [ ] `bash tests/check-css.sh` and `php .github/scripts/check-language-files.php`
- [ ] Log in, navigate buildings/research/fleetTable with an inbound attack — red banner appears
- [ ] Sit on buildings, wait ≤20s after a new inbound fleet is created — banner appears without refresh
- [ ] Hide the tab — no further `attackAlert` requests; show tab — poll resumes
- [ ] When hostiles clear, next poll hides the banner
- [ ] Vacation infobox still shows independently of the attack banner