### PR TITLE
Fix Config global save across universes

### DIFF
--- a/includes/classes/Config.php
+++ b/includes/classes/Config.php
@@ -129,44 +129,98 @@ class Config
 			// Do nothing here.
 			return true;
 		}
-		
+
 		if(is_null($options))
 		{
 			$options	= array();
 		}
-		
+
 		$options	+= array(
 			'noGlobalSave' => false
 		);
-		
-		$updateData = array();
-		$params     = array();
-		foreach ($this->updateRecords as $columnName) {
-			$updateData[]             = '`' . $columnName . '` = :' . $columnName;
-			$params[':' . $columnName] = $this->configData[$columnName];
 
-			//TODO: find a better way ...
-			if(!$options['noGlobalSave'] && in_array($columnName, self::$globalConfigKeys))
-			{
-				foreach(Universe::availableUniverses() as $universeId)
-				{
-					if($universeId != $this->configData['uni'])
-					{
-						$config = Config::get();
-						$config->$columnName = $this->configData[$columnName];
-						$config->save(array('noGlobalSave' => true));
-					}
-				}
+		$columnNames = array_values(array_unique($this->updateRecords));
+		$globalKeys  = array();
+		$localKeys   = array();
+		foreach ($columnNames as $columnName) {
+			if (in_array($columnName, self::$globalConfigKeys, true)) {
+				$globalKeys[] = $columnName;
+			} else {
+				$localKeys[] = $columnName;
 			}
 		}
 
-		$sql = 'UPDATE %%CONFIG%% SET '.implode(', ', $updateData).' WHERE `UNI` = :universe';
-		$params[':universe'] = $this->configData['uni'];
-		$db     = Database::get();
-		$db->update($sql, $params);
-		
+		$fanOutGlobals = !$options['noGlobalSave'] && !empty($globalKeys);
+		$scopedKeys    = $fanOutGlobals ? $localKeys : array_merge($globalKeys, $localKeys);
+
+		$db             = Database::get();
+		$useTransaction = $fanOutGlobals && !empty($scopedKeys);
+
+		try {
+			if ($useTransaction) {
+				$db->beginTransaction();
+			}
+
+			if ($fanOutGlobals) {
+				$this->executeUpdate($db, $globalKeys, false);
+				$this->syncGlobalValuesToOtherInstances($globalKeys);
+			}
+
+			if (!empty($scopedKeys)) {
+				$this->executeUpdate($db, $scopedKeys, true);
+			}
+
+			if ($useTransaction) {
+				$db->commit();
+			}
+		} catch (\Throwable $e) {
+			if ($useTransaction) {
+				$db->rollback();
+			}
+			throw $e;
+		}
+
 		$this->updateRecords = array();
 		return true;
+	}
+
+	/**
+	 * @param list<string> $columnNames
+	 */
+	private function executeUpdate(DatabaseInterface $db, array $columnNames, bool $scopeToUniverse): void
+	{
+		$updateData = array();
+		$params     = array();
+		foreach ($columnNames as $columnName) {
+			$updateData[]              = '`' . $columnName . '` = :' . $columnName;
+			$params[':' . $columnName] = $this->configData[$columnName];
+		}
+
+		$sql = 'UPDATE %%CONFIG%% SET '.implode(', ', $updateData);
+		if ($scopeToUniverse) {
+			$sql .= ' WHERE `UNI` = :universe';
+			$params[':universe'] = $this->configData['uni'];
+		}
+
+		$db->update($sql, $params);
+	}
+
+	/**
+	 * @param list<string> $globalKeys
+	 */
+	private function syncGlobalValuesToOtherInstances(array $globalKeys): void
+	{
+		$uni = $this->configData['uni'];
+		foreach (self::$instances as $instanceUni => $instance) {
+			if ($instance === $this || $instanceUni == $uni) {
+				continue;
+			}
+			foreach ($globalKeys as $key) {
+				if (isset($instance->configData[$key])) {
+					$instance->configData[$key] = $this->configData[$key];
+				}
+			}
+		}
 	}
 
 	static function getAll(): never

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -418,6 +418,11 @@ class ConfigRecordingDatabase implements DatabaseInterface
     {
     }
 
+    public function getHandle(): ?\PDO
+    {
+        return null;
+    }
+
     public function beginTransaction(): void
     {
         $this->begins++;

--- a/tests/Unit/ConfigTest.php
+++ b/tests/Unit/ConfigTest.php
@@ -1,18 +1,37 @@
 <?php
 
 use HiveNova\Core\Config;
+use HiveNova\Core\Database;
+use HiveNova\Core\DatabaseInterface;
 use HiveNova\Core\Universe;
 
 use PHPUnit\Framework\TestCase;
 
 class ConfigTest extends TestCase
 {
+    private ?DatabaseInterface $previousDb = null;
+
     protected function setUp(): void
     {
         // Reset singleton between tests
         $ref = new ReflectionProperty(Config::class, 'instances');
         $ref->setAccessible(true);
         $ref->setValue(null, []);
+
+        $dbRef = new ReflectionProperty(Database::class, 'instance');
+        $dbRef->setAccessible(true);
+        $this->previousDb = $dbRef->getValue();
+    }
+
+    protected function tearDown(): void
+    {
+        $dbRef = new ReflectionProperty(Database::class, 'instance');
+        $dbRef->setAccessible(true);
+        if ($this->previousDb instanceof DatabaseInterface) {
+            Database::setInstance($this->previousDb);
+        } else {
+            $dbRef->setValue(null, null);
+        }
     }
 
     // -----------------------------------------------------------------------
@@ -183,5 +202,234 @@ class ConfigTest extends TestCase
         // Config::get() with no arg → universe=0 → Universe::current()=1
         $retrieved = Config::get();
         $this->assertSame(9, $retrieved->game_speed);
+    }
+
+    // -----------------------------------------------------------------------
+    // save — DB path
+    // -----------------------------------------------------------------------
+
+    public function testSaveLocalKeyUpdatesOnlyCurrentUniverse(): void
+    {
+        $db = new ConfigRecordingDatabase();
+        Database::setInstance($db);
+
+        $uni1 = new Config(['uni' => 1, 'game_speed' => 1, 'game_name' => 'A']);
+        $uni2 = new Config(['uni' => 2, 'game_speed' => 2, 'game_name' => 'A']);
+        Config::setInstance($uni1, 1);
+        Config::setInstance($uni2, 2);
+
+        $uni1->game_speed = 5;
+        $this->assertTrue($uni1->save());
+
+        $this->assertCount(1, $db->updates);
+        $this->assertStringContainsString('`game_speed`', $db->updates[0]['sql']);
+        $this->assertStringContainsString('WHERE `UNI` = :universe', $db->updates[0]['sql']);
+        $this->assertSame(1, $db->updates[0]['params'][':universe']);
+        $this->assertSame(5, $db->updates[0]['params'][':game_speed']);
+        $this->assertSame(2, $uni2->game_speed);
+        $this->assertSame(0, $db->begins);
+    }
+
+    public function testSaveGlobalKeyUpdatesAllRowsAndOtherInstances(): void
+    {
+        $db = new ConfigRecordingDatabase();
+        Database::setInstance($db);
+
+        $uni1 = new Config(['uni' => 1, 'game_speed' => 1, 'game_name' => 'Old']);
+        $uni2 = new Config(['uni' => 2, 'game_speed' => 2, 'game_name' => 'Old']);
+        Config::setInstance($uni1, 1);
+        Config::setInstance($uni2, 2);
+
+        $uni1->game_name = 'HiveNova';
+        $this->assertTrue($uni1->save());
+
+        $this->assertCount(1, $db->updates);
+        $this->assertStringContainsString('`game_name`', $db->updates[0]['sql']);
+        $this->assertStringNotContainsString('WHERE `UNI`', $db->updates[0]['sql']);
+        $this->assertArrayNotHasKey(':universe', $db->updates[0]['params']);
+        $this->assertSame('HiveNova', $uni1->game_name);
+        $this->assertSame('HiveNova', $uni2->game_name);
+        $this->assertSame(0, $db->begins);
+    }
+
+    public function testSaveMixedKeysUsesTransactionAndTwoUpdates(): void
+    {
+        $db = new ConfigRecordingDatabase();
+        Database::setInstance($db);
+
+        $uni1 = new Config(['uni' => 1, 'game_speed' => 1, 'game_name' => 'Old']);
+        $uni2 = new Config(['uni' => 2, 'game_speed' => 2, 'game_name' => 'Old']);
+        Config::setInstance($uni1, 1);
+        Config::setInstance($uni2, 2);
+
+        $uni1->game_name = 'HiveNova';
+        $uni1->game_speed = 9;
+        $this->assertTrue($uni1->save());
+
+        $this->assertSame(1, $db->begins);
+        $this->assertSame(1, $db->commits);
+        $this->assertSame(0, $db->rollbacks);
+        $this->assertCount(2, $db->updates);
+        $this->assertStringNotContainsString('WHERE `UNI`', $db->updates[0]['sql']);
+        $this->assertStringContainsString('`game_name`', $db->updates[0]['sql']);
+        $this->assertStringContainsString('WHERE `UNI` = :universe', $db->updates[1]['sql']);
+        $this->assertStringContainsString('`game_speed`', $db->updates[1]['sql']);
+        $this->assertSame('HiveNova', $uni2->game_name);
+        $this->assertSame(2, $uni2->game_speed);
+    }
+
+    public function testSaveMixedKeysRollsBackWhenSecondUpdateFails(): void
+    {
+        $db = new ConfigRecordingDatabase();
+        $db->failOnUpdate = 2;
+        Database::setInstance($db);
+
+        $uni1 = new Config(['uni' => 1, 'game_speed' => 1, 'game_name' => 'Old']);
+        Config::setInstance($uni1, 1);
+
+        $uni1->game_name = 'HiveNova';
+        $uni1->game_speed = 9;
+
+        $this->expectException(RuntimeException::class);
+        try {
+            $uni1->save();
+        } finally {
+            $this->assertSame(1, $db->begins);
+            $this->assertSame(0, $db->commits);
+            $this->assertSame(1, $db->rollbacks);
+        }
+    }
+
+    public function testSaveWithNoGlobalSaveScopesGlobalKeyToCurrentUniverse(): void
+    {
+        $db = new ConfigRecordingDatabase();
+        Database::setInstance($db);
+
+        $uni1 = new Config(['uni' => 1, 'game_name' => 'Old']);
+        $uni2 = new Config(['uni' => 2, 'game_name' => 'Old']);
+        Config::setInstance($uni1, 1);
+        Config::setInstance($uni2, 2);
+
+        $uni1->game_name = 'LocalOnly';
+        $this->assertTrue($uni1->save(['noGlobalSave' => true]));
+
+        $this->assertCount(1, $db->updates);
+        $this->assertStringContainsString('WHERE `UNI` = :universe', $db->updates[0]['sql']);
+        $this->assertSame(1, $db->updates[0]['params'][':universe']);
+        $this->assertSame('LocalOnly', $uni1->game_name);
+        $this->assertSame('Old', $uni2->game_name);
+    }
+
+    public function testSaveGlobalKeyWithSingleUniverseDoesNotError(): void
+    {
+        $db = new ConfigRecordingDatabase();
+        Database::setInstance($db);
+
+        $uni1 = new Config(['uni' => 1, 'game_name' => 'Old']);
+        Config::setInstance($uni1, 1);
+
+        $uni1->game_name = 'Solo';
+        $this->assertTrue($uni1->save());
+
+        $this->assertCount(1, $db->updates);
+        $this->assertStringNotContainsString('WHERE `UNI`', $db->updates[0]['sql']);
+        $this->assertSame('Solo', $uni1->game_name);
+    }
+}
+
+class ConfigRecordingDatabase implements DatabaseInterface
+{
+    /** @var list<array{sql: string, params: array<string, mixed>}> */
+    public array $updates = [];
+
+    public int $begins = 0;
+
+    public int $commits = 0;
+
+    public int $rollbacks = 0;
+
+    public ?int $failOnUpdate = null;
+
+    public function select($qry, array $params = array())
+    {
+        return [];
+    }
+
+    public function selectSingle($qry, array $params = array(), $field = false)
+    {
+        return false;
+    }
+
+    public function insert($qry, array $params = array())
+    {
+        return true;
+    }
+
+    public function update($qry, array $params = array())
+    {
+        if ($this->failOnUpdate !== null && count($this->updates) + 1 === $this->failOnUpdate) {
+            throw new RuntimeException('update failed');
+        }
+        $this->updates[] = ['sql' => $qry, 'params' => $params];
+        return true;
+    }
+
+    public function delete($qry, array $params = array())
+    {
+        return true;
+    }
+
+    public function replace($qry, array $params = array())
+    {
+        return true;
+    }
+
+    public function query($qry)
+    {
+        return true;
+    }
+
+    public function nativeQuery($qry)
+    {
+        return [];
+    }
+
+    public function lastInsertId()
+    {
+        return 0;
+    }
+
+    public function rowCount()
+    {
+        return 0;
+    }
+
+    public function getQueryCounter()
+    {
+        return count($this->updates);
+    }
+
+    public function quote($str)
+    {
+        return "'" . $str . "'";
+    }
+
+    public function disconnect()
+    {
+    }
+
+    public function beginTransaction(): void
+    {
+        $this->begins++;
+    }
+
+    public function commit(): void
+    {
+        $this->commits++;
+    }
+
+    public function rollback(): void
+    {
+        $this->rollbacks++;
     }
 }


### PR DESCRIPTION
## Summary
- Replaces nested per-universe `Config::save()` fan-out with a bulk `UPDATE` of global keys on all `%%CONFIG%%` rows, plus a scoped update for universe-local keys.
- Fixes the existing bug where `Config::get()` without a universe id rewrote only the current universe, so global settings never reached other unis.
- Mixed saves wrap both updates in a transaction; other in-memory `Config` instances are synced without nested saves.

Closes #158

## Test plan
- [x] `./vendor/bin/phpunit tests/Unit/ConfigTest.php`
- [ ] Save a global admin setting (e.g. game name) with two universes and confirm both rows update
- [ ] Save a universe-local setting (e.g. game speed) and confirm only that universe changes