### PR TITLE
feat: planet-slot metal and silicon mine bonuses

### DIFF
--- a/includes/classes/PlanetProductionBonus.php
+++ b/includes/classes/PlanetProductionBonus.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace HiveNova\Core;
+
+/**
+ * Metal and silicon mine bonuses by solar-system slot.
+ * Uranium and solar-satellite energy stay on temperature formulas.
+ */
+class PlanetProductionBonus
+{
+	public const METAL = 901;
+	public const CRYSTAL = 902;
+
+	private const METAL_BY_SLOT = [
+		6  => 1.17,
+		7  => 1.23,
+		8  => 1.35,
+		9  => 1.23,
+		10 => 1.17,
+	];
+
+	private const CRYSTAL_BY_SLOT = [
+		1 => 1.40,
+		2 => 1.30,
+		3 => 1.20,
+	];
+
+	/**
+	 * @return array{901: float, 902: float}
+	 */
+	public static function factors(int $planetType, int $slot): array
+	{
+		if ($planetType !== 1) {
+			return [self::METAL => 1.0, self::CRYSTAL => 1.0];
+		}
+
+		return [
+			self::METAL   => self::METAL_BY_SLOT[$slot] ?? 1.0,
+			self::CRYSTAL => self::CRYSTAL_BY_SLOT[$slot] ?? 1.0,
+		];
+	}
+
+	public static function forResource(int $planetType, int $slot, int $resourceId): float
+	{
+		$factors = self::factors($planetType, $slot);
+
+		return $factors[$resourceId] ?? 1.0;
+	}
+}

--- a/includes/classes/ResourceCalculator.php
+++ b/includes/classes/ResourceCalculator.php
@@ -148,6 +148,13 @@ class ResourceCalculator
             }
         }
 
+        $slotBonus = PlanetProductionBonus::factors(
+            (int) $this->PLANET['planet_type'],
+            (int) $this->PLANET['planet']
+        );
+        $temp[901]['plus'] *= $slotBonus[901];
+        $temp[902]['plus'] *= $slotBonus[902];
+
         $this->PLANET['metal_max']     = $temp[901]['max'] * $this->config->storage_multiplier * (1 + $this->USER['factor']['ResourceStorage']);
         $this->PLANET['crystal_max']   = $temp[902]['max'] * $this->config->storage_multiplier * (1 + $this->USER['factor']['ResourceStorage']);
         $this->PLANET['deuterium_max'] = $temp[903]['max'] * $this->config->storage_multiplier * (1 + $this->USER['factor']['ResourceStorage']);

--- a/includes/classes/ResourceUpdate.php
+++ b/includes/classes/ResourceUpdate.php
@@ -108,6 +108,8 @@ class ResourceUpdate
 		// Inactivity forces 100% production in reBuildCache; include it so the
 		// cache rebuilds when a player crosses the inactive threshold (or returns).
 		$Hash[]	= \isInactive($this->USER) ? 1 : 0;
+		$Hash[]	= $this->PLANET['planet'];
+		$Hash[]	= $this->PLANET['temp_max'];
 		return md5(implode("::", $Hash));
 	}
 	

--- a/includes/pages/game/ShowInformationPage.php
+++ b/includes/pages/game/ShowInformationPage.php
@@ -6,6 +6,7 @@ use HiveNova\Core\Database;
 use HiveNova\Core\Config;
 use HiveNova\Core\HTTP;
 use HiveNova\Core\BuildFunctions;
+use HiveNova\Core\PlanetProductionBonus;
 use HiveNova\Core\ResourceUpdate;
 
 /**
@@ -235,6 +236,14 @@ class ShowInformationPage extends AbstractGamePage
 						continue;
 
 					$Production	= eval(ResourceUpdate::getProd($ProdGrid[$elementID]['production'][$ID], $elementID));
+
+					if (in_array($ID, array(901, 902), true)) {
+						$Production *= PlanetProductionBonus::forResource(
+							(int) $PLANET['planet_type'],
+							(int) $PLANET['planet'],
+							$ID
+						);
+					}
 
 					if(in_array($ID, $reslist['resstype'][2]))
 					{

--- a/includes/pages/game/ShowResourcesPage.php
+++ b/includes/pages/game/ShowResourcesPage.php
@@ -4,6 +4,7 @@ namespace HiveNova\Page\Game;
 
 use HiveNova\Core\Database;
 use HiveNova\Core\Config;
+use HiveNova\Core\PlanetProductionBonus;
 use HiveNova\Core\ResourceUpdate;
 
 /**
@@ -151,6 +152,14 @@ class ShowResourcesPage extends AbstractGamePage
 					continue;
 
 				$Production	= eval(ResourceUpdate::getProd($ProdGrid[$ProdID]['production'][$ID], $ProdID));
+
+				if (in_array($ID, array(901, 902), true)) {
+					$Production *= PlanetProductionBonus::forResource(
+						(int) $PLANET['planet_type'],
+						(int) $PLANET['planet'],
+						$ID
+					);
+				}
 
 				if(in_array($ID, $reslist['resstype'][2]))
 				{

--- a/tests/Unit/PlanetProductionBonusTest.php
+++ b/tests/Unit/PlanetProductionBonusTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use HiveNova\Core\PlanetProductionBonus;
+use PHPUnit\Framework\TestCase;
+
+class PlanetProductionBonusTest extends TestCase
+{
+	public function testSlotsOneThroughFifteen(): void
+	{
+		$metal = [
+			1 => 1.00, 2 => 1.00, 3 => 1.00, 4 => 1.00, 5 => 1.00,
+			6 => 1.17, 7 => 1.23, 8 => 1.35, 9 => 1.23, 10 => 1.17,
+			11 => 1.00, 12 => 1.00, 13 => 1.00, 14 => 1.00, 15 => 1.00,
+		];
+		$crystal = [
+			1 => 1.40, 2 => 1.30, 3 => 1.20, 4 => 1.00, 5 => 1.00,
+			6 => 1.00, 7 => 1.00, 8 => 1.00, 9 => 1.00, 10 => 1.00,
+			11 => 1.00, 12 => 1.00, 13 => 1.00, 14 => 1.00, 15 => 1.00,
+		];
+
+		for ($slot = 1; $slot <= 15; $slot++) {
+			$factors = PlanetProductionBonus::factors(1, $slot);
+			$this->assertEqualsWithDelta($metal[$slot], $factors[901], 0.0001, "metal slot {$slot}");
+			$this->assertEqualsWithDelta($crystal[$slot], $factors[902], 0.0001, "silicon slot {$slot}");
+		}
+	}
+
+	public function testMoonHasNoBonusEvenOnSlotEight(): void
+	{
+		$factors = PlanetProductionBonus::factors(3, 8);
+		$this->assertSame(1.0, $factors[901]);
+		$this->assertSame(1.0, $factors[902]);
+	}
+
+	public function testUnknownSlotsAreNeutral(): void
+	{
+		foreach ([0, 16, -1] as $slot) {
+			$factors = PlanetProductionBonus::factors(1, $slot);
+			$this->assertSame(1.0, $factors[901], "metal slot {$slot}");
+			$this->assertSame(1.0, $factors[902], "silicon slot {$slot}");
+		}
+	}
+
+	public function testForResourceFallsBackToOne(): void
+	{
+		$this->assertSame(1.0, PlanetProductionBonus::forResource(1, 8, 903));
+		$this->assertSame(1.35, PlanetProductionBonus::forResource(1, 8, 901));
+	}
+}

--- a/tests/Unit/ResourceCalculatorTest.php
+++ b/tests/Unit/ResourceCalculatorTest.php
@@ -1,0 +1,307 @@
+<?php
+
+use HiveNova\Core\Config;
+use HiveNova\Core\ResourceCalculator;
+use PHPUnit\Framework\TestCase;
+
+class ResourceCalculatorTest extends TestCase
+{
+	private function makeConfig(array $overrides = []): Config
+	{
+		return new Config(array_merge([
+			'uni'                    => 1,
+			'metal_basic_income'     => 20,
+			'crystal_basic_income'   => 10,
+			'deuterium_basic_income' => 0,
+			'energy_basic_income'    => 0,
+			'resource_multiplier'    => 1,
+			'storage_multiplier'     => 1,
+			'energySpeed'            => 1,
+			'max_overflow'           => 2,
+		], $overrides));
+	}
+
+	private function makeResource(): array
+	{
+		return [
+			1   => 'metal_mine',
+			2   => 'crystal_mine',
+			3   => 'deuterium_sintetizer',
+			4   => 'solar_plant',
+			12  => 'fusion_plant',
+			212 => 'solar_satelit',
+			901 => 'metal',
+			902 => 'crystal',
+			903 => 'deuterium',
+			911 => 'energy',
+			113 => 'energy_tech',
+			131 => 'plasma_tech_metal',
+			132 => 'plasma_tech_crystal',
+			133 => 'plasma_tech_deuterium',
+		];
+	}
+
+	private function makeReslist(array $prod): array
+	{
+		return [
+			'prod'     => $prod,
+			'storage'  => [],
+			'resstype' => [1 => [901, 902, 903], 2 => [911]],
+		];
+	}
+
+	private function makeUser(array $overrides = []): array
+	{
+		return array_merge([
+			'id'                    => 1,
+			'universe'              => 1,
+			'factor'                => [
+				'Resource'        => 0,
+				'Energy'          => 0,
+				'ResourceStorage' => 0,
+			],
+			'energy_tech'           => 0,
+			'plasma_tech_metal'     => 0,
+			'plasma_tech_crystal'   => 0,
+			'plasma_tech_deuterium' => 0,
+		], $overrides);
+	}
+
+	private function makePlanet(array $overrides = []): array
+	{
+		return array_merge([
+			'planet_type'                    => 1,
+			'planet'                         => 8,
+			'temp_max'                       => 40,
+			'metal'                          => 0,
+			'crystal'                        => 0,
+			'deuterium'                      => 0,
+			'metal_mine'                     => 1,
+			'metal_mine_porcent'             => 10,
+			'crystal_mine'                   => 1,
+			'crystal_mine_porcent'           => 10,
+			'deuterium_sintetizer'           => 1,
+			'deuterium_sintetizer_porcent'   => 10,
+			'solar_plant'                    => 1,
+			'solar_plant_porcent'            => 10,
+			'fusion_plant'                   => 0,
+			'fusion_plant_porcent'           => 10,
+			'solar_satelit'                  => 1,
+			'solar_satelit_porcent'          => 10,
+		], $overrides);
+	}
+
+	private function calculator(array $user, array $planet, array $resource, array $reslist, Config $config): ResourceCalculator
+	{
+		return new ResourceCalculator($user, $planet, $config, $resource, $reslist, 3600);
+	}
+
+	public function testSlotEightBoostsMetalPlusBeforeOfficer(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			1 => ['production' => [901 => '1000', 911 => '-100']],
+			4 => ['production' => [911 => '1000']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([1, 4]);
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser();
+
+		$slot8 = $this->calculator($user, $this->makePlanet(['planet' => 8]), $resource, $reslist, $config);
+		$slot8->reBuildCache();
+		$slot4 = $this->calculator($user, $this->makePlanet(['planet' => 4]), $resource, $reslist, $config);
+		$slot4->reBuildCache();
+
+		$this->assertEqualsWithDelta(1350.0, $slot8->getPlanet()['metal_perhour'], 0.001);
+		$this->assertEqualsWithDelta(1000.0, $slot4->getPlanet()['metal_perhour'], 0.001);
+	}
+
+	public function testOfficerAppliesAfterSlotBonus(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			1 => ['production' => [901 => '1000', 911 => '-100']],
+			4 => ['production' => [911 => '1000']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([1, 4]);
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser(['factor' => [
+			'Resource' => 0.10,
+			'Energy' => 0,
+			'ResourceStorage' => 0,
+		]]);
+		$calc = $this->calculator($user, $this->makePlanet(['planet' => 8]), $resource, $reslist, $config);
+		$calc->reBuildCache();
+
+		// 1000 * 1.35 * (1 + 0.10) = 1485
+		$this->assertEqualsWithDelta(1485.0, $calc->getPlanet()['metal_perhour'], 0.001);
+	}
+
+	public function testUraniumIgnoresSlotWhenTemperatureMatches(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			3 => ['production' => [
+				903 => '(10 * $BuildLevel * pow(1.1, $BuildLevel) * (-0.002 * $BuildTemp + 1.28) * (0.1 * $BuildLevelFactor))',
+				911 => '-30',
+			]],
+			4 => ['production' => [911 => '1000']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([3, 4]);
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser();
+		$temp     = 40;
+
+		$inner = $this->calculator($user, $this->makePlanet(['planet' => 1, 'temp_max' => $temp]), $resource, $reslist, $config);
+		$inner->reBuildCache();
+		$outer = $this->calculator($user, $this->makePlanet(['planet' => 15, 'temp_max' => $temp]), $resource, $reslist, $config);
+		$outer->reBuildCache();
+
+		$this->assertEqualsWithDelta(
+			$inner->getPlanet()['deuterium_perhour'],
+			$outer->getPlanet()['deuterium_perhour'],
+			0.0001
+		);
+	}
+
+	public function testDeuteriumFollowsTwoMoonsTemperatureKernel(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			3 => ['production' => [
+				903 => '(10 * $BuildLevel * pow(1.1, $BuildLevel) * (-0.002 * $BuildTemp + 1.28) * (0.1 * $BuildLevelFactor))',
+				911 => '-30',
+			]],
+			4 => ['production' => [911 => '1000']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([3, 4]);
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser();
+
+		$hot = $this->calculator($user, $this->makePlanet(['planet' => 8, 'temp_max' => 240]), $resource, $reslist, $config);
+		$hot->reBuildCache();
+		$cold = $this->calculator($user, $this->makePlanet(['planet' => 8, 'temp_max' => -110]), $resource, $reslist, $config);
+		$cold->reBuildCache();
+
+		$level = 1;
+		$factor = 10;
+		$hotExpected = 10 * $level * (1.1 ** $level) * (-0.002 * 240 + 1.28) * (0.1 * $factor);
+		$coldExpected = 10 * $level * (1.1 ** $level) * (-0.002 * -110 + 1.28) * (0.1 * $factor);
+
+		$this->assertEqualsWithDelta($hotExpected, $hot->getPlanet()['deuterium_perhour'], 0.001);
+		$this->assertEqualsWithDelta($coldExpected, $cold->getPlanet()['deuterium_perhour'], 0.001);
+	}
+
+	public function testSatelliteEnergyFollowsTemperatureNotSlot(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			212 => ['production' => [
+				911 => '(($BuildTemp + 160) / 6) * (0.1 * $BuildLevelFactor) * $BuildLevel',
+			]],
+			1 => ['production' => [901 => '1000', 911 => '-1']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([212, 1]);
+		$config   = $this->makeConfig();
+		$user     = $this->makeUser();
+
+		$hotSlot1 = $this->calculator($user, $this->makePlanet(['planet' => 1, 'temp_max' => 240, 'solar_satelit' => 1]), $resource, $reslist, $config);
+		$hotSlot1->reBuildCache();
+		$hotSlot15 = $this->calculator($user, $this->makePlanet(['planet' => 15, 'temp_max' => 240, 'solar_satelit' => 1]), $resource, $reslist, $config);
+		$hotSlot15->reBuildCache();
+		$cold = $this->calculator($user, $this->makePlanet(['planet' => 1, 'temp_max' => -110, 'solar_satelit' => 1]), $resource, $reslist, $config);
+		$cold->reBuildCache();
+
+		$hotEnergy = round((240 + 160) / 6);
+		$coldEnergy = round((-110 + 160) / 6);
+
+		$this->assertEqualsWithDelta($hotEnergy, $hotSlot1->getPlanet()['energy'], 0.001);
+		$this->assertEqualsWithDelta($hotEnergy, $hotSlot15->getPlanet()['energy'], 0.001);
+		$this->assertEqualsWithDelta($coldEnergy, $cold->getPlanet()['energy'], 0.001);
+	}
+
+	public function testEnergyShortageScalesBoostedPlus(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			1 => ['production' => [901 => '1000', 911 => '-200']],
+			4 => ['production' => [911 => '100']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([1, 4]);
+		$config   = $this->makeConfig();
+		$calc = $this->calculator($this->makeUser(), $this->makePlanet(['planet' => 8]), $resource, $reslist, $config);
+		$calc->reBuildCache();
+
+		// prodLevel = 100/200 = 0.5; 1000 * 1.35 * 0.5 = 675
+		$this->assertEqualsWithDelta(675.0, $calc->getPlanet()['metal_perhour'], 0.001);
+	}
+
+	public function testZeroEnergyUseZerosPerHour(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			1 => ['production' => [901 => '1000']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([1]);
+		$config   = $this->makeConfig();
+		$calc = $this->calculator($this->makeUser(), $this->makePlanet(['planet' => 8]), $resource, $reslist, $config);
+		$calc->reBuildCache();
+
+		$this->assertEquals(0, $calc->getPlanet()['metal_perhour']);
+	}
+
+	public function testMoonDoesNotGetSlotMetalBonus(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			1 => ['production' => [901 => '1000', 911 => '-100']],
+			4 => ['production' => [911 => '1000']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([1, 4]);
+		$config   = $this->makeConfig();
+		$calc = $this->calculator(
+			$this->makeUser(),
+			$this->makePlanet(['planet' => 8, 'planet_type' => 3]),
+			$resource,
+			$reslist,
+			$config
+		);
+		$calc->reBuildCache();
+
+		$this->assertEqualsWithDelta(1000.0, $calc->getPlanet()['metal_perhour'], 0.001);
+	}
+
+	public function testExecCalcDoesNotMultiplyBasicIncomeBySlot(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			1 => ['production' => [901 => '0', 911 => '-100']],
+			4 => ['production' => [911 => '1000']],
+			22 => ['storage' => [901 => '100000', 902 => '100000', 903 => '100000']],
+		];
+		$resource = $this->makeResource() + [22 => 'metal_store'];
+		$reslist  = $this->makeReslist([1, 4]);
+		$reslist['storage'] = [22];
+		$config   = $this->makeConfig(['metal_basic_income' => 20]);
+		$planet   = $this->makePlanet(['planet' => 8, 'metal' => 0, 'metal_store' => 1]);
+		$calc     = $this->calculator($this->makeUser(), $planet, $resource, $reslist, $config);
+		$calc->reBuildCache();
+		$calc->execCalc();
+
+		$this->assertEqualsWithDelta(20.0, $calc->getPlanet()['metal'], 0.001);
+	}
+
+	public function testSlotThreeBoostsSilicon(): void
+	{
+		$GLOBALS['ProdGrid'] = [
+			2 => ['production' => [902 => '1000', 911 => '-100']],
+			4 => ['production' => [911 => '1000']],
+		];
+		$resource = $this->makeResource();
+		$reslist  = $this->makeReslist([2, 4]);
+		$config   = $this->makeConfig();
+		$calc = $this->calculator($this->makeUser(), $this->makePlanet(['planet' => 3]), $resource, $reslist, $config);
+		$calc->reBuildCache();
+
+		$this->assertEqualsWithDelta(1200.0, $calc->getPlanet()['crystal_perhour'], 0.001);
+	}
+}

--- a/tests/Unit/ResourceUpdateTest.php
+++ b/tests/Unit/ResourceUpdateTest.php
@@ -498,6 +498,52 @@ class ResourceUpdateTest extends TestCase
 		$this->assertNotEquals($hashActive, $hashInactive, 'Hash must differ when inactivity forces full production');
 	}
 
+	public function testHashChangesWhenPlanetSlotChanges(): void
+	{
+		$resource = $this->makeResource();
+		$reslist  = array_replace($this->makeReslist(), ['prod' => [22]]);
+		$config   = $this->makeConfig();
+		Config::setInstance($config, 1);
+
+		$user    = $this->makeUser();
+		$planet8 = $this->makePlanet(['planet' => 8]);
+		$planet9 = $this->makePlanet(['planet' => 9]);
+
+		$eco = new ResourceUpdate(false, false);
+		$eco->setResourceData($resource, $reslist);
+
+		$eco->setData($user, $planet8);
+		$hash8 = $eco->CreateHash();
+
+		$eco->setData($user, $planet9);
+		$hash9 = $eco->CreateHash();
+
+		$this->assertNotEquals($hash8, $hash9, 'Hash must differ when planet slot changes');
+	}
+
+	public function testHashChangesWhenTempMaxChanges(): void
+	{
+		$resource = $this->makeResource();
+		$reslist  = array_replace($this->makeReslist(), ['prod' => [22]]);
+		$config   = $this->makeConfig();
+		Config::setInstance($config, 1);
+
+		$user = $this->makeUser();
+		$cool = $this->makePlanet(['temp_max' => 40]);
+		$hot  = $this->makePlanet(['temp_max' => 200]);
+
+		$eco = new ResourceUpdate(false, false);
+		$eco->setResourceData($resource, $reslist);
+
+		$eco->setData($user, $cool);
+		$hashCool = $eco->CreateHash();
+
+		$eco->setData($user, $hot);
+		$hashHot = $eco->CreateHash();
+
+		$this->assertNotEquals($hashCool, $hashHot, 'Hash must differ when temp_max changes');
+	}
+
 	// -----------------------------------------------------------------------
 	// ReBuildCache path (HASH=false forces ReBuildCache to run)
 	// -----------------------------------------------------------------------
@@ -779,6 +825,7 @@ class ResourceUpdateTest extends TestCase
 		];
 
 		$planet = $this->makePlanet([
+			'planet'                      => 4,
 			'metal_mine'                  => 1,
 			'metal_mine_porcent'          => 0,   // player dialed mines off
 			'solar_plant_building'        => 100,


### PR DESCRIPTION
## Summary
- Metal and silicon mine base production now scales with the planet's position in the system: more silicon on inner slots (1–3), more metal on mid-belt slots (6–10). See #32.
- Uranium synthesizers and solar satellites keep the existing temperature formulas; basic income is not multiplied.
- Production cache hashes include slot and max temperature so rates rebuild after deploy or admin slot changes. Resources and information pages use the same multipliers as accrual.

## Test plan
- [ ] Unit tests: `PlanetProductionBonusTest`, `ResourceCalculatorTest`, `ResourceUpdateTest` hash cases
- [ ] Two colonies with the same mines at slot 3 vs slot 8: silicon and metal rates differ; uranium differs only if temperature differs
- [ ] Solar satellite energy still follows planet temperature
- [ ] Resources page mine rows match header hourly rates after the bonus
- [ ] Moons do not receive mine slot bonuses

Closes #32