### PR TITLE
Fix player card crash, galaxy fleet leak, and marketplace cargo

### DIFF
--- a/includes/classes/AchievementService.php
+++ b/includes/classes/AchievementService.php
@@ -565,6 +565,20 @@ class AchievementService
     }
 
     /**
+     * Normalize admin-edited trigger JSON. Returns null when the paste is not a JSON object/array.
+     */
+    public static function sanitizeTriggerParams(string $raw): ?string
+    {
+        $decoded = json_decode($raw, true);
+        if (!is_array($decoded)) {
+            return null;
+        }
+
+        $encoded = json_encode($decoded, JSON_UNESCAPED_UNICODE);
+        return is_string($encoded) ? $encoded : null;
+    }
+
+    /**
      * @return array<string, mixed>
      */
     private function decodeParams(string $json): array

--- a/includes/classes/GalaxyRows.php
+++ b/includes/classes/GalaxyRows.php
@@ -513,7 +513,7 @@ class GalaxyRows
 			'system'    => (int) $this->galaxyRow['system'],
 			'planet'    => (int) $this->galaxyRow['planet'],
 			'buildings' => $shareIntel ? $this->buildCountMap($reslist['build'], $inventoryRow) : new \stdClass(),
-			'fleet'     => $shareIntel ? $this->buildCountMap($reslist['fleet'], $inventoryRow) : new \stdClass(),
+			'fleet'     => ($shareIntel && !$galaxyPreview) ? $this->buildCountMap($reslist['fleet'], $inventoryRow) : new \stdClass(),
 			'defense'   => ($shareIntel && !$galaxyPreview) ? $this->buildCountMap($reslist['defense'], $inventoryRow) : new \stdClass(),
 			'queue'     => array(
 				'building' => 0,

--- a/includes/classes/MarketPlaceResource.php
+++ b/includes/classes/MarketPlaceResource.php
@@ -2,6 +2,8 @@
 
 namespace HiveNova\Core;
 
+use HiveNova\Core\LeftoverBonus;
+
 /**
  * Maps marketplace ex_resource_type (1–3) onto tech IDs 901–903.
  */
@@ -46,5 +48,16 @@ class MarketPlaceResource
 	{
 		$limit = $requested ?? MARKET_TRADE_HISTORY_LIMIT;
 		return max(1, min(200, $limit));
+	}
+
+	/**
+	 * Per-ship cargo used when sizing a market pickup fleet.
+	 * Matches FleetFunctions::GetFleetRoom (leftover hyperspace cargo × storage factor).
+	 *
+	 * @param array<string, mixed> $player
+	 */
+	public static function shipHaulCapacity(int $shipId, array $player, float $storageFactor): float
+	{
+		return LeftoverBonus::shipCapacity($shipId, 1, $player) * $storageFactor;
 	}
 }

--- a/includes/pages/adm/ShowAchievementsPage.php
+++ b/includes/pages/adm/ShowAchievementsPage.php
@@ -30,30 +30,35 @@ function ShowAchievementsPage()
 
     if ($_SERVER['REQUEST_METHOD'] === 'POST' && HTTP::_GP('save', 0)) {
         $id = HTTP::_GP('id', 0);
-        $db->update(
-            'UPDATE %%ACHIEVEMENTS%% SET
-            active = :active,
-            hidden = :hidden,
-            reward_type = :rewardType,
-            reward_amount = :rewardAmount,
-            celebration_tier = :tier,
-            trigger_params = :params
-            WHERE id = :id AND universe = :universe;',
-            [
-                ':active'       => HTTP::_GP('active', 0) ? 1 : 0,
-                ':hidden'       => HTTP::_GP('hidden', 0) ? 1 : 0,
-                ':rewardType'   => HTTP::_GP('reward_type', 'none'),
-                ':rewardAmount' => HTTP::_GP('reward_amount', 0),
-                ':tier'         => HTTP::_GP('celebration_tier', 'normal'),
-                ':params'       => HTTP::_GP('trigger_params', '{}'),
-                ':id'           => $id,
-                ':universe'     => $universe,
-            ]
-        );
-        AchievementService::get()->clearDefinitionCache();
-        AchievementService::get()->loadDefinitions($universe);
-        if (empty($message)) {
-            $message = 'Achievement saved.';
+        $params = AchievementService::sanitizeTriggerParams(HTTP::_GP('trigger_params', '{}'));
+        if ($params === null) {
+            $message = 'Achievement not saved: trigger params must be valid JSON.';
+        } else {
+            $db->update(
+                'UPDATE %%ACHIEVEMENTS%% SET
+                active = :active,
+                hidden = :hidden,
+                reward_type = :rewardType,
+                reward_amount = :rewardAmount,
+                celebration_tier = :tier,
+                trigger_params = :params
+                WHERE id = :id AND universe = :universe;',
+                [
+                    ':active'       => HTTP::_GP('active', 0) ? 1 : 0,
+                    ':hidden'       => HTTP::_GP('hidden', 0) ? 1 : 0,
+                    ':rewardType'   => HTTP::_GP('reward_type', 'none'),
+                    ':rewardAmount' => HTTP::_GP('reward_amount', 0),
+                    ':tier'         => HTTP::_GP('celebration_tier', 'normal'),
+                    ':params'       => $params,
+                    ':id'           => $id,
+                    ':universe'     => $universe,
+                ]
+            );
+            AchievementService::get()->clearDefinitionCache();
+            AchievementService::get()->loadDefinitions($universe);
+            if (empty($message)) {
+                $message = 'Achievement saved.';
+            }
         }
     }
 

--- a/includes/pages/game/ShowMarketPlacePage.php
+++ b/includes/pages/game/ShowMarketPlacePage.php
@@ -185,16 +185,16 @@ class ShowMarketPlacePage extends AbstractGamePage
 		$F1type = 0;
 		//PRIO for LC
 		if($shipType == 1) {
-			$F1capacity = $pricelist[202]['capacity'] * $factor;
+			$F1capacity = MarketPlaceResource::shipHaulCapacity(202, $USER, $factor);
 			$F1type = 202;
 		}
 		// PRIO for HC
 		else {
-			$F1capacity = $pricelist[203]['capacity'] * $factor;
+			$F1capacity = MarketPlaceResource::shipHaulCapacity(203, $USER, $factor);
 			$F1type = 203;
 		}
 
-		$F1 = min($PLANET[$resource[$F1type]], ceil($amount / $F1capacity));
+		$F1 = min($PLANET[$resource[$F1type]], ceil($amount / max($F1capacity, 1)));
 
 			//taken
 		$amountTMP = $amount - $F1 * $F1capacity;
@@ -205,15 +205,15 @@ class ShowMarketPlacePage extends AbstractGamePage
 		if ($amountTMP > 0) {
 			//We need HC
 			if($shipType == 1) {
-				$F2capacity = $pricelist[203]['capacity'] * $factor;
+				$F2capacity = MarketPlaceResource::shipHaulCapacity(203, $USER, $factor);
 				$F2type = 203;
 			}
 			//We need LC
 			else{
-				$F2capacity = $pricelist[202]['capacity'] * $factor;
+				$F2capacity = MarketPlaceResource::shipHaulCapacity(202, $USER, $factor);
 				$F2type = 202;
 			}
-			$F2 = min($PLANET[$resource[$F2type]], ceil($amountTMP / $F2capacity));
+			$F2 = min($PLANET[$resource[$F2type]], ceil($amountTMP / max($F2capacity, 1)));
 			$amountTMP -= $F2 * $F2capacity;
 		}
 		//------------------------------------------------------------------------

--- a/includes/pages/game/ShowPlayerCardPage.php
+++ b/includes/pages/game/ShowPlayerCardPage.php
@@ -60,6 +60,10 @@ class ShowPlayerCardPage extends AbstractGamePage
 			':playerID'	=> $PlayerID
 		));
 
+		if (!is_array($query)) {
+			$this->printMessage($LNG['page_doesnt_exist']);
+		}
+
 		$totalfights = $query['wons'] + $query['loos'] + $query['draws'];
 		
 		if ($totalfights == 0) {

--- a/tests/Unit/AchievementServiceTest.php
+++ b/tests/Unit/AchievementServiceTest.php
@@ -34,6 +34,13 @@ class AchievementServiceTest extends TestCase
         $this->assertSame(['threshold' => 5], $this->invokePrivate($service, 'decodeParams', ['{"threshold":5}']));
     }
 
+    public function testSanitizeTriggerParamsRejectsInvalidJson(): void
+    {
+        $this->assertNull(AchievementService::sanitizeTriggerParams('not-json'));
+        $this->assertNull(AchievementService::sanitizeTriggerParams('"string"'));
+        $this->assertSame('{"threshold":1}', AchievementService::sanitizeTriggerParams('{"threshold":1}'));
+    }
+
     public function testResolveEventValueUsesUserWonsWhenPayloadEmpty(): void
     {
         $service = AchievementService::get();

--- a/tests/Unit/GalaxyRowsVizJsonTest.php
+++ b/tests/Unit/GalaxyRowsVizJsonTest.php
@@ -194,6 +194,33 @@ class GalaxyRowsVizJsonTest extends TestCase
 		$this->assertJsContractValidJson($json);
 	}
 
+	public function testGalaxyPreviewOmitsFleetAndDefenseMaps(): void
+	{
+		$json = $this->invokeBuildPlanetVizJson([
+			'image'          => 'normaltempplanet03',
+			'temp_min'       => 30,
+			'temp_max'       => 70,
+			'diameter'       => 12767,
+			'field_current'  => 42,
+			'field_max'      => 163,
+			'terraformer'    => 0,
+			'metal_mine'     => 10,
+			'light_fighter'  => 4,
+			'rocket_launcher'=> 12,
+			'galaxy'         => 1,
+			'system'         => 88,
+			'planet'         => 7,
+			'der_metal'      => 0,
+			'der_crystal'    => 0,
+		], true, './styles/theme/hive/', true);
+		$payload = $this->decodePayload($json);
+
+		$this->assertSame(10, $payload['buildings'][1]);
+		$this->assertSame([], (array) $payload['fleet']);
+		$this->assertSame([], (array) $payload['defense']);
+		$this->assertJsContractValidJson($json);
+	}
+
 	public function testOtherPlanetPayloadIsSparsePublic(): void
 	{
 		$json = $this->invokeBuildPlanetVizJson([
@@ -438,7 +465,8 @@ class GalaxyRowsVizJsonTest extends TestCase
 		$this->assertIsArray($payload);
 		$this->assertTrue($payload['shareIntel']);
 		$this->assertSame(12, $payload['buildings'][1]);
-		$this->assertSame(3, $payload['fleet'][202]);
+		$this->assertSame([], (array) $payload['fleet']);
+		$this->assertSame([], (array) $payload['defense']);
 	}
 
 	public function testGetColonizeSlotStatusPrefersCapWhenBothBlock(): void

--- a/tests/Unit/MarketPlaceResourceTest.php
+++ b/tests/Unit/MarketPlaceResourceTest.php
@@ -37,4 +37,15 @@ class MarketPlaceResourceTest extends TestCase
         $this->assertSame(200, MarketPlaceResource::historyLimit(999));
         $this->assertSame(25, MarketPlaceResource::historyLimit(25));
     }
+
+    public function testShipHaulCapacityAppliesLeftoverCargoAndStorage(): void
+    {
+        $GLOBALS['pricelist'][217]['capacity'] = 100;
+        $GLOBALS['requirements'][217][114] = 1;
+        $GLOBALS['resource'][114] = 'hyperspace_tech';
+
+        $player = ['hyperspace_tech' => 10, 'factor' => ['ShipStorage' => 0]];
+        $this->assertEqualsWithDelta(110.0, MarketPlaceResource::shipHaulCapacity(217, $player, 1.0), 1e-9);
+        $this->assertEqualsWithDelta(220.0, MarketPlaceResource::shipHaulCapacity(217, $player, 2.0), 1e-9);
+    }
 }

--- a/tests/smoke.php
+++ b/tests/smoke.php
@@ -33,9 +33,9 @@ $pages = [
     'buildings',
     'research',
     'shipyard',
-    'fleet',        // FleetStep1
-    'fleettable',
-    'fleetdealer',
+    'fleetTable',
+    'fleetStep1',
+    'fleetDealer',
     'galaxy',
     'alliance',
     'messages',
@@ -50,13 +50,13 @@ $pages = [
     'trader',
     'officier',
     'techtree',
-    'battlesimulator',
-    'battlehall',
+    'battleSimulator',
+    'battleHall',
     'records',
     'changelog',
     'chat',
-    'buddylist',
-    'banlist',
+    'buddyList',
+    'banList',
     'board',
     'questions',
     'ticket',
@@ -138,6 +138,10 @@ function detectErrors(string $body): array {
     if (stripos($body, 'id="stepintro"') !== false
         || preg_match('/<title>[^<]*Installer/i', $body)) {
         $issues[] = 'Redirected to installer (DB unavailable or upgrade required)';
+    }
+    if (stripos($body, 'This page does not exist') !== false
+        || stripos($body, 'page_doesnt_exist') !== false) {
+        $issues[] = 'Missing page (routing slug does not match a controller)';
     }
     return $issues;
 }
@@ -240,6 +244,23 @@ foreach ($pages as $page) {
     }
 }
 
+echo "[ JSON ] attackAlert        ";
+[$status, $body, $curlErr] = curl_get("$baseUrl/game.php?page=attackAlert&ajax=1", $cookieFile);
+$alert = is_string($body) ? json_decode($body, true) : null;
+if ($curlErr) {
+    echo "FAIL curl error: $curlErr\n";
+    $fail++;
+} elseif ($status >= 400) {
+    echo "FAIL HTTP $status\n";
+    $fail++;
+} elseif (!is_array($alert) || !array_key_exists('count', $alert)) {
+    echo "FAIL expected JSON {count:N}\n";
+    $fail++;
+} else {
+    echo "OK (count=" . (int) $alert['count'] . ")\n";
+    $pass++;
+}
+
 // Extract session ID from cookie jar to supply as ?sid= for CSRF-protected admin pages
 $sid = '';
 foreach (file($cookieFile) ?: [] as $line) {
@@ -292,6 +313,7 @@ $adminPages = [
     'dump',
     'transactions',
     'buildlog',
+    'achievements',
     // skipping: logout (ends session)
 ];
 


### PR DESCRIPTION
## Summary
- Guard player cards when the user row is missing, and omit fleet maps from galaxy preview / planetViz the same way defense already was.
- Size marketplace pickup fleets with leftover hyperspace cargo so haul math matches fleet send.
- Reject invalid admin achievement `trigger_params` JSON instead of treating it as an empty object (threshold 1).
- Smoke uses real camelCase page slugs, flags missing controllers, and checks attack-alert JSON.

Follow-up to #250.

## Test plan
- [ ] Open a player card with a bogus `id` and confirm a missing-page message instead of a PHP error
- [ ] As a buddy/ally, hover galaxy and load planetViz — buildings may show, fleet/defense maps stay empty
- [ ] Buy a marketplace offer and confirm LC/HC counts match leftover cargo, not raw pricelist capacity
- [ ] In admin achievements, save invalid trigger JSON and confirm it is not written
- [ ] `php vendor/bin/phpunit tests/Unit/GalaxyRowsVizJsonTest.php tests/Unit/MarketPlaceResourceTest.php tests/Unit/AchievementServiceTest.php`
- [ ] `php tests/smoke.php` against a local instance