### PR TITLE
Fix missing-row crashes, planetViz intel leak, and leftover ship info

### DIFF
--- a/includes/GeneralFunctions.php
+++ b/includes/GeneralFunctions.php
@@ -392,6 +392,24 @@ function makebr($text)
 	return (version_compare(PHP_VERSION, "5.3.0", ">=")) ? nl2br((string) $text, false) : strtr($text, array("\r\n" => $BR, "\r" => $BR, "\n" => $BR));
 }
 
+function mergeUserStatPoints(array &$user): void
+{
+	$row = \HiveNova\Core\Database::get()->selectSingle(
+		'SELECT total_points FROM %%STATPOINTS%% WHERE id_owner = :userId AND stat_type = :statType',
+		[
+			':userId'   => $user['id'] ?? 0,
+			':statType' => 1,
+		]
+	);
+
+	if (is_array($row)) {
+		$user += $row;
+		return;
+	}
+
+	$user['total_points'] = $user['total_points'] ?? 0;
+}
+
 function CheckNoobProtec($OwnerPlayer, $TargetPlayer, $Player)
 {
 	$config	= \HiveNova\Core\Config::get();

--- a/includes/classes/FleetDispatchService.php
+++ b/includes/classes/FleetDispatchService.php
@@ -224,8 +224,7 @@ class FleetDispatchService
                 throw new \RuntimeException($LNG['fl_admin_attack']);
             }
 
-            $sql = 'SELECT total_points FROM %%STATPOINTS%% WHERE id_owner = :userId AND stat_type = :statType';
-            $USER += Database::get()->selectSingle($sql, [':userId' => $USER['id'], ':statType' => 1]);
+            mergeUserStatPoints($USER);
 
             $IsNoobProtec = CheckNoobProtec($USER, $targetPlayerData, $targetPlayerData);
 
@@ -351,6 +350,10 @@ class FleetDispatchService
                 [':id' => $PLANET['id']]
             );
             $deutNeeded = $fleetResource[903] + $consumption;
+            if (!is_array($lockedPlanet)) {
+                $db->rollback();
+                throw new \RuntimeException($LNG['fl_not_enough_resource']);
+            }
             if ($lockedPlanet[$resource[901]] < $fleetResource[901] ||
                 $lockedPlanet[$resource[902]] < $fleetResource[902] ||
                 $lockedPlanet[$resource[903]] < $deutNeeded) {

--- a/includes/classes/GalaxyRows.php
+++ b/includes/classes/GalaxyRows.php
@@ -491,7 +491,7 @@ class GalaxyRows
 
 		$debrisTotal = (int) $this->galaxyRow['der_metal'] + (int) $this->galaxyRow['der_crystal'];
 		$debris = null;
-		if ($debrisTotal > 0) {
+		if ($shareIntel && $debrisTotal > 0) {
 			$debris = array(
 				'metal'   => (int) $this->galaxyRow['der_metal'],
 				'crystal' => (int) $this->galaxyRow['der_crystal'],
@@ -502,9 +502,9 @@ class GalaxyRows
 			'shareIntel' => (bool) $shareIntel,
 			'texture'   => $this->galaxyRow['image'],
 			'type'      => 1,
-			'tempMin'   => (int) $this->galaxyRow['temp_min'],
-			'tempMax'   => (int) $this->galaxyRow['temp_max'],
-			'diameter'  => (int) $this->galaxyRow['diameter'],
+			'tempMin'   => $shareIntel ? (int) $this->galaxyRow['temp_min'] : 0,
+			'tempMax'   => $shareIntel ? (int) $this->galaxyRow['temp_max'] : 0,
+			'diameter'  => $shareIntel ? (int) $this->galaxyRow['diameter'] : 0,
 			'fields'    => array(
 				'current' => $fieldsCurrent,
 				'max'     => $fieldsMax,
@@ -542,9 +542,9 @@ class GalaxyRows
 			'shareIntel' => (bool) $shareIntel,
 			'texture'   => 'mond',
 			'type'      => 3,
-			'tempMin'   => $tempMin,
-			'tempMax'   => $tempMax,
-			'diameter'  => (int) $this->galaxyRow['m_diameter'],
+			'tempMin'   => $shareIntel ? $tempMin : 0,
+			'tempMax'   => $shareIntel ? $tempMax : 0,
+			'diameter'  => $shareIntel ? (int) $this->galaxyRow['m_diameter'] : 0,
 			'fields'    => array(
 				'current' => 0,
 				'max'     => 1,

--- a/includes/pages/game/ShowAlliancePage.php
+++ b/includes/pages/game/ShowAlliancePage.php
@@ -608,10 +608,7 @@ class ShowAlliancePage extends AbstractGamePage
 		));
 
 		try {
-			$USER    += $db->selectSingle('SELECT total_points FROM %%STATPOINTS%% WHERE id_owner = :userId AND stat_type = :statType', array(
-				':userId'    => $USER['id'],
-				':statType'    => 1
-			));
+			mergeUserStatPoints($USER);
 		} catch (Exception) {
 			$USER['total_points'] = 0;
 		}
@@ -1336,10 +1333,7 @@ class ShowAlliancePage extends AbstractGamePage
 		$memberList	= array();
 
 		try {
-			$USER    += $db->selectSingle('SELECT total_points FROM %%STATPOINTS%% WHERE id_owner = :userId AND stat_type = :statType', array(
-				':userId'    => $USER['id'],
-				':statType'    => 1
-			));
+			mergeUserStatPoints($USER);
 		} catch (Exception) {
 			$USER['total_points'] = 0;
 		}

--- a/includes/pages/game/ShowBuddyListPage.php
+++ b/includes/pages/game/ShowBuddyListPage.php
@@ -53,10 +53,14 @@ class ShowBuddyListPage extends AbstractGamePage
 
 		$db = Database::get();
 
-		$sql = "SELECT username, galaxy, `system`, planet FROM %%USERS%% WHERE id = :friendID;";
+        $sql = "SELECT username, galaxy, `system`, planet FROM %%USERS%% WHERE id = :friendID;";
         $userData = $db->selectSingle($sql, array(
             ':friendID'  => $id
         ));
+
+		if (!is_array($userData)) {
+			$this->printMessage($LNG['page_doesnt_exist']);
+		}
 
 		$this->assign(array(
 			'username'	=> $userData['username'],

--- a/includes/pages/game/ShowFleetAjaxPage.php
+++ b/includes/pages/game/ShowFleetAjaxPage.php
@@ -167,14 +167,8 @@ class ShowFleetAjaxPage extends AbstractGamePage
 			if (IsVacationMode($targetData)) {
 				$this->sendData(605, $LNG['fa_vacation_mode']);
 			}
-			$sql	= 'SELECT total_points
-			FROM %%STATPOINTS%%
-			WHERE id_owner = :userId AND stat_type = :statType';
 
-			$USER	+= Database::get()->selectSingle($sql, array(
-				':userId'	=> $USER['id'],
-				':statType'	=> 1
-			));
+			mergeUserStatPoints($USER);
 
 			$IsNoobProtec	= CheckNoobProtec($USER, $targetData, $targetData);
 

--- a/includes/pages/game/ShowFleetMissilePage.php
+++ b/includes/pages/game/ShowFleetMissilePage.php
@@ -86,6 +86,9 @@ class ShowFleetMissilePage extends AbstractGamePage
 			$targetUser = array('onlinetime' => 0, 'banaday' => 0, 'urlaubs_modus' => 0, 'authattack' => 0);
 		} else {
 			$targetUser		= GetUserByID($target['id_owner'], array('onlinetime', 'banaday', 'urlaubs_modus', 'authattack'));
+			if (!is_array($targetUser)) {
+				$targetUser = array('onlinetime' => 0, 'banaday' => 0, 'urlaubs_modus' => 0, 'authattack' => 0);
+			}
 		}
 
 		if (Config::get()->adm_attack == 1 && $targetUser['authattack'] > $USER['authlevel'])
@@ -97,15 +100,11 @@ class ShowFleetMissilePage extends AbstractGamePage
         $User2Points = $db->selectSingle($sql, array(
             ':ownerId'  => $target['id_owner']
         ));
+		if (!is_array($User2Points)) {
+			$User2Points = ['total_points' => 0];
+		}
 
-		$sql	= 'SELECT total_points
-		FROM %%STATPOINTS%%
-		WHERE id_owner = :userId AND stat_type = :statType';
-
-		$USER	+= Database::get()->selectSingle($sql, array(
-			':userId'	=> $USER['id'],
-			':statType'	=> 1
-		));
+		mergeUserStatPoints($USER);
 
         $IsNoobProtec	= CheckNoobProtec($USER, $User2Points, $targetUser);
 			

--- a/includes/pages/game/ShowInformationPage.php
+++ b/includes/pages/game/ShowInformationPage.php
@@ -6,6 +6,7 @@ use HiveNova\Core\Database;
 use HiveNova\Core\Config;
 use HiveNova\Core\HTTP;
 use HiveNova\Core\BuildFunctions;
+use HiveNova\Core\LeftoverBonus;
 use HiveNova\Core\PlanetProductionBonus;
 use HiveNova\Core\ResourceUpdate;
 
@@ -286,9 +287,9 @@ class ShowInformationPage extends AbstractGamePage
 			$FleetInfo	= array(
 				'structure'		=> $pricelist[$elementID]['cost'][901] + $pricelist[$elementID]['cost'][902],
 				'tech'			=> $pricelist[$elementID]['tech'],
-				'attack'		=> $CombatCaps[$elementID]['attack'],
+				'attack'		=> $CombatCaps[$elementID]['attack'] * LeftoverBonus::attackMultiplier((int) $elementID, $USER),
 				'shield'		=> $CombatCaps[$elementID]['shield'],
-				'capacity'		=> $pricelist[$elementID]['capacity'],
+				'capacity'		=> LeftoverBonus::shipCapacity((int) $elementID, 1, $USER),
 				'speed1'		=> $pricelist[$elementID]['speed'],
 				'speed2'		=> $pricelist[$elementID]['speed2'],
 				'consumption1'	=> $pricelist[$elementID]['consumption'],
@@ -316,7 +317,7 @@ class ShowInformationPage extends AbstractGamePage
 		{
 			$FleetInfo	= array(
 				'structure'		=> $pricelist[$elementID]['cost'][901] + $pricelist[$elementID]['cost'][902],
-				'attack'		=> $CombatCaps[$elementID]['attack'],
+				'attack'		=> $CombatCaps[$elementID]['attack'] * LeftoverBonus::attackMultiplier((int) $elementID, $USER),
 				'shield'		=> $CombatCaps[$elementID]['shield'],
 				'rapidfire'		=> array(
 					'from'	=> array(),

--- a/includes/pages/game/ShowMarketPlacePage.php
+++ b/includes/pages/game/ShowMarketPlacePage.php
@@ -222,6 +222,14 @@ class ShowMarketPlacePage extends AbstractGamePage
 			return $LNG['market_p_msg_more_ships_is_needed'];
 		}
 
+		$sql = "SELECT * FROM %%USERS%% WHERE id = :userId;";
+		$USER_2   = Database::get()->selectSingle($sql, array(
+			':userId'       => $fleetResult['fleet_owner']
+		));
+		if (!is_array($USER_2)) {
+			return $LNG['market_p_msg_not_found'];
+		}
+
 		$fleetArrayTMP = array();
 		$fleetArrayTMP = array($F1type => $F1, $F2type => $F2);
 		$fleetArray = $fleetArrayTMP;
@@ -257,10 +265,6 @@ class ShowMarketPlacePage extends AbstractGamePage
 
 		/////////////////////////////////////////////////////////////////////////////
 		/// SEND/
-		$sql = "SELECT * FROM %%USERS%% WHERE id = :userId;";
-		$USER_2   = Database::get()->selectSingle($sql, array(
-			':userId'       => $fleetResult['fleet_owner']
-		));
 		$fleetArray						= FleetFunctions::unserialize($fleetResult['fleet_array']);
 		$SpeedFactor    	= FleetFunctions::GetGameSpeedFactor();
 		$Distance    		= FleetFunctions::GetTargetDistance(array($PLANET['galaxy'], $PLANET['system'], $PLANET['planet']), array($fleetResult['fleet_end_galaxy'], $fleetResult['fleet_end_system'], $fleetResult['fleet_end_planet']));

--- a/includes/pages/game/ShowNotesPage.php
+++ b/includes/pages/game/ShowNotesPage.php
@@ -77,6 +77,9 @@ class ShowNotesPage extends AbstractGamePage
                 ':userID'   => $USER['id'],
                 ':noteID'   => $noteID
             ));
+			if (!is_array($noteDetail)) {
+				$this->printMessage($LNG['page_doesnt_exist']);
+			}
 		} else {
 			$noteDetail	= array(
 				'id'		=> 0,

--- a/includes/pages/game/ShowPhalanxPage.php
+++ b/includes/pages/game/ShowPhalanxPage.php
@@ -81,7 +81,7 @@ class ShowPhalanxPage extends AbstractGamePage
 		));
 
 		$sql = "SELECT id, name, id_owner FROM %%PLANETS%% WHERE universe = :universe
-		AND galaxy = :galaxy AND `system` = :system AND planet = :planet AND :type;";
+		AND galaxy = :galaxy AND `system` = :system AND planet = :planet AND planet_type = :type;";
 		
 		$TargetInfo = $db->selectSingle($sql, array(
 			':universe'	=> Universe::current(),

--- a/includes/pages/game/ShowStatisticsPage.php
+++ b/includes/pages/game/ShowStatisticsPage.php
@@ -122,10 +122,7 @@ class ShowStatisticsPage extends AbstractGamePage
                 $RangeList    = array();
 
                 try {
-                    $USER    += $db->selectSingle('SELECT total_points FROM %%STATPOINTS%% WHERE id_owner = :userId AND stat_type = :statType', array(
-                        ':userId'    => $USER['id'],
-                        ':statType'    => 1
-                    ));
+                    mergeUserStatPoints($USER);
                 } catch (Exception) {
                     $USER['total_points'] = 0;
                 }

--- a/tests/Support/FakeAchievementDatabase.php
+++ b/tests/Support/FakeAchievementDatabase.php
@@ -40,6 +40,8 @@ class FakeAchievementDatabase implements DatabaseInterface
 
     public int $expeditionCount = 0;
 
+    public bool $missingStatPoints = false;
+
     /** @var array<string, int|string> */
     public array $statPoints = [
         'total_points' => 0,
@@ -216,6 +218,9 @@ class FakeAchievementDatabase implements DatabaseInterface
         }
 
         if (str_contains($qry, 'FROM %%STATPOINTS%%')) {
+            if ($this->missingStatPoints) {
+                return $field === false ? false : null;
+            }
             if (str_contains($qry, 'MAX(') && str_contains($qry, 'total_rank')) {
                 $rank = (int) ($this->statPoints['total_rank'] ?? 0);
                 return $field === 'rank' ? $rank : ['rank' => $rank];

--- a/tests/Unit/FleetDispatchServiceTest.php
+++ b/tests/Unit/FleetDispatchServiceTest.php
@@ -611,6 +611,22 @@ class FleetDispatchServiceTest extends TestCase
         $this->addToAssertionCount(1);
     }
 
+    public function testValidateMissionDoesNotFatalWhenStatPointsMissing(): void
+    {
+        $this->fake->achievement->missingStatPoints = true;
+
+        FleetDispatchService::validateMission(
+            ['id' => 10, 'id_owner' => 2, 'destruyed' => 0],
+            ['id' => 2, 'authlevel' => 0, 'authattack' => 0, 'onlinetime' => TIMESTAMP, 'urlaubs_modus' => 0, 'banaday' => 0, 'total_points' => 0, 'ally_id' => 0],
+            1,
+            ['id' => 1, 'authlevel' => 0, 'ally_id' => 0],
+            $this->baseFleetData(['availableMissions' => ['MissionSelector' => [1]]]),
+            Config::get()
+        );
+
+        $this->addToAssertionCount(1);
+    }
+
     // -------------------------------------------------------------------------
     // calculateMetrics
     // -------------------------------------------------------------------------
@@ -684,6 +700,45 @@ class FleetDispatchServiceTest extends TestCase
         $this->assertSame(9900, $planet['metal']);
         $this->assertSame(4950, $planet['crystal']);
         $this->assertSame(2900, $planet['deuterium']);
+    }
+
+    public function testDispatchThrowsWhenLockedPlanetMissing(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Not enough resource');
+
+        $planet = [
+            'id'          => 42,
+            'galaxy'      => 1,
+            'system'      => 5,
+            'planet'      => 8,
+            'planet_type' => 1,
+            'metal'       => 10000,
+            'crystal'     => 5000,
+            'deuterium'   => 3000,
+        ];
+
+        FleetDispatchService::dispatch([
+            'fleetArray'         => [202 => 1],
+            'targetMission'      => 3,
+            'USER'               => ['id' => 1, 'universe' => 1],
+            'targetPlanetData'   => ['id' => 99, 'id_owner' => 2],
+            'targetGalaxy'       => 1,
+            'targetSystem'       => 6,
+            'targetPlanet'       => 3,
+            'targetType'         => 1,
+            'fleetResource'      => [901 => 100, 902 => 50, 903 => 25],
+            'fleetStartTime'     => TIMESTAMP + 3600,
+            'fleetStayTime'      => 0,
+            'fleetEndTime'       => TIMESTAMP + 7200,
+            'fleetGroup'         => 0,
+            'consumption'        => 75,
+            'markettype'         => 0,
+            'WantedResourceType' => 0,
+            'WantedResourceAmount' => 0,
+            'maxFlightTime'      => 0,
+            'visibility'         => 0,
+        ], $planet);
     }
 
     public function testDispatchThrowsWhenLockedPlanetLacksResources(): void

--- a/tests/Unit/GalaxyRowsVizJsonTest.php
+++ b/tests/Unit/GalaxyRowsVizJsonTest.php
@@ -241,8 +241,34 @@ class GalaxyRowsVizJsonTest extends TestCase
 
 		$this->assertSame(['current' => 0, 'max' => 0], $payload['fields']);
 		$this->assertFalse($payload['shareIntel']);
+		$this->assertSame(0, $payload['tempMin']);
+		$this->assertSame(0, $payload['tempMax']);
+		$this->assertSame(0, $payload['diameter']);
+		$this->assertNull($payload['debris']);
 		$this->assertArrayNotHasKey('vizState', $payload);
 		$this->assertSame([], (array) $payload['buildings']);
+		$this->assertJsContractValidJson($json, ['sparse' => true]);
+	}
+
+	public function testOtherPlanetPayloadOmitsDebrisMap(): void
+	{
+		$json = $this->invokeBuildPlanetVizJson([
+			'image'         => 'wasserplanet04',
+			'temp_min'      => 20,
+			'temp_max'      => 60,
+			'diameter'      => 11800,
+			'field_current' => 99,
+			'field_max'     => 163,
+			'galaxy'        => 2,
+			'system'        => 145,
+			'planet'        => 9,
+			'der_metal'     => 5000,
+			'der_crystal'   => 2500,
+		], false, './styles/theme/hive/');
+		$payload = $this->decodePayload($json);
+
+		$this->assertNull($payload['debris']);
+		$this->assertSame(0, $payload['tempMin']);
 		$this->assertJsContractValidJson($json, ['sparse' => true]);
 	}
 
@@ -352,6 +378,9 @@ class GalaxyRowsVizJsonTest extends TestCase
 
 		$this->assertArrayNotHasKey('vizState', $payload);
 		$this->assertFalse($payload['shareIntel']);
+		$this->assertSame(0, $payload['tempMin']);
+		$this->assertSame(0, $payload['tempMax']);
+		$this->assertSame(0, $payload['diameter']);
 		$this->assertSame([], (array) $payload['buildings']);
 		$this->assertJsContractValidJson($json, ['sparse' => true]);
 	}
@@ -450,6 +479,9 @@ class GalaxyRowsVizJsonTest extends TestCase
 
 		$this->assertIsArray($payload);
 		$this->assertFalse($payload['shareIntel']);
+		$this->assertSame(0, $payload['tempMin']);
+		$this->assertSame(0, $payload['tempMax']);
+		$this->assertSame(0, $payload['diameter']);
 		$this->assertSame([], (array) $payload['buildings']);
 		$this->assertSame([], (array) $payload['fleet']);
 	}


### PR DESCRIPTION
## Summary
- Guard buddy requests, notes, marketplace seller lookup, fleet `FOR UPDATE`, and `$USER += selectSingle` when `statpoints` is missing so PHP 8 does not TypeError.
- Zero temperature, diameter, and debris on galaxy planetViz for non-shared intel; phalanx queries `planet_type = 1` instead of `AND 1`.
- Show leftover attack and cargo on the ship/defense info popup so UI matches combat and fleet room.

## Test plan
- [ ] Open buddy request and notes with a bogus id — missing-page message, no PHP error
- [ ] As a stranger, `planetViz&ref=planet:{id}` — `shareIntel` false and `tempMin`/`diameter`/`debris` empty
- [ ] Buy a marketplace offer after the seller account is gone — offer-not-found before send
- [ ] Phalanx a planet that also has a moon — scan the planet, not the moon
- [ ] Open bomber/battlecruiser info with leftover techs — attack/cargo match combat/fleet room
- [ ] `php vendor/bin/phpunit tests/Unit/GalaxyRowsVizJsonTest.php tests/Unit/FleetDispatchServiceTest.php`