### PR TITLE
Rewrite install upgrade path to use Migrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ GitHub Actions runs on every push and pull request (`.github/workflows/ci.yaml`)
 
 ### Database Migrations
 
-After pulling new code, apply any pending schema changes with the CLI migration tool:
+After pulling new code, apply pending schema changes with the CLI tool (preferred for operators with shell access):
 
 ```bash
 # Check current version and list pending migrations
@@ -167,6 +167,8 @@ php migrate.php run --dry-run
 ```
 
 Run from the project root. The tool requires `includes/config.php` to exist (created by the web installer).
+
+If the game redirects to `install/index.php?mode=upgrade` (`dbVersion` behind `DB_VERSION_REQUIRED` in `includes/dbtables.php`), either run the CLI commands above or use the web wizard: create `includes/ENABLE_INSTALL_TOOL`, open the upgrade page, and confirm. The wizard dumps prefixed tables to `includes/backups/` then applies the same `install/migrations/` files as the CLI. PHP migrations are included in-process (not copied to the web root).
 
 ### If you run HiveNova on NGINX - Read nginx.md file!
 

--- a/includes/classes/Database.php
+++ b/includes/classes/Database.php
@@ -94,7 +94,7 @@ class Database implements DatabaseInterface
 		$this->dbHandle = NULL;
 	}
 
-	public function getHandle()
+	public function getHandle(): ?PDO
 	{
 		return $this->dbHandle;
 	}

--- a/includes/classes/DatabaseInterface.php
+++ b/includes/classes/DatabaseInterface.php
@@ -2,6 +2,8 @@
 
 namespace HiveNova\Core;
 
+use PDO;
+
 interface DatabaseInterface
 {
 	public function select($qry, array $params = array());
@@ -17,6 +19,7 @@ interface DatabaseInterface
 	public function getQueryCounter();
 	public function quote($str);
 	public function disconnect();
+	public function getHandle(): ?PDO;
 	public function beginTransaction(): void;
 	public function commit(): void;
 	public function rollback(): void;

--- a/includes/classes/InstallerUpgrade.php
+++ b/includes/classes/InstallerUpgrade.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace HiveNova\Core;
+
+use Exception;
+use PDO;
+
+/**
+ * Web-installer upgrade: preview pending migrations, dump prefixed tables, apply via Migrator.
+ */
+class InstallerUpgrade
+{
+    public function __construct(
+        private readonly DatabaseInterface $db,
+        private readonly SQLDumper $dumper,
+        private readonly string $migrationsDir,
+        private readonly string $prefix,
+        private readonly int $requiredVersion,
+        private readonly string $backupDir = 'includes/backups',
+        private ?Migrator $migrator = null,
+    ) {
+    }
+
+    public function migrator(): Migrator
+    {
+        if ($this->migrator instanceof Migrator) {
+            return $this->migrator;
+        }
+
+        $pdo = $this->db->getHandle();
+        if (!$pdo instanceof PDO) {
+            throw new Exception('Database PDO handle is not available.');
+        }
+
+        $this->migrator = new Migrator(
+            $pdo,
+            $this->migrationsDir,
+            $this->prefix,
+            $this->requiredVersion,
+        );
+
+        return $this->migrator;
+    }
+
+    /**
+     * @return array<string, string> filename => preview text
+     */
+    public function preview(): array
+    {
+        $migrator = $this->migrator();
+        $pending  = $migrator->getPendingMigrations($migrator->getCurrentVersion());
+        $updates  = [];
+
+        foreach ($pending as $migration) {
+            if ($migration['extension'] === 'php') {
+                $updates[$migration['filename']] = '(PHP migration)';
+                continue;
+            }
+
+            $sql = file_get_contents($migration['path']);
+            $updates[$migration['filename']] = str_replace(
+                '%PREFIX%',
+                $this->prefix,
+                $sql === false ? '' : $sql
+            );
+        }
+
+        return $updates;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function listPrefixedTables(string $databaseName): array
+    {
+        $rows      = $this->db->nativeQuery('SHOW TABLE STATUS FROM `' . $databaseName . '`;');
+        $tables    = [];
+        $prefixLen = strlen($this->prefix);
+
+        foreach ($rows as $table) {
+            $name = $table['Name'] ?? '';
+            if ($name !== '' && $this->prefix === substr($name, 0, $prefixLen)) {
+                $tables[] = $name;
+            }
+        }
+
+        return $tables;
+    }
+
+    /**
+     * @return array{applied: array, revision: int, backupPath: string}
+     */
+    public function apply(string $databaseName): array
+    {
+        $tables = $this->listPrefixedTables($databaseName);
+        if ($tables === []) {
+            throw new Exception('No tables found for dump.');
+        }
+
+        @set_time_limit(600);
+
+        $timestamp  = defined('TIMESTAMP') ? TIMESTAMP : time();
+        $backupPath = rtrim($this->backupDir, '/') . '/2MoonsBackup_'
+            . date('Y_m_d_H_i_s', $timestamp) . '.sql';
+
+        $this->dumper->dumpTablesToFile($tables, $backupPath);
+
+        try {
+            $applied = $this->migrator()->run();
+            $this->migrator()->updateVersion();
+        } catch (Exception $e) {
+            throw $this->restoreOrFail($backupPath, $e->getMessage());
+        }
+
+        $revision = $this->requiredVersion;
+        if ($applied !== []) {
+            $last     = $applied[array_key_last($applied)];
+            $revision = (int) $last['rev'];
+        }
+
+        return [
+            'applied'    => $applied,
+            'revision'   => $revision,
+            'backupPath' => $backupPath,
+        ];
+    }
+
+    private function restoreOrFail(string $backupPath, string $errorMessage): Exception
+    {
+        try {
+            $this->dumper->restoreDatabase($backupPath);
+            $message = 'Update error.<br><br>' . $errorMessage
+                . '<br><br><b><i>Backup restored.</i></b>';
+        } catch (Exception $e) {
+            $message = 'Update error.<br><br>' . $errorMessage
+                . '<br><br><b><i>Can not restore backup. Your game is maybe broken right now.</i></b>'
+                . '<br><br>Restore error:<br>' . $e->getMessage();
+        }
+
+        return new Exception($message);
+    }
+}

--- a/install/index.php
+++ b/install/index.php
@@ -101,169 +101,50 @@ switch ($mode) {
 		$ftp->chmod('install', $CHMOD);
 		break;
 	case 'upgrade':
-		// Willkommen zum Update page. Anzeige, von und zu geupdatet wird. Informationen, dass ein backup erstellt wird.
+		$installerUpgrade = new \HiveNova\Core\InstallerUpgrade(
+			\HiveNova\Core\Database::get(),
+			new \HiveNova\Core\SQLDumper(),
+			ROOT_PATH . 'install/migrations/',
+			DB_PREFIX,
+			DB_VERSION_REQUIRED,
+		);
 
-        try {
-            $sql    = "SELECT dbVersion FROM %%SYSTEM%%;";
-
-            $dbVersion  = \HiveNova\Core\Database::get()->selectSingle($sql, array(), 'dbVersion');
-        } catch (Exception $e) {
-            $dbVersion  = 0;
-        }
-
-        $updates = array();
-
-        $fileRevision = 0;
-
-		$directoryIterator = new DirectoryIterator(ROOT_PATH . 'install/migrations/');
-		/** @var $fileInfo DirectoryIterator */
-		foreach ($directoryIterator as $fileInfo) {
-			if (!$fileInfo->isFile() || !preg_match('/^migration_\d+/', $fileInfo->getFilename())) {
-				continue;
-			}
-
-			$fileRevision = substr($fileInfo->getFilename(), 10, -4);
-
-            if ($fileRevision <= $dbVersion || $fileRevision > DB_VERSION_REQUIRED) {
-                continue;
-            }
-
-            $updates[$fileInfo->getPathname()] = makebr(str_replace('%PREFIX%', DB_PREFIX, file_get_contents($fileInfo->getPathname())));
+		$updates = array();
+		foreach ($installerUpgrade->preview() as $file => $content) {
+			$updates[$file] = str_ends_with((string) $file, '.php') ? $content : makebr($content);
 		}
 
 		$template->assign_vars(array(
-			'file_revision' => min(DB_VERSION_REQUIRED, $fileRevision),
-			'sql_revision'  => $dbVersion,
-            'updates'       => $updates,
+			'file_revision' => DB_VERSION_REQUIRED,
+			'sql_revision'  => $installerUpgrade->migrator()->getCurrentVersion(),
+			'updates'       => $updates,
 			'header'        => $LNG['menu_upgrade']
 		));
 
 		$template->show('ins_update.tpl');
 		break;
 	case 'doupgrade':
-		// TODO:Need a rewrite!
 		require 'includes/config.php';
 
-		// Create a Backup
-        $sqlTableRaw  = \HiveNova\Core\Database::get()->nativeQuery("SHOW TABLE STATUS FROM `" . DB_NAME . "`;");
-		$prefixCounts = strlen(DB_PREFIX);
-		$dbTables     = array();
-		foreach($sqlTableRaw as $table)
-		{
-			if (DB_PREFIX == substr($table['Name'], 0, $prefixCounts)) {
-				$dbTables[] = $table['Name'];
-			}
-		}
+		$installerUpgrade = new \HiveNova\Core\InstallerUpgrade(
+			\HiveNova\Core\Database::get(),
+			new \HiveNova\Core\SQLDumper(),
+			ROOT_PATH . 'install/migrations/',
+			DB_PREFIX,
+			DB_VERSION_REQUIRED,
+		);
 
-		if (empty($dbTables))
-		{
-			throw new Exception('No tables found for dump.');
-		}
+		$result = $installerUpgrade->apply(DB_NAME);
 
-        @set_time_limit(600);
-
-		$fileName = '2MoonsBackup_' . date('Y_m_d_H_i_s', TIMESTAMP) . '.sql';
-		$filePath = 'includes/backups/' . $fileName;
-		
-		$dump = new \HiveNova\Core\SQLDumper;
-		$dump->dumpTablesToFile($dbTables, $filePath);
-
-        try {
-            $sql	= "SELECT dbVersion FROM %%SYSTEM%%;";
-
-            $dbVersion	= \HiveNova\Core\Database::get()->selectSingle($sql, array(), 'dbVersion');
-        } catch (Exception $e) {
-            $dbVersion  = 0;
-        }
-
-		$httpRoot = PROTOCOL . HTTP_HOST . str_replace(array('\\', '//'), '/', dirname(dirname($_SERVER['SCRIPT_NAME'])) . '/');
-		$revision = $dbVersion;
-		$fileList = array();
-		$directoryIterator = new DirectoryIterator(ROOT_PATH . 'install/migrations/');
-		/** @var $fileInfo DirectoryIterator */
-		foreach ($directoryIterator as $fileInfo) {
-			if (!$fileInfo->isFile()) {
-				continue;
-			}
-			$fileRevision = substr($fileInfo->getFilename(), 10, -4);
-			if ($fileRevision > $revision && $fileRevision <= DB_VERSION_REQUIRED) {
-				$fileExtension = pathinfo($filePath, PATHINFO_EXTENSION);
-				$key           = $fileRevision . ((int)$fileExtension === 'php');
-				$fileList[$key] = array(
-					'fileName'      => $fileInfo->getFilename(),
-					'fileRevision'  => $fileRevision,
-					'fileExtension' => $fileExtension
-				);
-			}
-		}
-		ksort($fileList);
-        foreach ($fileList as $fileInfo) {
-            switch ($fileInfo['fileExtension']) {
-                case 'php':
-                    copy(ROOT_PATH.'install/migrations/' . $fileInfo['fileName'], ROOT_PATH.$fileInfo['fileName']);
-                    $ch = curl_init($httpRoot . $fileInfo['fileName']);
-                    curl_setopt($ch, CURLOPT_HEADER, false);
-                    curl_setopt($ch, CURLOPT_NOBODY, true);
-                    curl_setopt($ch, CURLOPT_MUTE, true);
-                    curl_exec($ch);
-                    if (curl_errno($ch)) {
-                        $errorMessage = 'CURL-Error on update ' . basename($fileInfo['filePath']) . ':' . curl_error($ch);
-                        try {
-                            $dump->restoreDatabase($filePath);
-                            $message = 'Update error.<br><br>' . $errorMessage . '<br><br><b><i>Backup restored.</i></b>';
-                        }
-                        catch (Exception $e) {
-                            $message = 'Update error.<br><br>' . $errorMessage . '<br><br><b><i>Can not restore backup. Your game is maybe broken right now.</i></b><br><br>Restore error:<br>' . $e->getMessage();
-                        }
-                        throw new Exception($message);
-                    }
-                    curl_close($ch);
-                    unlink($fileInfo['fileName']);
-                    break;
-                case 'sql';
-                    $data = file_get_contents(ROOT_PATH . 'install/migrations/' . $fileInfo['fileName']);
-                    try {
-                        $queries	= explode(";\n", str_replace('%PREFIX%', DB_PREFIX, $data));
-                        $queries	= array_filter($queries);
-                        foreach($queries as $query)
-                        {
-							try {
-								// alter table IF NOT EXISTS
-								\HiveNova\Core\Database::get()->nativeQuery(trim($query));
-							}
-							catch (Exception $e) {
-								error_log('Query: [' . $query . '] failed. Error: ' . $e->getMessage() . '. Skipped');
-							}
-                        }
-                    }
-                    catch (Exception $e) {
-                        $errorMessage = $e->getMessage();
-                        try {
-                            $dump->restoreDatabase($filePath);
-                            $message = 'Update error.<br><br>' . $errorMessage . '<br><br><b><i>Backup restored.</i></b>';
-                        }
-                        catch (Exception $e) {
-                            $message = 'Update error.<br><br>' . $errorMessage . '<br><br><b><i>Can not restore backup. Your game is maybe broken right now.</i></b><br><br>Restore error:<br>' . $e->getMessage();
-                        }
-                        throw new Exception($message);
-                    }
-                    break;
-            }
-        }
-        $revision = end($fileList);
-        $revision = $revision['fileRevision'];
-
-        \HiveNova\Core\Database::get()->update("UPDATE %%SYSTEM%% SET dbVersion = " . DB_VERSION_REQUIRED . ";");
-
-        ClearCache();
+		ClearCache();
 
 		$template->assign_vars(array(
-			'update'   => !empty($fileList),
-			'revision' => $revision,
+			'update'   => $result['applied'] !== [],
+			'revision' => $result['revision'],
 			'header'   => $LNG['menu_upgrade'],
-        ));
+		));
 		$template->show('ins_doupdate.tpl');
-        unlink($enableInstallToolFile);
+		unlink($enableInstallToolFile);
 		break;
 	case 'install':
 		$step = \HiveNova\Core\HTTP::_GP('step', 0);

--- a/language/en/INSTALL.php
+++ b/language/en/INSTALL.php
@@ -42,7 +42,7 @@ $LNG['upgrade_success']			= 'Update of the database successfully. Database is no
 $LNG['upgrade_nothingtodo']		= 'No action is required. Database is already up to revision %s.';
 $LNG['upgrade_back']			= 'Back';
 $LNG['upgrade_intro_welcome']	= 'Welcome to the database upgrader!';
-$LNG['upgrade_available']		= 'Available updates for your database! The database is at the revision %s and can update to revision %s.<br><br>Please choose from the following menu to the first SQL update to install:';
+$LNG['upgrade_available']		= 'Available updates for your database! The database is at revision %s and can be updated to revision %s.<br><br>Review the pending migrations below, then continue. A backup of prefixed tables is taken before they are applied.';
 $LNG['upgrade_notavailable']	= 'The used revision %s is the latest for your database.';
 $LNG['upgrade_required_rev']	= 'The Updater can work only from revision r2579 (2Moons v1. 7) or later.';
 

--- a/migrate.php
+++ b/migrate.php
@@ -93,14 +93,9 @@ if ($command === 'run') {
 
     echo "Applying " . count($pending) . " migration(s)...\n\n";
     foreach ($pending as $m) {
-        echo "[{$m['rev']}] {$m['filename']} ... ";
-        match ($m['extension']) {
-            'sql' => $migrator->applySqlMigration($m),
-            'php' => $migrator->applyPhpMigration($m),
-        };
-        echo "OK\n";
+        echo "[{$m['rev']}] {$m['filename']}\n";
     }
-    $migrator->updateVersion();
+    $migrator->run();
     echo "\nDB version updated to " . DB_VERSION_REQUIRED . ".\n";
     exit(0);
 }

--- a/tests/Support/DiscordWebhookDatabaseStub.php
+++ b/tests/Support/DiscordWebhookDatabaseStub.php
@@ -112,6 +112,11 @@ class DiscordWebhookDatabaseStub implements DatabaseInterface
 	{
 	}
 
+	public function getHandle(): ?\PDO
+	{
+		return null;
+	}
+
 	public function beginTransaction(): void
 	{
 	}

--- a/tests/Support/FakeAchievementDatabase.php
+++ b/tests/Support/FakeAchievementDatabase.php
@@ -338,6 +338,7 @@ class FakeAchievementDatabase implements DatabaseInterface
     public function getQueryCounter() { return 0; }
     public function quote($str) { return "'" . addslashes((string) $str) . "'"; }
     public function disconnect() {}
+    public function getHandle(): ?\PDO { return null; }
     public function beginTransaction(): void {}
     public function commit(): void {}
     public function rollback(): void {}

--- a/tests/Support/FakeDatabase.php
+++ b/tests/Support/FakeDatabase.php
@@ -368,6 +368,11 @@ class FakeDatabase implements DatabaseInterface
         $this->session->disconnect();
     }
 
+    public function getHandle(): ?\PDO
+    {
+        return null;
+    }
+
     public function beginTransaction(): void
     {
         $this->achievement->beginTransaction();

--- a/tests/Support/PushSubscriptionDatabaseStub.php
+++ b/tests/Support/PushSubscriptionDatabaseStub.php
@@ -67,6 +67,7 @@ class PushSubscriptionDatabaseStub implements DatabaseInterface
 	public function getQueryCounter() { return 0; }
 	public function quote($str) { return "'" . addslashes((string) $str) . "'"; }
 	public function disconnect() {}
+	public function getHandle(): ?\PDO { return null; }
 	public function beginTransaction(): void {}
 	public function commit(): void {}
 	public function rollback(): void {}

--- a/tests/Support/SessionDatabaseStub.php
+++ b/tests/Support/SessionDatabaseStub.php
@@ -105,6 +105,11 @@ class SessionDatabaseStub implements DatabaseInterface
     {
     }
 
+    public function getHandle(): ?\PDO
+    {
+        return null;
+    }
+
     public function beginTransaction(): void
     {
     }

--- a/tests/Unit/DatabaseTest.php
+++ b/tests/Unit/DatabaseTest.php
@@ -162,7 +162,7 @@ class DatabaseTest extends TestCase
         $required = ['select', 'selectSingle', 'insert', 'update', 'delete',
                      'replace', 'query', 'nativeQuery',
                      'lastInsertId', 'rowCount', 'getQueryCounter',
-                     'quote', 'disconnect'];
+                     'quote', 'disconnect', 'getHandle'];
 
         foreach ($required as $method) {
             $this->assertTrue($ref->hasMethod($method),

--- a/tests/Unit/FacebookAuthTest.php
+++ b/tests/Unit/FacebookAuthTest.php
@@ -142,6 +142,8 @@ class FacebookAuthFakeDatabase implements DatabaseInterface
 
     public function disconnect() {}
 
+    public function getHandle(): ?\PDO { return null; }
+
     public function beginTransaction(): void {}
 
     public function commit(): void {}

--- a/tests/Unit/InstallerUpgradeTest.php
+++ b/tests/Unit/InstallerUpgradeTest.php
@@ -1,0 +1,253 @@
+<?php
+
+use HiveNova\Core\DatabaseInterface;
+use HiveNova\Core\InstallerUpgrade;
+use HiveNova\Core\Migrator;
+use HiveNova\Core\SQLDumper;
+
+use PHPUnit\Framework\TestCase;
+
+class RecordingSqlDumper extends SQLDumper
+{
+    /** @var list<string> */
+    public array $dumpedTables = [];
+
+    public string $dumpedPath = '';
+
+    public int $dumpCalls = 0;
+
+    public int $restoreCalls = 0;
+
+    public ?Exception $restoreException = null;
+
+    public function dumpTablesToFile($dbTables, $filePath)
+    {
+        $this->dumpCalls++;
+        $this->dumpedTables = array_values($dbTables);
+        $this->dumpedPath   = $filePath;
+
+        return true;
+    }
+
+    public function restoreDatabase($filePath)
+    {
+        $this->restoreCalls++;
+        if ($this->restoreException instanceof Exception) {
+            throw $this->restoreException;
+        }
+    }
+}
+
+class RecordingMigrator extends Migrator
+{
+    public int $runCalls = 0;
+
+    public int $updateCalls = 0;
+
+    public ?Exception $runException = null;
+
+    /** @var list<array<string, mixed>> */
+    public array $toApply = [];
+
+    public function run(bool $dryRun = false): array
+    {
+        $this->runCalls++;
+        if ($this->runException instanceof Exception) {
+            throw $this->runException;
+        }
+
+        return $this->toApply;
+    }
+
+    public function updateVersion(): void
+    {
+        $this->updateCalls++;
+    }
+}
+
+class InstallerUpgradeTest extends TestCase
+{
+    private string $migrationsDir;
+
+    protected function setUp(): void
+    {
+        $this->migrationsDir = sys_get_temp_dir() . '/installer_upgrade_' . uniqid();
+        mkdir($this->migrationsDir);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->migrationsDir . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+        rmdir($this->migrationsDir);
+    }
+
+    private function addMigration(int $rev, string $ext, string $body): void
+    {
+        file_put_contents("{$this->migrationsDir}/migration_{$rev}.{$ext}", $body);
+    }
+
+    private function makeUpgrade(
+        DatabaseInterface $db,
+        SQLDumper $dumper,
+        ?Migrator $migrator = null,
+        int $required = 5,
+        string $backupDir = '',
+    ): InstallerUpgrade {
+        return new InstallerUpgrade(
+            $db,
+            $dumper,
+            $this->migrationsDir,
+            'uni1_',
+            $required,
+            $backupDir !== '' ? $backupDir : sys_get_temp_dir(),
+            $migrator,
+        );
+    }
+
+    private function recordingMigrator(): RecordingMigrator
+    {
+        return new RecordingMigrator($this->createMock(PDO::class), $this->migrationsDir, 'uni1_', 5);
+    }
+
+    public function testPreviewListsPendingSqlAndPhpInOrderIgnoringJunk(): void
+    {
+        file_put_contents("{$this->migrationsDir}/README.txt", 'ignore');
+        $this->addMigration(1, 'sql', "ALTER TABLE %PREFIX%users ADD x INT;\n");
+        $this->addMigration(3, 'php', "<?php\n");
+        $this->addMigration(2, 'sql', "ALTER TABLE %PREFIX%planets ADD y INT;\n");
+        $this->addMigration(9, 'sql', "ALTER TABLE too_new INT;\n");
+
+        $stmt = $this->createMock(PDOStatement::class);
+        $stmt->method('fetchColumn')->willReturn('1');
+        $pdo = $this->createMock(PDO::class);
+        $pdo->method('query')->willReturn($stmt);
+
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('getHandle')->willReturn($pdo);
+
+        $upgrade = $this->makeUpgrade($db, new RecordingSqlDumper(), required: 5);
+        $preview = $upgrade->preview();
+
+        $this->assertSame(
+            ['migration_2.sql', 'migration_3.php'],
+            array_keys($preview)
+        );
+        $this->assertStringContainsString('uni1_planets', $preview['migration_2.sql']);
+        $this->assertSame('(PHP migration)', $preview['migration_3.php']);
+    }
+
+    public function testMigratorFailsFastWhenHandleIsNull(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('getHandle')->willReturn(null);
+
+        $upgrade = $this->makeUpgrade($db, new RecordingSqlDumper());
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Database PDO handle is not available.');
+        $upgrade->migrator();
+    }
+
+    public function testListPrefixedTablesFiltersByPrefix(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('nativeQuery')->willReturn([
+            ['Name' => 'uni1_users'],
+            ['Name' => 'other_users'],
+            ['Name' => 'uni1_planets'],
+        ]);
+
+        $upgrade = $this->makeUpgrade($db, new RecordingSqlDumper(), $this->recordingMigrator());
+        $this->assertSame(['uni1_users', 'uni1_planets'], $upgrade->listPrefixedTables('gamedb'));
+    }
+
+    public function testApplyThrowsWhenNoPrefixedTables(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('nativeQuery')->willReturn([['Name' => 'other_users']]);
+
+        $dumper   = new RecordingSqlDumper();
+        $migrator = $this->recordingMigrator();
+        $upgrade  = $this->makeUpgrade($db, $dumper, $migrator);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('No tables found for dump.');
+        try {
+            $upgrade->apply('gamedb');
+        } finally {
+            $this->assertSame(0, $dumper->dumpCalls);
+            $this->assertSame(0, $migrator->runCalls);
+        }
+    }
+
+    public function testApplyDumpsThenRunsWithoutRestore(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('nativeQuery')->willReturn([['Name' => 'uni1_users']]);
+
+        $dumper   = new RecordingSqlDumper();
+        $migrator = $this->recordingMigrator();
+        $migrator->toApply = [
+            ['rev' => 4, 'filename' => 'migration_4.sql', 'path' => '', 'extension' => 'sql'],
+        ];
+
+        $upgrade = $this->makeUpgrade($db, $dumper, $migrator, backupDir: '/tmp/backups');
+        $result  = $upgrade->apply('gamedb');
+
+        $this->assertSame(1, $dumper->dumpCalls);
+        $this->assertSame(['uni1_users'], $dumper->dumpedTables);
+        $this->assertStringContainsString('2MoonsBackup_', $dumper->dumpedPath);
+        $this->assertSame(1, $migrator->runCalls);
+        $this->assertSame(1, $migrator->updateCalls);
+        $this->assertSame(0, $dumper->restoreCalls);
+        $this->assertSame(4, $result['revision']);
+        $this->assertCount(1, $result['applied']);
+    }
+
+    public function testApplyRestoresBackupWhenRunThrows(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('nativeQuery')->willReturn([['Name' => 'uni1_users']]);
+
+        $dumper   = new RecordingSqlDumper();
+        $migrator = $this->recordingMigrator();
+        $migrator->runException = new Exception('boom');
+
+        $upgrade = $this->makeUpgrade($db, $dumper, $migrator);
+
+        try {
+            $upgrade->apply('gamedb');
+            $this->fail('Expected exception');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('boom', $e->getMessage());
+            $this->assertStringContainsString('Backup restored.', $e->getMessage());
+        }
+
+        $this->assertSame(1, $dumper->dumpCalls);
+        $this->assertSame(1, $dumper->restoreCalls);
+        $this->assertSame(0, $migrator->updateCalls);
+    }
+
+    public function testApplyReportsRestoreFailure(): void
+    {
+        $db = $this->createMock(DatabaseInterface::class);
+        $db->method('nativeQuery')->willReturn([['Name' => 'uni1_users']]);
+
+        $dumper = new RecordingSqlDumper();
+        $dumper->restoreException = new Exception('disk full');
+        $migrator = $this->recordingMigrator();
+        $migrator->runException = new Exception('boom');
+
+        $upgrade = $this->makeUpgrade($db, $dumper, $migrator);
+
+        try {
+            $upgrade->apply('gamedb');
+            $this->fail('Expected exception');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('Can not restore backup', $e->getMessage());
+            $this->assertStringContainsString('disk full', $e->getMessage());
+        }
+    }
+}

--- a/tests/Unit/OpenIDAuthTest.php
+++ b/tests/Unit/OpenIDAuthTest.php
@@ -122,6 +122,8 @@ class OpenIDAuthFakeDatabase implements DatabaseInterface
 
     public function disconnect() {}
 
+    public function getHandle(): ?\PDO { return null; }
+
     public function beginTransaction(): void {}
 
     public function commit(): void {}

--- a/tests/Unit/SQLDumperTest.php
+++ b/tests/Unit/SQLDumperTest.php
@@ -105,6 +105,8 @@ class SQLDumperFakeDatabase implements DatabaseInterface
 
     public function disconnect() {}
 
+    public function getHandle(): ?\PDO { return null; }
+
     public function beginTransaction(): void {}
 
     public function commit(): void {}

--- a/tests/Unit/ShowDestructionPageTest.php
+++ b/tests/Unit/ShowDestructionPageTest.php
@@ -113,6 +113,11 @@ final class DestructionPageDatabaseStub implements DatabaseInterface
     {
     }
 
+    public function getHandle(): ?\PDO
+    {
+        return null;
+    }
+
     public function beginTransaction(): void
     {
     }

--- a/tests/ci-install.php
+++ b/tests/ci-install.php
@@ -171,19 +171,12 @@ echo "[ 4/4 ] Running migrations ... ";
 
 $migrator       = new \HiveNova\Core\Migrator($pdo, ROOT_PATH . 'install/migrations', DB_PREFIX, DB_VERSION_REQUIRED);
 $currentVersion = $migrator->getCurrentVersion();
-$pending        = $migrator->getPendingMigrations($currentVersion);
+$applied        = $migrator->run();
 
-if (empty($pending)) {
+if ($applied === []) {
     echo "already up to date (v{$currentVersion})\n";
 } else {
-    foreach ($pending as $m) {
-        match ($m['extension']) {
-            'sql' => $migrator->applySqlMigration($m),
-            'php' => $migrator->applyPhpMigration($m),
-        };
-    }
-    $migrator->updateVersion();
-    echo "applied " . count($pending) . " migration(s), now v" . DB_VERSION_REQUIRED . "\n";
+    echo "applied " . count($applied) . " migration(s), now v" . DB_VERSION_REQUIRED . "\n";
 }
 
 echo "\n=== Install complete ===\n";


### PR DESCRIPTION
## Summary
- Web `upgrade`/`doupgrade` now preview and apply schema changes through `Migrator` (same engine as `php migrate.php`), so PHP migrations actually run instead of being misclassified as SQL.
- The wizard still dumps prefixed tables and restores the dump if apply fails; CLI/CI call `Migrator::run()`.
- Documents CLI vs web upgrade in the README. Fixes #159.

## Test plan
- [ ] `php vendor/bin/phpunit tests/Unit/InstallerUpgradeTest.php tests/Unit/MigratorTest.php tests/Unit/DatabaseTest.php`
- [ ] With `ENABLE_INSTALL_TOOL` and a behind `dbVersion`, open `install/index.php?mode=upgrade` and confirm pending SQL + PHP are listed, then submit `doupgrade`
- [ ] Confirm `includes/backups/` gets a dump and `dbVersion` matches `DB_VERSION_REQUIRED`
- [ ] `php migrate.php status` / `run --dry-run` still work after a code pull