### PR TITLE
feat: In-game live event firehose (#251)

### DIFF
--- a/includes/classes/EventFirehoseFeed.php
+++ b/includes/classes/EventFirehoseFeed.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace HiveNova\Core;
+
+use ArrayAccess;
+
+class EventFirehoseFeed
+{
+	public const LIMIT = 50;
+
+	public const JSON_KEYS = ['id', 'time', 'eventType', 'size', 'outcome'];
+
+	/**
+	 * @param array<string, string>|ArrayAccess $LNG
+	 * @return list<array{id: int, time: string, eventType: string, size: string, outcome: string}>
+	 */
+	public static function fetch(int $universe, array|ArrayAccess $LNG, string $timezone, int $sinceId = 0): array
+	{
+		$limit = self::LIMIT;
+		if ($sinceId > 0) {
+			$sql = 'SELECT id, time, event_type, size_bucket, outcome
+				FROM %%UNIVERSE_EVENTS%%
+				WHERE universe = :universe AND id > :sinceId
+				ORDER BY id DESC
+				LIMIT ' . $limit;
+			$params = [
+				':universe' => $universe,
+				':sinceId'  => $sinceId,
+			];
+		} else {
+			$sql = 'SELECT id, time, event_type, size_bucket, outcome
+				FROM %%UNIVERSE_EVENTS%%
+				WHERE universe = :universe
+				ORDER BY id DESC
+				LIMIT ' . $limit;
+			$params = [
+				':universe' => $universe,
+			];
+		}
+
+		$rows = Database::get()->select($sql, $params);
+		$out  = [];
+		foreach ($rows as $row) {
+			$out[] = self::present($row, $LNG, $timezone);
+		}
+
+		return $out;
+	}
+
+	/**
+	 * @param array<string, mixed> $row
+	 * @param array<string, string>|ArrayAccess $LNG
+	 * @return array{id: int, time: string, eventType: string, size: string, outcome: string}
+	 */
+	public static function present(array $row, array|ArrayAccess $LNG, string $timezone): array
+	{
+		$eventType = (string) ($row['event_type'] ?? EventFirehoseWriter::EVENT_BATTLE);
+		$size      = (string) ($row['size_bucket'] ?? EventFirehoseWriter::SIZE_SMALL);
+		$outcome   = (string) ($row['outcome'] ?? EventFirehoseWriter::OUTCOME_DRAW);
+		$time      = (int) ($row['time'] ?? 0);
+
+		return [
+			'id'        => (int) ($row['id'] ?? 0),
+			'time'      => _date($LNG['php_tdformat'] ?? 'd. M Y, H:i:s', $time, $timezone),
+			'eventType' => (string) ($LNG['ef_event_' . $eventType] ?? $LNG['ef_event_battle'] ?? 'Battle'),
+			'size'      => (string) ($LNG['ef_size_' . $size] ?? $size),
+			'outcome'   => (string) ($LNG['ef_outcome_' . $outcome] ?? $outcome),
+		];
+	}
+}

--- a/includes/classes/EventFirehoseWriter.php
+++ b/includes/classes/EventFirehoseWriter.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace HiveNova\Core;
+
+use Throwable;
+
+class EventFirehoseWriter
+{
+	public const EVENT_BATTLE = 'battle';
+
+	public const SIZE_SMALL = 'small';
+
+	public const SIZE_MEDIUM = 'medium';
+
+	public const SIZE_LARGE = 'large';
+
+	public const OUTCOME_ATTACKER = 'attacker';
+
+	public const OUTCOME_DEFENDER = 'defender';
+
+	public const OUTCOME_DRAW = 'draw';
+
+	public const SMALL_MAX = 1_000_000;
+
+	public const MEDIUM_MAX = 100_000_000;
+
+	public static function sizeBucket(float $totalUnitsLost): string
+	{
+		if ($totalUnitsLost < self::SMALL_MAX) {
+			return self::SIZE_SMALL;
+		}
+		if ($totalUnitsLost < self::MEDIUM_MAX) {
+			return self::SIZE_MEDIUM;
+		}
+
+		return self::SIZE_LARGE;
+	}
+
+	public static function outcome(string $won): string
+	{
+		return match ($won) {
+			'a' => self::OUTCOME_ATTACKER,
+			'r' => self::OUTCOME_DEFENDER,
+			default => self::OUTCOME_DRAW,
+		};
+	}
+
+	public static function record(int $universe, int $time, float $totalUnitsLost, string $won): void
+	{
+		try {
+			Database::get()->insert(
+				'INSERT INTO %%UNIVERSE_EVENTS%% SET
+				universe	= :universe,
+				time		= :time,
+				event_type	= :eventType,
+				size_bucket	= :sizeBucket,
+				outcome		= :outcome;',
+				[
+					':universe'		=> $universe,
+					':time'			=> $time,
+					':eventType'	=> self::EVENT_BATTLE,
+					':sizeBucket'	=> self::sizeBucket($totalUnitsLost),
+					':outcome'		=> self::outcome($won),
+				]
+			);
+		} catch (Throwable $e) {
+			error_log('EventFirehoseWriter: ' . $e->getMessage());
+		}
+	}
+}

--- a/includes/classes/cronjob/CleanerCronjob.php
+++ b/includes/classes/cronjob/CleanerCronjob.php
@@ -134,6 +134,11 @@ class CleanerCronjob implements CronjobTask
 			':time'	=> $del_before
 		));
 
+		$sql	= 'DELETE FROM %%UNIVERSE_EVENTS%% WHERE `time` < :time;';
+		Database::get()->delete($sql, array(
+			':time'	=> $del_before
+		));
+
 		$sql	= 'DELETE FROM %%MESSAGES%% WHERE `message_deleted` < :time;';
 		Database::get()->delete($sql, array(
 			':time'	=> $del_messages

--- a/includes/classes/missions/MissionCaseAttack.php
+++ b/includes/classes/missions/MissionCaseAttack.php
@@ -4,6 +4,7 @@ namespace HiveNova\Mission;
 
 use HiveNova\Core\Config;
 use HiveNova\Core\Database;
+use HiveNova\Core\EventFirehoseWriter;
 use HiveNova\Core\DiscordWebhookService;
 use HiveNova\Core\FleetFunctions;
 use HiveNova\Core\MissionFunctions;
@@ -571,6 +572,13 @@ HTML;
 			':universe'	=> $this->_fleet['fleet_universe'],
 			':result'	=> $combatResult['won']
 		));
+
+		EventFirehoseWriter::record(
+			(int) $this->_fleet['fleet_universe'],
+			(int) $this->_fleet['fleet_start_time'],
+			(float) ($combatResult['unitLost']['attacker'] + $combatResult['unitLost']['defender']),
+			(string) $combatResult['won']
+		);
 
 		$sql = 'UPDATE %%USERS%% SET
 		`'.$attackStatus.'` = `'.$attackStatus.'` + 1,

--- a/includes/classes/missions/MissionCaseDestruction.php
+++ b/includes/classes/missions/MissionCaseDestruction.php
@@ -4,6 +4,7 @@ namespace HiveNova\Mission;
 
 use HiveNova\Core\Config;
 use HiveNova\Core\Database;
+use HiveNova\Core\EventFirehoseWriter;
 use HiveNova\Core\DiscordWebhookService;
 use HiveNova\Core\FleetFunctions;
 use HiveNova\Core\MissionFunctions;
@@ -584,6 +585,13 @@ HTML;
 			':universe'	=> $this->_fleet['fleet_universe'],
 			':result'	=> $combatResult['won']
 		));
+
+		EventFirehoseWriter::record(
+			(int) $this->_fleet['fleet_universe'],
+			(int) $this->_fleet['fleet_start_time'],
+			(float) ($combatResult['unitLost']['attacker'] + $combatResult['unitLost']['defender']),
+			(string) $combatResult['won']
+		);
 
 		$sql = 'UPDATE %%USERS%% SET
 		`'.$attackStatus.'` = `'.$attackStatus.'` + 1,

--- a/includes/dbtables.php
+++ b/includes/dbtables.php
@@ -15,7 +15,7 @@
  * @link https://github.com/jkroepke/2Moons
  */
 
-defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 24);
+defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 25);
 defined('DB_NAME')             || define('DB_NAME',   $database['databasename']);
 defined('DB_PREFIX')           || define('DB_PREFIX', $database['tableprefix']);
 
@@ -59,6 +59,7 @@ $dbTableNames	= array(
 	'TICKETS_CATEGORY'	=> DB_PREFIX.'ticket_category',
 	'TOPKB'				=> DB_PREFIX.'topkb',
 	'TOPKB_USERS'		=> DB_PREFIX.'users_to_topkb',
+	'UNIVERSE_EVENTS'		=> DB_PREFIX.'universe_events',
 	'USERS'				=> DB_PREFIX.'users',
 	'USERS_ACS'			=> DB_PREFIX.'users_to_acs',
 	'USERS_AUTH'		=> DB_PREFIX.'users_to_extauth',

--- a/includes/pages/game/ShowEventFirehosePage.php
+++ b/includes/pages/game/ShowEventFirehosePage.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace HiveNova\Page\Game;
+
+use HiveNova\Core\EventFirehoseFeed;
+use HiveNova\Core\HTTP;
+
+class ShowEventFirehosePage extends AbstractGamePage
+{
+	public static $requireModule = 0;
+
+	function __construct()
+	{
+		parent::__construct();
+	}
+
+	function show()
+	{
+		if (defined('AJAX_REQUEST') && AJAX_REQUEST) {
+			$this->sendJSON(['events' => $this->loadEvents()]);
+			return;
+		}
+
+		$this->tplObj->loadscript('event-firehose.js');
+		$this->assign([
+			'EventList' => $this->loadEvents(),
+		]);
+		$this->display('page.eventFirehose.default.tpl');
+	}
+
+	/**
+	 * @return list<array{id: int, time: string, eventType: string, size: string, outcome: string}>
+	 */
+	protected function loadEvents(): array
+	{
+		global $USER, $LNG;
+
+		$universe = (int) ($USER['universe'] ?? 0);
+		$timezone = (string) ($USER['timezone'] ?? 'UTC');
+		$sinceId  = HTTP::_GP('sinceId', 0);
+
+		return EventFirehoseFeed::fetch($universe, $LNG, $timezone, $sinceId);
+	}
+}

--- a/install/install.sql
+++ b/install/install.sql
@@ -766,6 +766,17 @@ CREATE TABLE `%PREFIX%topkb` (
   KEY `time` (`universe`,`rid`,`time`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8;
 
+CREATE TABLE `%PREFIX%universe_events` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `universe` tinyint(3) unsigned NOT NULL,
+  `time` int(11) NOT NULL,
+  `event_type` varchar(16) NOT NULL,
+  `size_bucket` varchar(16) NOT NULL,
+  `outcome` varchar(16) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `universe_id` (`universe`,`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
 CREATE TABLE `%PREFIX%users` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `username` varchar(32) NOT NULL DEFAULT '',

--- a/install/migrations/migration_25.sql
+++ b/install/migrations/migration_25.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS `%PREFIX%universe_events` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `universe` tinyint(3) unsigned NOT NULL,
+  `time` int(11) NOT NULL,
+  `event_type` varchar(16) NOT NULL,
+  `size_bucket` varchar(16) NOT NULL,
+  `outcome` varchar(16) NOT NULL,
+  PRIMARY KEY (`id`),
+  KEY `universe_id` (`universe`,`id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;

--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -99,6 +99,15 @@ $LNG['lm_battlesim']						= 'Kampfsimulator';
 $LNG['lm_playercard']                       			= 'Spielerinformationen';
 $LNG['lm_info']                     				= 'Informationen';
 $LNG['lm_disclamer']						= 'Impressum';
+$LNG['ef_title']							= 'Universums-Feed';
+$LNG['ef_empty']							= 'Das Universum ist still.';
+$LNG['ef_event_battle']					= 'Kampf';
+$LNG['ef_size_small']						= 'Scharmützel';
+$LNG['ef_size_medium']						= 'Gefecht';
+$LNG['ef_size_large']						= 'Große Schlacht';
+$LNG['ef_outcome_attacker']				= 'Angreifer siegten';
+$LNG['ef_outcome_defender']				= 'Verteidiger hielten stand';
+$LNG['ef_outcome_draw']					= 'Unentschieden';
 	
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -108,6 +108,15 @@ $LNG['lm_battlesim']						= 'Simulator';
 $LNG['lm_playercard']                       = 'Player Profile';
 $LNG['lm_info']                     		= 'Info';
 $LNG['lm_disclamer']						= 'Credits';
+$LNG['ef_title']							= 'Universe feed';
+$LNG['ef_empty']							= 'The universe is quiet.';
+$LNG['ef_event_battle']					= 'Battle';
+$LNG['ef_size_small']						= 'Skirmish';
+$LNG['ef_size_medium']						= 'Clash';
+$LNG['ef_size_large']						= 'Major battle';
+$LNG['ef_outcome_attacker']				= 'Attackers prevailed';
+$LNG['ef_outcome_defender']				= 'Defenders held';
+$LNG['ef_outcome_draw']					= 'Stalemate';
 
 //----------------------------------------------------------------------------//
 // Overview

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -98,6 +98,15 @@ $LNG['lm_battlesim']						= "Sim. de Batallas";
 $LNG['lm_playercard']                       = 'Información del Jugador';
 $LNG['lm_info']                     		= 'Información';
 $LNG['lm_disclamer']						= 'Contacto';
+$LNG['ef_title']							= 'Actividad del universo';
+$LNG['ef_empty']							= 'El universo está en calma.';
+$LNG['ef_event_battle']					= 'Batalla';
+$LNG['ef_size_small']						= 'Escaramuza';
+$LNG['ef_size_medium']						= 'Choque';
+$LNG['ef_size_large']						= 'Gran batalla';
+$LNG['ef_outcome_attacker']				= 'Los atacantes prevalecieron';
+$LNG['ef_outcome_defender']				= 'Los defensores resistieron';
+$LNG['ef_outcome_draw']					= 'Empate';
 
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -88,6 +88,15 @@ $LNG['lm_battlesim']						= 'Simulateur de Combat';
 $LNG['lm_playercard']                       = 'Profil du joueur';
 $LNG['lm_info']                     		= 'Info';
 $LNG['lm_disclamer']						= 'Crédits';
+$LNG['ef_title']							= 'Flux univers';
+$LNG['ef_empty']							= 'L\'univers est calme.';
+$LNG['ef_event_battle']					= 'Bataille';
+$LNG['ef_size_small']						= 'Escarmouche';
+$LNG['ef_size_medium']						= 'Affrontement';
+$LNG['ef_size_large']						= 'Grande bataille';
+$LNG['ef_outcome_attacker']				= 'Les attaquants l\'ont emporté';
+$LNG['ef_outcome_defender']				= 'Les défenseurs ont tenu';
+$LNG['ef_outcome_draw']					= 'Match nul';
 
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -101,6 +101,15 @@ $LNG['lm_battlesim']						= 'Symulator walki';
 $LNG['lm_playercard']                       = 'Informacje o graczu';
 $LNG['lm_info']                     		= 'Informacje';
 $LNG['lm_disclamer']						= 'Kontakt';
+$LNG['ef_title']							= 'Kanał uniwersum';
+$LNG['ef_empty']							= 'Uniwersum jest ciche.';
+$LNG['ef_event_battle']					= 'Bitwa';
+$LNG['ef_size_small']						= 'Potyczka';
+$LNG['ef_size_medium']						= 'Starcie';
+$LNG['ef_size_large']						= 'Wielka bitwa';
+$LNG['ef_outcome_attacker']				= 'Atakujący zwyciężyli';
+$LNG['ef_outcome_defender']				= 'Obrońcy się utrzymali';
+$LNG['ef_outcome_draw']					= 'Remis';
 	
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -102,6 +102,15 @@ $LNG['lm_battlesim']						= 'Simulador';
 $LNG['lm_playercard']                       = 'Página de Jogador';
 $LNG['lm_info']                     		= 'Informação';
 $LNG['lm_disclamer']						= 'Creditos';
+$LNG['ef_title']							= 'Feed do universo';
+$LNG['ef_empty']							= 'O universo está calmo.';
+$LNG['ef_event_battle']					= 'Batalha';
+$LNG['ef_size_small']						= 'Escaramuça';
+$LNG['ef_size_medium']						= 'Confronto';
+$LNG['ef_size_large']						= 'Grande batalha';
+$LNG['ef_outcome_attacker']				= 'Os atacantes prevaleceram';
+$LNG['ef_outcome_defender']				= 'Os defensores resistiram';
+$LNG['ef_outcome_draw']					= 'Empate';
 	
 //----------------------------------------------------------------------------//
 // Vista Geral

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -95,6 +95,15 @@ $LNG['lm_battlesim']                      = 'Симулятор боя';
 $LNG['lm_playercard']                     = 'Об игроке';
 $LNG['lm_info']                           = 'Информация';
 $LNG['lm_disclamer']                      = 'Контакты';
+$LNG['ef_title']							= 'Лента вселенной';
+$LNG['ef_empty']							= 'Во вселенной тихо.';
+$LNG['ef_event_battle']					= 'Бой';
+$LNG['ef_size_small']						= 'Стычка';
+$LNG['ef_size_medium']						= 'Сражение';
+$LNG['ef_size_large']						= 'Крупный бой';
+$LNG['ef_outcome_attacker']				= 'Атакующие победили';
+$LNG['ef_outcome_defender']				= 'Защитники устояли';
+$LNG['ef_outcome_draw']					= 'Ничья';
 
 // Обзор
 $LNG['ov_newname_specialchar']            = 'Название планеты и луны может состоять только из букв, цифр, пробелов и символов "_", "-", "."';

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -104,6 +104,15 @@ $LNG['lm_battlesim']						= 'Simülasyon';
 $LNG['lm_playercard']                       = 'Oyuncu Profili';
 $LNG['lm_info']                     		= 'Bilgi';
 $LNG['lm_disclamer']						= 'Iletişim';
+$LNG['ef_title']							= 'Evren akışı';
+$LNG['ef_empty']							= 'Evren sessiz.';
+$LNG['ef_event_battle']					= 'Savaş';
+$LNG['ef_size_small']						= 'Çatışma';
+$LNG['ef_size_medium']						= 'Kapışma';
+$LNG['ef_size_large']						= 'Büyük savaş';
+$LNG['ef_outcome_attacker']				= 'Saldıranlar üstün geldi';
+$LNG['ef_outcome_defender']				= 'Savunanlar dayandı';
+$LNG['ef_outcome_draw']					= 'Berabere';
 
 
 //----------------------------------------------------------------------------//

--- a/scripts/game/event-firehose.js
+++ b/scripts/game/event-firehose.js
@@ -1,0 +1,243 @@
+(function (root) {
+	'use strict';
+
+	var POLL_MS = 20000;
+	var MAX_ROWS = 50;
+
+	function responseLooksLikeJson(response, bodyText) {
+		if (!response || !response.ok) {
+			return false;
+		}
+		var url = response.url || '';
+		if (url.indexOf('index.php') !== -1) {
+			return false;
+		}
+		var trimmed = (bodyText || '').replace(/^\s+/, '');
+		return trimmed.charAt(0) === '{' || trimmed.charAt(0) === '[';
+	}
+
+	function parseEvents(bodyText) {
+		var data = JSON.parse(bodyText);
+		if (!data || !Array.isArray(data.events)) {
+			return null;
+		}
+		return data.events;
+	}
+
+	function existingIds(list) {
+		var ids = {};
+		if (!list) {
+			return ids;
+		}
+		var rows = list.querySelectorAll('[data-event-id]');
+		for (var i = 0; i < rows.length; i++) {
+			ids[rows[i].getAttribute('data-event-id')] = true;
+		}
+		return ids;
+	}
+
+	function maxId(list) {
+		var max = 0;
+		if (!list) {
+			return max;
+		}
+		var rows = list.querySelectorAll('[data-event-id]');
+		for (var i = 0; i < rows.length; i++) {
+			var n = parseInt(rows[i].getAttribute('data-event-id'), 10);
+			if (!isNaN(n) && n > max) {
+				max = n;
+			}
+		}
+		return max;
+	}
+
+	function renderRow(event) {
+		var tr = createElement('tr');
+		tr.setAttribute('data-event-id', String(event.id));
+		['time', 'eventType', 'size', 'outcome'].forEach(function (key) {
+			var td = createElement('td');
+			td.textContent = event[key] == null ? '' : String(event[key]);
+			tr.appendChild(td);
+		});
+		return tr;
+	}
+
+	function createElement(tag) {
+		if (typeof document !== 'undefined' && document.createElement) {
+			return document.createElement(tag);
+		}
+		var node = {
+			children: [],
+			attrs: {},
+			textContent: '',
+			setAttribute: function (name, value) {
+				this.attrs[name] = value;
+			},
+			getAttribute: function (name) {
+				return this.attrs[name];
+			},
+			appendChild: function (child) {
+				this.children.push(child);
+			}
+		};
+		return node;
+	}
+
+	function mergeEvents(list, events) {
+		if (!list || !events || !events.length) {
+			return;
+		}
+		var seen = existingIds(list);
+		var empty = list.querySelector('.event-firehose-empty');
+		if (empty) {
+			empty.parentNode.removeChild(empty);
+		}
+		var added = 0;
+		for (var i = events.length - 1; i >= 0; i--) {
+			var event = events[i];
+			if (!event || typeof event.id === 'undefined') {
+				continue;
+			}
+			var id = String(event.id);
+			if (seen[id]) {
+				continue;
+			}
+			seen[id] = true;
+			list.insertBefore(renderRow(event), list.firstChild);
+			added += 1;
+		}
+		if (!added) {
+			return;
+		}
+		var rows = list.querySelectorAll('[data-event-id]');
+		for (var j = MAX_ROWS; j < rows.length; j++) {
+			rows[j].parentNode.removeChild(rows[j]);
+		}
+	}
+
+	function createPoller(options) {
+		var list = options.list;
+		var fetchFn = options.fetchFn || fetch;
+		var hiddenFn = options.hiddenFn || function () {
+			return typeof document !== 'undefined' && document.hidden;
+		};
+		var intervalMs = options.intervalMs || POLL_MS;
+		var baseUrl = options.url || 'game.php?page=eventFirehose&ajax=1';
+		var timer = null;
+		var stopped = false;
+
+		function pollUrl() {
+			var since = maxId(list);
+			if (since > 0) {
+				return baseUrl + (baseUrl.indexOf('?') === -1 ? '?' : '&') + 'sinceId=' + since;
+			}
+			return baseUrl;
+		}
+
+		function poll() {
+			if (stopped || hiddenFn()) {
+				return Promise.resolve();
+			}
+			return fetchFn(pollUrl(), { credentials: 'same-origin' }).then(function (response) {
+				return response.text().then(function (bodyText) {
+					if (!responseLooksLikeJson(response, bodyText)) {
+						stop();
+						return;
+					}
+					try {
+						var events = parseEvents(bodyText);
+						if (events === null) {
+							return;
+						}
+						mergeEvents(list, events);
+					} catch (e) {
+						stop();
+					}
+				});
+			}).catch(function () {
+				// Keep last list on network error.
+			});
+		}
+
+		function start() {
+			if (stopped) {
+				return;
+			}
+			poll();
+			if (timer) {
+				clearInterval(timer);
+			}
+			timer = setInterval(poll, intervalMs);
+		}
+
+		function stop() {
+			stopped = true;
+			if (timer) {
+				clearInterval(timer);
+				timer = null;
+			}
+		}
+
+		function onVisibility() {
+			if (stopped) {
+				return;
+			}
+			if (hiddenFn()) {
+				if (timer) {
+					clearInterval(timer);
+					timer = null;
+				}
+				return;
+			}
+			start();
+		}
+
+		return {
+			poll: poll,
+			start: start,
+			stop: stop,
+			onVisibility: onVisibility,
+			isStopped: function () { return stopped; },
+			mergeEvents: mergeEvents
+		};
+	}
+
+	function init(doc) {
+		doc = doc || (typeof document !== 'undefined' ? document : null);
+		if (!doc) {
+			return null;
+		}
+		var list = doc.getElementById('event-firehose-list');
+		if (!list) {
+			return null;
+		}
+		var poller = createPoller({ list: list });
+		if (typeof document !== 'undefined') {
+			document.addEventListener('visibilitychange', poller.onVisibility);
+		}
+		poller.start();
+		return poller;
+	}
+
+	var api = {
+		POLL_MS: POLL_MS,
+		responseLooksLikeJson: responseLooksLikeJson,
+		parseEvents: parseEvents,
+		mergeEvents: mergeEvents,
+		createPoller: createPoller,
+		init: init
+	};
+
+	root.HiveNovaEventFirehose = api;
+	if (typeof module !== 'undefined' && module.exports) {
+		module.exports = api;
+	}
+
+	if (typeof document !== 'undefined') {
+		if (document.readyState === 'loading') {
+			document.addEventListener('DOMContentLoaded', function () { init(document); });
+		} else {
+			init(document);
+		}
+	}
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/styles/templates/game/page.eventFirehose.default.tpl
+++ b/styles/templates/game/page.eventFirehose.default.tpl
@@ -1,0 +1,24 @@
+{block name="title" prepend}{$LNG.ef_title}{/block}
+{block name="content"}
+<table class="table519" id="event-firehose">
+<tbody>
+<tr>
+	<th colspan="4">{$LNG.ef_title}</th>
+</tr>
+</tbody>
+<tbody id="event-firehose-list">
+{foreach $EventList as $row}
+<tr data-event-id="{$row.id}">
+	<td>{$row.time}</td>
+	<td>{$row.eventType}</td>
+	<td>{$row.size}</td>
+	<td>{$row.outcome}</td>
+</tr>
+{foreachelse}
+<tr class="event-firehose-empty">
+	<td colspan="4">{$LNG.ef_empty}</td>
+</tr>
+{/foreach}
+</tbody>
+</table>
+{/block}

--- a/tests/Support/FakeAchievementDatabase.php
+++ b/tests/Support/FakeAchievementDatabase.php
@@ -24,6 +24,13 @@ class FakeAchievementDatabase implements DatabaseInterface
     public array $grants = [];
 
     /** @var list<array<string, mixed>> */
+    public array $universeEvents = [];
+
+    public int $universeEventId = 0;
+
+    public bool $throwOnUniverseEventsInsert = false;
+
+    /** @var list<array<string, mixed>> */
     public array $messages = [];
 
     /** @var list<array<string, mixed>> */
@@ -137,6 +144,31 @@ class FakeAchievementDatabase implements DatabaseInterface
                 $rows[] = ['key' => $def['key'], 'points' => (int) ($def['points'] ?? 0)];
             }
             return $rows;
+        }
+
+        if (str_contains($qry, 'FROM %%UNIVERSE_EVENTS%%')) {
+            $universe = (int) ($params[':universe'] ?? 0);
+            $sinceId = (int) ($params[':sinceId'] ?? 0);
+            $rows = array_values(array_filter(
+                $this->universeEvents,
+                static function (array $row) use ($universe, $sinceId): bool {
+                    if ((int) ($row['universe'] ?? 0) !== $universe) {
+                        return false;
+                    }
+                    if ($sinceId > 0 && (int) ($row['id'] ?? 0) <= $sinceId) {
+                        return false;
+                    }
+
+                    return true;
+                }
+            ));
+            usort($rows, static fn (array $a, array $b): int => (int) $b['id'] <=> (int) $a['id']);
+            $limit = 50;
+            if (preg_match('/LIMIT\s+(\d+)/i', $qry, $m)) {
+                $limit = (int) $m[1];
+            }
+
+            return array_slice($rows, 0, $limit);
         }
 
         if (str_contains($qry, 'FROM %%USERS%% WHERE id >') && str_contains($qry, 'LIMIT')) {
@@ -271,6 +303,21 @@ class FakeAchievementDatabase implements DatabaseInterface
 
         if (str_contains($qry, '%%MESSAGES%%')) {
             $this->messages[] = $params;
+        }
+
+        if (str_contains($qry, '%%UNIVERSE_EVENTS%%')) {
+            if ($this->throwOnUniverseEventsInsert) {
+                throw new RuntimeException('universe events insert failed');
+            }
+            $this->universeEventId++;
+            $this->universeEvents[] = [
+                'id' => $this->universeEventId,
+                'universe' => (int) ($params[':universe'] ?? 0),
+                'time' => (int) ($params[':time'] ?? 0),
+                'event_type' => (string) ($params[':eventType'] ?? ''),
+                'size_bucket' => (string) ($params[':sizeBucket'] ?? ''),
+                'outcome' => (string) ($params[':outcome'] ?? ''),
+            ];
         }
 
         if (str_contains($qry, '%%RW%%')) {

--- a/tests/Unit/CleanerCronjobRunTest.php
+++ b/tests/Unit/CleanerCronjobRunTest.php
@@ -63,7 +63,7 @@ class CleanerCronjobRunTest extends TestCase
         $this->assertTrue(
             (bool) array_filter(
                 $fake->achievement->deleteLog,
-                static fn (string $sql): bool => str_contains($sql, '%%MESSAGES%%')
+                static fn (string $sql): bool => str_contains($sql, '%%UNIVERSE_EVENTS%%')
             )
         );
     }

--- a/tests/Unit/CleanerCronjobTest.php
+++ b/tests/Unit/CleanerCronjobTest.php
@@ -82,6 +82,15 @@ class CleanerCronjobTest extends TestCase
         );
     }
 
+    public function testUniverseEventsCleanupIsActive(): void
+    {
+        $this->assertMatchesRegularExpression(
+            '/DELETE FROM %%UNIVERSE_EVENTS%%[^;]+`time`[^;]+:time/s',
+            $this->source,
+            'UNIVERSE_EVENTS cleanup must be active and bounded by time / :time'
+        );
+    }
+
     public function testLogShipyardCleanupIsActive(): void
     {
         $this->assertMatchesRegularExpression(

--- a/tests/Unit/EventFirehoseFeedTest.php
+++ b/tests/Unit/EventFirehoseFeedTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use HiveNova\Core\EventFirehoseFeed;
+use HiveNova\Core\EventFirehoseWriter;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+class EventFirehoseFeedTest extends TestCase
+{
+	use SwapDatabaseInstance;
+
+	private FakeDatabase $fake;
+
+	/** @var array<string, string> */
+	private array $lng;
+
+	protected function setUp(): void
+	{
+		$this->fake = new FakeDatabase();
+		$this->swapDatabaseInstance($this->fake);
+		$this->lng = [
+			'php_tdformat' => 'Y-m-d',
+			'ef_event_battle' => 'Battle',
+			'ef_size_small' => 'Skirmish',
+			'ef_size_medium' => 'Clash',
+			'ef_size_large' => 'Major battle',
+			'ef_outcome_attacker' => 'Attackers prevailed',
+			'ef_outcome_defender' => 'Defenders held',
+			'ef_outcome_draw' => 'Stalemate',
+		];
+	}
+
+	protected function tearDown(): void
+	{
+		$this->restoreDatabaseInstance();
+		parent::tearDown();
+	}
+
+	public function test_json_keys_are_allowlisted(): void
+	{
+		$presented = EventFirehoseFeed::present([
+			'id' => 3,
+			'time' => 1_700_000_000,
+			'event_type' => 'battle',
+			'size_bucket' => 'small',
+			'outcome' => 'draw',
+			'rid' => 'leak',
+			'username' => 'alice',
+			'galaxy' => 1,
+		], $this->lng, 'UTC');
+
+		$this->assertSame(EventFirehoseFeed::JSON_KEYS, array_keys($presented));
+		$this->assertArrayNotHasKey('rid', $presented);
+		$this->assertArrayNotHasKey('username', $presented);
+		$this->assertArrayNotHasKey('galaxy', $presented);
+		$this->assertArrayNotHasKey('units', $presented);
+	}
+
+	public function test_universe_isolation_and_since_id(): void
+	{
+		EventFirehoseWriter::record(1, 100, 10, 'a');
+		EventFirehoseWriter::record(2, 100, 10, 'r');
+		EventFirehoseWriter::record(1, 101, 10, 'w');
+
+		$uni1 = EventFirehoseFeed::fetch(1, $this->lng, 'UTC');
+		$this->assertCount(2, $uni1);
+
+		$newer = EventFirehoseFeed::fetch(1, $this->lng, 'UTC', (int) $uni1[1]['id']);
+		$this->assertCount(1, $newer);
+		$this->assertSame($uni1[0]['id'], $newer[0]['id']);
+	}
+
+	public function test_empty_feed_and_limit(): void
+	{
+		$this->assertSame([], EventFirehoseFeed::fetch(1, $this->lng, 'UTC'));
+
+		for ($i = 0; $i < 60; $i++) {
+			EventFirehoseWriter::record(1, 100 + $i, 10, 'a');
+		}
+		$rows = EventFirehoseFeed::fetch(1, $this->lng, 'UTC');
+		$this->assertCount(50, $rows);
+	}
+}

--- a/tests/Unit/EventFirehoseWriterTest.php
+++ b/tests/Unit/EventFirehoseWriterTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use HiveNova\Core\EventFirehoseWriter;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+class EventFirehoseWriterTest extends TestCase
+{
+	use SwapDatabaseInstance;
+
+	private FakeDatabase $fake;
+
+	protected function setUp(): void
+	{
+		$this->fake = new FakeDatabase();
+		$this->swapDatabaseInstance($this->fake);
+	}
+
+	protected function tearDown(): void
+	{
+		$this->restoreDatabaseInstance();
+		parent::tearDown();
+	}
+
+	public function test_size_bucket_boundaries(): void
+	{
+		$this->assertSame(EventFirehoseWriter::SIZE_SMALL, EventFirehoseWriter::sizeBucket(0));
+		$this->assertSame(EventFirehoseWriter::SIZE_SMALL, EventFirehoseWriter::sizeBucket(999_999));
+		$this->assertSame(EventFirehoseWriter::SIZE_MEDIUM, EventFirehoseWriter::sizeBucket(1_000_000));
+		$this->assertSame(EventFirehoseWriter::SIZE_MEDIUM, EventFirehoseWriter::sizeBucket(99_999_999));
+		$this->assertSame(EventFirehoseWriter::SIZE_LARGE, EventFirehoseWriter::sizeBucket(100_000_000));
+	}
+
+	public function test_record_stores_enums_not_raw_units_or_rid(): void
+	{
+		EventFirehoseWriter::record(1, 1_700_000_000, 1_500_000, 'a');
+
+		$rows = $this->fake->achievement->universeEvents;
+		$this->assertCount(1, $rows);
+		$row = $rows[0];
+		$this->assertSame('battle', $row['event_type']);
+		$this->assertSame('medium', $row['size_bucket']);
+		$this->assertSame('attacker', $row['outcome']);
+		$this->assertArrayNotHasKey('rid', $row);
+		$this->assertArrayNotHasKey('units', $row);
+		$this->assertArrayNotHasKey(':reportId', $row);
+	}
+
+	public function test_record_failure_does_not_throw(): void
+	{
+		$this->fake->achievement->throwOnUniverseEventsInsert = true;
+		EventFirehoseWriter::record(1, 1, 10, 'w');
+		$this->assertSame([], $this->fake->achievement->universeEvents);
+	}
+}

--- a/tests/Unit/MissionCaseCombatTest.php
+++ b/tests/Unit/MissionCaseCombatTest.php
@@ -55,6 +55,9 @@ class MissionCaseCombatTest extends TestCase
         $this->assertNotEmpty($this->fake->achievement->messages);
         $this->assertNotEmpty($this->fake->fleetUpdates);
         $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertCount(1, $this->fake->achievement->universeEvents);
+        $this->assertSame('battle', $this->fake->achievement->universeEvents[0]['event_type']);
+        $this->assertArrayNotHasKey('rid', $this->fake->achievement->universeEvents[0]);
     }
 
     public function test_destruction_runs_combat_against_planet(): void
@@ -71,6 +74,8 @@ class MissionCaseCombatTest extends TestCase
 
         $this->assertNotEmpty($this->fake->achievement->messages);
         $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertCount(1, $this->fake->achievement->universeEvents);
+        $this->assertSame('battle', $this->fake->achievement->universeEvents[0]['event_type']);
     }
 
     public function test_mip_destroys_defenses_when_missiles_outnumber_interceptors(): void
@@ -91,6 +96,7 @@ class MissionCaseCombatTest extends TestCase
 
         $this->assertSame(1, $mission->kill);
         $this->assertGreaterThanOrEqual(2, count($this->fake->achievement->messages));
+        $this->assertSame([], $this->fake->achievement->universeEvents);
     }
 
     public function test_attack_return_event_restores_fleet_and_notifies_owner(): void

--- a/tests/Unit/ShowEventFirehosePageTest.php
+++ b/tests/Unit/ShowEventFirehosePageTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use HiveNova\Core\Database;
+use HiveNova\Core\EventFirehoseFeed;
+use HiveNova\Page\Game\ShowEventFirehosePage;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+/**
+ * @internal
+ */
+final class TestableShowEventFirehosePage extends ShowEventFirehosePage
+{
+	public function __construct()
+	{
+	}
+
+	protected function sendJSON($data): void
+	{
+	}
+
+	protected function save(): void
+	{
+	}
+
+	public function publicEvents(): array
+	{
+		return $this->loadEvents();
+	}
+}
+
+class ShowEventFirehosePageTest extends TestCase
+{
+	use SwapDatabaseInstance;
+
+	protected function setUp(): void
+	{
+		global $USER, $LNG;
+
+		$USER = ['id' => 1, 'universe' => 1, 'timezone' => 'UTC'];
+		$LNG = [
+			'php_tdformat' => 'Y-m-d',
+			'ef_event_battle' => 'Battle',
+			'ef_size_small' => 'Skirmish',
+			'ef_outcome_attacker' => 'Attackers prevailed',
+		];
+		$this->swapDatabaseInstance(new FakeDatabase());
+	}
+
+	protected function tearDown(): void
+	{
+		global $USER, $LNG;
+		unset($USER, $LNG);
+		$_REQUEST = [];
+		$this->restoreDatabaseInstance();
+		parent::tearDown();
+	}
+
+	public function test_page_is_not_in_main_menus(): void
+	{
+		$nav = file_get_contents(__DIR__ . '/../../styles/templates/game/main.navigation.tpl');
+		$bottom = file_get_contents(__DIR__ . '/../../styles/templates/game/main.bottomnav.tpl');
+		$this->assertStringNotContainsString('eventFirehose', $nav);
+		$this->assertStringNotContainsString('eventFirehose', $bottom);
+		$this->assertStringNotContainsString('ef_title', $nav);
+		$this->assertStringNotContainsString('ef_title', $bottom);
+	}
+
+	public function test_feed_ignores_client_universe_param(): void
+	{
+		$_REQUEST['universe'] = 2;
+		$_REQUEST['sinceId'] = 0;
+
+		Database::get()->insert(
+			'INSERT INTO %%UNIVERSE_EVENTS%% SET universe = :universe, time = :time, event_type = :eventType, size_bucket = :sizeBucket, outcome = :outcome;',
+			[
+				':universe' => 1,
+				':time' => 100,
+				':eventType' => 'battle',
+				':sizeBucket' => 'small',
+				':outcome' => 'attacker',
+			]
+		);
+		Database::get()->insert(
+			'INSERT INTO %%UNIVERSE_EVENTS%% SET universe = :universe, time = :time, event_type = :eventType, size_bucket = :sizeBucket, outcome = :outcome;',
+			[
+				':universe' => 2,
+				':time' => 100,
+				':eventType' => 'battle',
+				':sizeBucket' => 'small',
+				':outcome' => 'defender',
+			]
+		);
+
+		$page = new TestableShowEventFirehosePage();
+		$events = $page->publicEvents();
+		$this->assertCount(1, $events);
+		$this->assertSame(EventFirehoseFeed::JSON_KEYS, array_keys($events[0]));
+	}
+}

--- a/tests/check-bottom-nav.php
+++ b/tests/check-bottom-nav.php
@@ -65,7 +65,7 @@ $fullPages = [
     'alliance', 'messages', 'statistics', 'search', 'settings',
     'imperium', 'marketplace', 'trader', 'officier', 'techtree',
     'battlesimulator', 'battlehall', 'records', 'changelog', 'chat',
-    'buddylist', 'banlist', 'board', 'questions', 'ticket', 'viz',
+    'buddylist', 'banlist', 'board', 'questions', 'ticket', 'viz', 'eventFirehose',
 ];
 
 $popupPages = [

--- a/tests/js/event-firehose.test.js
+++ b/tests/js/event-firehose.test.js
@@ -1,0 +1,84 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert/strict');
+
+const firehose = require('../../scripts/game/event-firehose.js');
+
+function makeList(ids) {
+	const children = [];
+	const list = {
+		querySelector(sel) {
+			if (sel === '.event-firehose-empty') {
+				return children.find((c) => c.className === 'event-firehose-empty') || null;
+			}
+			return null;
+		},
+		querySelectorAll(sel) {
+			if (sel === '[data-event-id]') {
+				return children.filter((c) => c.getAttribute);
+			}
+			return [];
+		},
+		insertBefore(node) {
+			children.unshift(node);
+		},
+		firstChild: null,
+		_children: children
+	};
+	for (const id of ids) {
+		children.push({
+			getAttribute(name) { return name === 'data-event-id' ? String(id) : null; }
+		});
+	}
+	return list;
+}
+
+describe('HiveNovaEventFirehose', () => {
+	it('rejects login redirects as JSON', () => {
+		assert.equal(firehose.responseLooksLikeJson({ ok: true, url: 'https://x/index.php?code=3' }, '{}'), false);
+		assert.equal(firehose.responseLooksLikeJson({ ok: true, url: 'https://x/game.php?page=eventFirehose' }, '{"events":[]}'), true);
+		assert.equal(firehose.responseLooksLikeJson({ ok: false, url: 'https://x/game.php' }, '{"events":[]}'), false);
+	});
+
+	it('stops polling when the body is not JSON', async () => {
+		const list = makeList([]);
+		let calls = 0;
+		const poller = firehose.createPoller({
+			list,
+			hiddenFn: () => false,
+			fetchFn: async () => {
+				calls += 1;
+				return { ok: true, url: 'https://x/index.php?code=3', text: async () => '<html>login</html>' };
+			}
+		});
+		await poller.poll();
+		assert.equal(poller.isStopped(), true);
+		assert.equal(calls, 1);
+	});
+
+	it('does not poll while the tab is hidden', async () => {
+		let calls = 0;
+		const poller = firehose.createPoller({
+			list: makeList([]),
+			hiddenFn: () => true,
+			fetchFn: async () => {
+				calls += 1;
+				return { ok: true, url: 'https://x/game.php', text: async () => '{"events":[]}' };
+			}
+		});
+		await poller.poll();
+		assert.equal(calls, 0);
+		assert.equal(poller.isStopped(), false);
+	});
+
+	it('does not duplicate event ids when merging', () => {
+		const list = makeList([2]);
+		firehose.mergeEvents(list, [
+			{ id: 2, time: 'a', eventType: 'Battle', size: 'Skirmish', outcome: 'Draw' },
+			{ id: 3, time: 'b', eventType: 'Battle', size: 'Clash', outcome: 'Draw' }
+		]);
+		const ids = list.querySelectorAll('[data-event-id]').map((n) => n.getAttribute('data-event-id'));
+		assert.deepEqual(ids.sort(), ['2', '3']);
+	});
+});

--- a/tests/smoke.php
+++ b/tests/smoke.php
@@ -63,6 +63,7 @@ $pages = [
     'phalanx',
     'viz',
     'achievements',
+    'eventFirehose',
 ];
 
 $pass = 0;
@@ -258,6 +259,23 @@ if ($curlErr) {
     $fail++;
 } else {
     echo "OK (count=" . (int) $alert['count'] . ")\n";
+    $pass++;
+}
+
+echo "[ JSON ] eventFirehose      ";
+[$status, $body, $curlErr] = curl_get("$baseUrl/game.php?page=eventFirehose&ajax=1", $cookieFile);
+$feed = is_string($body) ? json_decode($body, true) : null;
+if ($curlErr) {
+    echo "FAIL curl error: $curlErr\n";
+    $fail++;
+} elseif ($status >= 400) {
+    echo "FAIL HTTP $status\n";
+    $fail++;
+} elseif (!is_array($feed) || !array_key_exists('events', $feed) || !is_array($feed['events'])) {
+    echo "FAIL expected JSON {events:[]}\n";
+    $fail++;
+} else {
+    echo "OK (events=" . count($feed['events']) . ")\n";
     $pass++;
 }
 


### PR DESCRIPTION
## Summary
- Adds an off-menu `game.php?page=eventFirehose` feed so logged-in players can see the universe moving without opening Hall of Fame.
- Combat (attack and destruction) writes a sanitized append-only `universe_events` row: generic battle, coarse size bucket, outcome — no names, coords, ships, `rid`, or raw loss totals.
- Polls JSON like the attack-alert page (`ajax=1`, pause when hidden, stop on login HTML). Retention uses `CleanerCronjob` / `del_oldstuff`.

## Test plan
- [ ] Run `./vendor/bin/phpunit` (EventFirehose*, ShowEventFirehose*, MissionCaseCombat, CleanerCronjob)
- [ ] Run `node --test tests/js/event-firehose.test.js`
- [ ] After migrate to DB v25, log in and open `game.php?page=eventFirehose` (no sidebar/bottom-nav link)
- [ ] Confirm empty state, then fight; after a full-page fleet tick, poll shows a vague battle row
- [ ] Confirm feed JSON keys are only `id`, `time`, `eventType`, `size`, `outcome`
- [ ] Confirm spy/MIP do not add rows; Hall of Fame still has names (unchanged)