### PR TITLE
Fix achievements crash, fleet coords, and install skip-all SQL errors

### DIFF
--- a/includes/classes/DiscordWebhookService.php
+++ b/includes/classes/DiscordWebhookService.php
@@ -10,8 +10,8 @@ class DiscordWebhookService
 {
 	private const USER_AGENT = 'DiscordBot (https://github.com/Hive-Pizza-Team/HiveNova, 1.0)';
 	private const USERNAME = 'HiveNova';
-	private const CONNECT_TIMEOUT = 2;
-	private const TIMEOUT = 3;
+	private const CONNECT_TIMEOUT = 1;
+	private const TIMEOUT = 1;
 
 	private const MISSION_NAMES = [
 		1  => 'Attack',

--- a/includes/classes/FleetFunctions.php
+++ b/includes/classes/FleetFunctions.php
@@ -445,6 +445,7 @@ class FleetFunctions
 
 	public static function GetAvailableMissions($USER, $MissionInfo, $GetInfoPlanet)
 	{
+		$GetInfoPlanet			= is_array($GetInfoPlanet) ? $GetInfoPlanet : array();
 		$YourPlanet				= (!empty($GetInfoPlanet['id_owner']) && $GetInfoPlanet['id_owner'] == $USER['id']) ? true : false;
 		$UsedPlanet				= (!empty($GetInfoPlanet['id_owner'])) ? true : false;
 		$availableMissions		= array();
@@ -696,24 +697,6 @@ class FleetFunctions
 		fleet_target_obj			= :missileTarget,
 		start_time					= :timestamp;';
 
-		if ($fleetTargetOwner > 0 && $fleetStartOwner != $fleetTargetOwner && in_array($fleetMission, [1, 2, 6, 9, 10], true)) {
-			PushNotificationService::notifyIncomingHostileFleet(
-				$fleetTargetOwner,
-				$fleetMission,
-				$fleetTargetPlanetGalaxy,
-				$fleetTargetPlanetSystem,
-				$fleetTargetPlanetPlanet
-			);
-			DiscordWebhookService::notifyIncomingHostile(
-				(int) $fleetTargetOwner,
-				(int) $fleetMission,
-				(int) $fleetTargetPlanetGalaxy,
-				(int) $fleetTargetPlanetSystem,
-				(int) $fleetTargetPlanetPlanet,
-				(int) $fleetTargetPlanetType
-			);
-		}
-
 		$db->insert($sql, array(
 			':fleetId'					=> $fleetId,
 			':fleetStartOwner'			=> $fleetStartOwner,
@@ -752,6 +735,24 @@ class FleetFunctions
 			(int) $fleetTargetPlanetType,
 			(int) $fleetMission
 		);
+
+		if ($fleetTargetOwner > 0 && $fleetStartOwner != $fleetTargetOwner && in_array($fleetMission, [1, 2, 6, 9, 10], true)) {
+			PushNotificationService::notifyIncomingHostileFleet(
+				$fleetTargetOwner,
+				$fleetMission,
+				$fleetTargetPlanetGalaxy,
+				$fleetTargetPlanetSystem,
+				$fleetTargetPlanetPlanet
+			);
+			DiscordWebhookService::notifyIncomingHostile(
+				(int) $fleetTargetOwner,
+				(int) $fleetMission,
+				(int) $fleetTargetPlanetGalaxy,
+				(int) $fleetTargetPlanetSystem,
+				(int) $fleetTargetPlanetPlanet,
+				(int) $fleetTargetPlanetType
+			);
+		}
 
 		return $fleetId;
 	}

--- a/includes/classes/HiveUtil.php
+++ b/includes/classes/HiveUtil.php
@@ -13,7 +13,7 @@ class HiveUtil
 {
 	static public function getRpcNodes(): array
 	{
-		return HIVE_RPC_NODES;
+		return \HIVE_RPC_NODES;
 	}
 
 	static public function isRpcError(mixed $result): bool
@@ -25,13 +25,23 @@ class HiveUtil
 		return array_key_exists('code', $result) && array_key_exists('message', $result);
 	}
 
-	static public function rpcCall(string $method, string $params): mixed
+	static public function rpcNodesToTry(?int $maxNodes = null): array
 	{
-		foreach (HiveUtil::getRpcNodes() as $rpcNode) {
+		$nodes = self::getRpcNodes();
+		if ($maxNodes === null) {
+			return $nodes;
+		}
+
+		return array_slice($nodes, 0, max(1, $maxNodes));
+	}
+
+	static public function rpcCall(string $method, string $params, ?int $maxNodes = null): mixed
+	{
+		foreach (HiveUtil::rpcNodesToTry($maxNodes) as $rpcNode) {
 			try {
 				$hive = new Hive([
 					'rpcNodes' => [$rpcNode],
-					'timeout'  => HIVE_RPC_TIMEOUT,
+					'timeout'  => \HIVE_RPC_TIMEOUT,
 				]);
 				$result = $hive->call($method, $params);
 			} catch (\Throwable $e) {
@@ -136,7 +146,7 @@ class HiveUtil
 			return '';
 		}
 
-		$result = HiveUtil::rpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]');
+		$result = HiveUtil::rpcCall('condenser_api.get_accounts', '[["'.$hiveaccount.'"]]', 3);
 		if (!is_array($result) || !isset($result[0])) {
 			return '';
 		}

--- a/includes/classes/Migrator.php
+++ b/includes/classes/Migrator.php
@@ -79,8 +79,8 @@ class Migrator
     }
 
     /**
-     * Applies a single SQL migration. Individual query errors are logged and skipped
-     * (mirrors web-runner behaviour for ALTER TABLE IF NOT EXISTS scenarios).
+     * Applies a single SQL migration. Idempotent schema errors (duplicate column/table/key)
+     * are logged and skipped. Other SQL errors abort the migration.
      */
     public function applySqlMigration(array $migration): void
     {
@@ -91,9 +91,22 @@ class Migrator
             try {
                 $this->pdo->exec($query);
             } catch (PDOException $e) {
+                if (!self::isIgnorableSqlError($e)) {
+                    throw $e;
+                }
                 error_log("Migration [{$migration['filename']}] query skipped: " . $e->getMessage());
             }
         }
+    }
+
+    public static function isIgnorableSqlError(PDOException $e): bool
+    {
+        $message = $e->getMessage();
+
+        return (bool) preg_match(
+            '/duplicate (column|entry|key)|duplicate column name|already exists|check that column\/key exists/i',
+            $message
+        );
     }
 
     /**

--- a/includes/classes/repository/MessageRepository.php
+++ b/includes/classes/repository/MessageRepository.php
@@ -20,6 +20,16 @@ class MessageRepository
             return ['sql' => '', 'params' => []];
         }
 
+        if ($category === 100) {
+            return [
+                'sql'    => ' AND (message_text LIKE :lostNeedle OR message_text LIKE :lostNeedleSpy)',
+                'params' => [
+                    ':lostNeedle'    => '%raportLose%',
+                    ':lostNeedleSpy' => '%spyReportLost%',
+                ],
+            ];
+        }
+
         $pattern = match ($category) {
             0 => '%spyReportLost%',
             3, 15 => '%raportLose%',

--- a/includes/pages/game/ShowAchievementsPage.php
+++ b/includes/pages/game/ShowAchievementsPage.php
@@ -60,6 +60,7 @@ class ShowAchievementsPage extends AbstractGamePage
             'unlockedCount'          => $unlockedCount,
             'totalCount'             => count($achievements),
             'pointsTotal'            => $pointsTotal,
+            'darkmatterName'         => $LNG['tech'][921] ?? '',
         ]);
 
         $this->display('page.achievements.default.tpl');

--- a/includes/pages/game/ShowFleetStep2Page.php
+++ b/includes/pages/game/ShowFleetStep2Page.php
@@ -51,6 +51,14 @@ class ShowFleetStep2Page extends AbstractGamePage
 			FleetFunctions::GotoFleetPage();
 		}
 
+		if (!FleetFunctions::HasCompleteTargetCoords($targetGalaxy, $targetSystem, $targetPlanet))
+		{
+			$this->printMessage($LNG['fl_incomplete_coords'], array(array(
+				'label'	=> $LNG['sys_back'],
+				'url'	=> 'game.php?page=fleetTable'
+			)));
+		}
+
 		$fleetArray    				= $_SESSION['fleet'][$token]['fleet'];
 
 		$db = Database::get();
@@ -61,8 +69,11 @@ class ShowFleetStep2Page extends AbstractGamePage
 			':targetSystem' => $targetSystem,
 			':targetPlanet' => $targetPlanet
 		));
+		if (!is_array($targetPlanetData)) {
+			$targetPlanetData = array();
+		}
 
-		if($targetType == 2 && $targetPlanetData['der_metal'] == 0 && $targetPlanetData['der_crystal'] == 0)
+		if($targetType == 2 && ($targetPlanetData['der_metal'] ?? 0) == 0 && ($targetPlanetData['der_crystal'] ?? 0) == 0)
 		{
 			$this->printMessage($LNG['fl_error_empty_derbis'], array(array(
 				'label'	=> $LNG['sys_back'],

--- a/includes/pages/game/ShowFleetStep3Page.php
+++ b/includes/pages/game/ShowFleetStep3Page.php
@@ -87,6 +87,10 @@ class ShowFleetStep3Page extends AbstractGamePage
 		$fleetSpeed   = $formData['fleetSpeed'];
 		$ownPlanet    = $formData['ownPlanet'];
 
+		if (!FleetFunctions::HasCompleteTargetCoords($targetGalaxy, $targetSystem, $targetPlanet)) {
+			FleetFunctions::GotoFleetPage(0);
+		}
+
 		if ($ownPlanet != $PLANET['id']) {
 			$this->printMessage($LNG['fl_own_planet_error'], array(array(
 				'label' => $LNG['sys_back'],

--- a/styles/templates/game/page.achievements.default.tpl
+++ b/styles/templates/game/page.achievements.default.tpl
@@ -32,7 +32,7 @@
 				</td>
 				<td>
 					{if $ach.reward_type != 'none' && $ach.reward_amount > 0}
-						{$ach.reward_amount|number} {$LNG.tech.921}
+						{$ach.reward_amount|number} {$darkmatterName}
 					{else}
 						&mdash;
 					{/if}

--- a/tests/Unit/FleetFunctionsDatabaseTest.php
+++ b/tests/Unit/FleetFunctionsDatabaseTest.php
@@ -268,6 +268,20 @@ class FleetFunctionsDatabaseTest extends TestCase
         $this->assertNotContains(7, $missions);
     }
 
+    public function testGetAvailableMissionsAcceptsMissingPlanetRow(): void
+    {
+        $user = ['id' => 1, 'universe' => 1];
+        $misInfo = [
+            'planet' => 8,
+            'planettype' => 1,
+            'Ship' => [208 => 1],
+        ];
+
+        $missions = FleetFunctions::GetAvailableMissions($user, $misInfo, false);
+
+        $this->assertContains(7, $missions);
+    }
+
     public function testGetAvailableMissionsIncludesSpyWithOnlyProbe(): void
     {
         $user = ['id' => 1, 'universe' => 1];

--- a/tests/Unit/HiveUtilTest.php
+++ b/tests/Unit/HiveUtilTest.php
@@ -115,4 +115,22 @@ class HiveUtilTest extends TestCase
     {
         $this->assertSame('', HiveUtil::getAccountAbout('Not Valid!'));
     }
+
+    public function testRpcNodesToTryCapsRetryBudget(): void
+    {
+        if (!defined('HIVE_RPC_NODES')) {
+            define('HIVE_RPC_NODES', [
+                'https://a.example',
+                'https://b.example',
+                'https://c.example',
+                'https://d.example',
+            ]);
+        }
+
+        $all = HiveUtil::getRpcNodes();
+        $this->assertGreaterThan(3, count($all));
+        $this->assertSame(array_slice($all, 0, 3), HiveUtil::rpcNodesToTry(3));
+        $this->assertSame($all, HiveUtil::rpcNodesToTry(null));
+        $this->assertCount(1, HiveUtil::rpcNodesToTry(0));
+    }
 }

--- a/tests/Unit/MessageRepositoryTest.php
+++ b/tests/Unit/MessageRepositoryTest.php
@@ -64,6 +64,15 @@ class MessageRepositoryTest extends TestCase
         $this->assertSame('%spyReportLost%', $clause['params'][':lostNeedle']);
     }
 
+    public function testLostFilterClauseMatchesAllInboxLostReports(): void
+    {
+        $clause = MessageRepository::lostFilterClause(100, 'lost');
+        $this->assertStringContainsString('message_text LIKE :lostNeedle', $clause['sql']);
+        $this->assertStringContainsString('message_text LIKE :lostNeedleSpy', $clause['sql']);
+        $this->assertSame('%raportLose%', $clause['params'][':lostNeedle']);
+        $this->assertSame('%spyReportLost%', $clause['params'][':lostNeedleSpy']);
+    }
+
     public function testLostFilterClauseIgnoredForOtherCategories(): void
     {
         $clause = MessageRepository::lostFilterClause(1, 'lost');
@@ -90,11 +99,12 @@ class MessageRepositoryTest extends TestCase
         $this->assertStringNotContainsString('lostNeedle', $this->lastSelectSingle['sql']);
     }
 
-    public function testCountMessagesAllInboxDoesNotAddLostNeedle(): void
+    public function testCountMessagesAllInboxAppliesLostFilter(): void
     {
         $this->stubDatabase();
         MessageRepository::countMessages(9, 100, false, 'lost');
-        $this->assertArrayNotHasKey(':lostNeedle', $this->lastSelectSingle['params']);
+        $this->assertSame('%raportLose%', $this->lastSelectSingle['params'][':lostNeedle']);
+        $this->assertSame('%spyReportLost%', $this->lastSelectSingle['params'][':lostNeedleSpy']);
     }
 
     public function testGetMessagesPagedAppliesLostFilterForSpy(): void
@@ -108,11 +118,13 @@ class MessageRepositoryTest extends TestCase
         $this->assertSame(10, $this->lastSelect['params'][':limit']);
     }
 
-    public function testGetMessagesPagedAllCategoryHasNoLostNeedle(): void
+    public function testGetMessagesPagedAllCategoryAppliesLostFilter(): void
     {
         $this->stubDatabase();
         MessageRepository::getMessagesPaged(9, 100, 5, 10, 'lost');
-        $this->assertArrayNotHasKey(':lostNeedle', $this->lastSelect['params']);
+        $this->assertSame('%raportLose%', $this->lastSelect['params'][':lostNeedle']);
+        $this->assertSame('%spyReportLost%', $this->lastSelect['params'][':lostNeedleSpy']);
+        $this->assertSame(5, $this->lastSelect['params'][':offset']);
     }
 
     public function testGetMessagesPagedOutboxIgnoresLostFilter(): void

--- a/tests/Unit/MigratorTest.php
+++ b/tests/Unit/MigratorTest.php
@@ -217,25 +217,39 @@ class MigratorTest extends TestCase
         $migrator->applySqlMigration($migration);
     }
 
-    public function testApplySqlMigrationContinuesOnQueryError(): void
+    public function testApplySqlMigrationSkipsDuplicateSchemaErrors(): void
     {
-        $sql = "BAD QUERY;\nGOOD QUERY;\n";
+        $sql = "ALTER TABLE foo ADD COLUMN bar INT;\nGOOD QUERY;\n";
         $this->addMigration(1, $sql);
 
         $pdo = $this->mockPdo();
         $pdo->expects($this->exactly(2))
             ->method('exec')
             ->willReturnOnConsecutiveCalls(
-                $this->throwException(new PDOException('syntax error')),
+                $this->throwException(new PDOException('Duplicate column name \'bar\'')),
                 1
             );
 
         $migrator  = $this->makeMigrator($pdo);
         $migration = $migrator->getPendingMigrations(0)[0];
-
-        // Must not throw — errors are logged and skipped
         $migrator->applySqlMigration($migration);
         $this->addToAssertionCount(1);
+    }
+
+    public function testApplySqlMigrationRethrowsUnexpectedSqlErrors(): void
+    {
+        $sql = "BAD QUERY;\n";
+        $this->addMigration(1, $sql);
+
+        $pdo = $this->mockPdo();
+        $pdo->method('exec')->willThrowException(new PDOException('syntax error'));
+
+        $migrator  = $this->makeMigrator($pdo);
+        $migration = $migrator->getPendingMigrations(0)[0];
+
+        $this->expectException(PDOException::class);
+        $this->expectExceptionMessage('syntax error');
+        $migrator->applySqlMigration($migration);
     }
 
     // -----------------------------------------------------------------------

--- a/tests/smoke.php
+++ b/tests/smoke.php
@@ -62,6 +62,7 @@ $pages = [
     'ticket',
     'phalanx',
     'viz',
+    'achievements',
 ];
 
 $pass = 0;


### PR DESCRIPTION
## Summary
- Fix the achievements page fatal (`{$LNG.tech.921}` / array offset) and include it in smoke.
- Reject incomplete fleet coordinates on steps 2–3 and tolerate a missing planet row in mission selection.
- Persist fleet rows before Discord notify (1s curl cap), cap Hive profile RPC retries, apply lost-message filter on the all-inbox tab, and only ignore idempotent SQL errors in the migrator.

## Test plan
- [ ] Open `game.php?page=achievements` — page renders, dark matter reward labels show.
- [ ] Fleet step 2 with galaxy/system/planet 0 — incomplete-coords message, no PHP warning.
- [ ] Messages “lost” filter on All tab lists combat/spy losses.
- [ ] `php vendor/bin/phpunit tests/Unit/MigratorTest.php tests/Unit/MessageRepositoryTest.php tests/Unit/HiveUtilTest.php tests/Unit/FleetFunctionsDatabaseTest.php --no-coverage`
- [ ] `php tests/smoke.php` (includes achievements)