### PR TITLE
Add salvage packages and inbound NPC raids (#108)

### DIFF
--- a/includes/classes/FleetDispatchService.php
+++ b/includes/classes/FleetDispatchService.php
@@ -49,6 +49,21 @@ class FleetDispatchService
         $fleetStorage       = $params['fleetStorage'];
         $consumption        = $params['consumption'];
 
+        if ($targetMission == 18) {
+            if (!isModuleAvailable(MODULE_MISSION_SALVAGE)) {
+                throw new \RuntimeException($LNG['fl_invalid_mission']);
+            }
+            $package = PvePackageService::findAt(
+                (int) $USER['universe'],
+                (int) $targetGalaxy,
+                (int) $targetSystem,
+                (int) $targetPlanet
+            );
+            if ($package === null) {
+                throw new \RuntimeException($LNG['fl_salvage_gone'] ?? $LNG['fl_no_target']);
+            }
+        }
+
         // Same planet
         if ($PLANET['galaxy'] == $targetGalaxy && $PLANET['system'] == $targetSystem &&
             $PLANET['planet'] == $targetPlanet && $PLANET['planet_type'] == $targetType) {
@@ -167,7 +182,7 @@ class FleetDispatchService
         }
 
         // For colonize / expedition / market the planet not existing is expected
-        if ($mission == 7 || $mission == 15 || $mission == 16) {
+        if ($mission == 7 || $mission == 15 || $mission == 16 || $mission == 18) {
             // synthetic target already set by caller — nothing to check here
         } else {
             if (!empty($targetPlanetData['destruyed'])) {
@@ -179,8 +194,8 @@ class FleetDispatchService
             }
         }
 
-        // Empty target player
-        if (empty($targetPlayerData)) {
+        // Empty target player (salvage on empty slot has no owner)
+        if (empty($targetPlayerData) && $mission != 18) {
             throw new \RuntimeException($LNG['fl_empty_target']);
         }
 
@@ -189,8 +204,8 @@ class FleetDispatchService
             throw new \RuntimeException($LNG['fl_invalid_mission']);
         }
 
-        // Vacation mode (except espionage = 8)
-        if ($mission != 8 && IsVacationMode($targetPlayerData)) {
+        // Vacation mode (except recycle and salvage)
+        if ($mission != 8 && $mission != 18 && !empty($targetPlayerData) && IsVacationMode($targetPlayerData)) {
             throw new \RuntimeException($LNG['fl_target_exists']);
         }
 

--- a/includes/classes/FleetFunctions.php
+++ b/includes/classes/FleetFunctions.php
@@ -457,7 +457,26 @@ class FleetFunctions
 		elseif ($MissionInfo['planettype'] == 2) {
 			if ((isset($MissionInfo['Ship'][209]) || isset($MissionInfo['Ship'][219])) && isModuleAvailable(MODULE_MISSION_RECYCLE) && !($GetInfoPlanet['der_metal'] == 0 && $GetInfoPlanet['der_crystal'] == 0))
 				$availableMissions[]	= 8;
+			$package = PvePackageService::findAt(
+				(int) $USER['universe'],
+				(int) $MissionInfo['galaxy'],
+				(int) $MissionInfo['system'],
+				(int) $MissionInfo['planet']
+			);
+			if ($package !== null && isModuleAvailable(MODULE_MISSION_SALVAGE)) {
+				$availableMissions[] = 18;
+			}
 		} else {
+			$package = PvePackageService::findAt(
+				(int) $USER['universe'],
+				(int) ($MissionInfo['galaxy'] ?? 0),
+				(int) ($MissionInfo['system'] ?? 0),
+				(int) $MissionInfo['planet']
+			);
+			if ($package !== null && isModuleAvailable(MODULE_MISSION_SALVAGE)) {
+				$availableMissions[] = 18;
+			}
+
 			if (!$UsedPlanet) {
 				if (isset($MissionInfo['Ship'][208]) && $MissionInfo['planettype'] == 1 && isModuleAvailable(MODULE_MISSION_COLONY))
 					$availableMissions[]	= 7;
@@ -575,7 +594,7 @@ class FleetFunctions
 		$fleetStartPlanetGalaxy, $fleetStartPlanetSystem, $fleetStartPlanetPlanet, $fleetStartPlanetType,
 		$fleetTargetOwner, $fleetTargetPlanetID, $fleetTargetPlanetGalaxy, $fleetTargetPlanetSystem,
 		$fleetTargetPlanetPlanet, $fleetTargetPlanetType, $fleetResource, $fleetStartTime, $fleetStayTime,
-		$fleetEndTime, $fleetGroup = 0, $missileTarget = 0, $fleetNoMReturn = 0, $consumption = 0)
+		$fleetEndTime, $fleetGroup = 0, $missileTarget = 0, $fleetNoMReturn = 0, $consumption = 0, $universe = null)
 	{
 		global $resource;
 		$fleetShipCount	= array_sum($fleetArray);
@@ -599,9 +618,10 @@ class FleetFunctions
 		}
 
 
-		$sql	= 'UPDATE %%PLANETS%% SET '.implode(', ', $planetQuery).' WHERE id = :planetId;';
-
-		$db->update($sql, $params);
+		if ($fleetStartPlanetID > 0) {
+			$sql	= 'UPDATE %%PLANETS%% SET '.implode(', ', $planetQuery).' WHERE id = :planetId;';
+			$db->update($sql, $params);
+		}
 
 		$sql	= 'INSERT INTO %%FLEETS%% SET
 		fleet_owner					= :fleetStartOwner,
@@ -657,7 +677,7 @@ class FleetFunctions
 			':fleetGroup'				=> $fleetGroup,
 			':missileTarget'			=> $missileTarget,
 			':timestamp'				=> TIMESTAMP,
-			':universe'	   				=> Universe::current(),
+			':universe'	   				=> $universe ?? Universe::current(),
 		));
 
 		$fleetId	= $db->lastInsertId();
@@ -724,7 +744,7 @@ class FleetFunctions
 			':fleetGroup'				=> $fleetGroup,
 			':missileTarget'			=> $missileTarget,
 			':timestamp'				=> TIMESTAMP,
-			':universe'	   				=> Universe::current(),
+			':universe'	   				=> $universe ?? Universe::current(),
 		));
 
 		FrequentLocationService::tryRecordFromFleet(

--- a/includes/classes/FlyingFleetHandler.php
+++ b/includes/classes/FlyingFleetHandler.php
@@ -38,6 +38,7 @@ class FlyingFleetHandler
 		15	=> 'HiveNova\\Mission\\MissionCaseExpedition',
 		16	=> 'HiveNova\\Mission\\MissionCaseTrade',
 		17	=> 'HiveNova\\Mission\\MissionCaseTransfer',
+		18	=> 'HiveNova\\Mission\\MissionCaseSalvage',
 	);
 
 	function setToken($token)

--- a/includes/classes/GalaxyRows.php
+++ b/includes/classes/GalaxyRows.php
@@ -31,6 +31,8 @@ class GalaxyRows
 	private $System;
 	private $galaxyData;
 	private $galaxyRow;
+	/** @var array<int, array<string, mixed>> */
+	private $salvageByPlanet = [];
 	
 	const PLANET_DESTROYED = false;
 	
@@ -82,7 +84,12 @@ class GalaxyRows
 			':galaxy'			=> $this->Galaxy,
 			':system'			=> $this->System,
 			':planetTypePlanet'	=> 1,
-	  	));
+		));
+
+		$this->salvageByPlanet = [];
+		foreach (PvePackageService::inSystem(Universe::current(), (int) $this->Galaxy, (int) $this->System) as $pkg) {
+			$this->salvageByPlanet[(int) $pkg['planet']] = $pkg;
+		}
 
 		foreach ($galaxyResult as $galaxyRow)
 		{
@@ -195,6 +202,7 @@ class GalaxyRows
 			8	=> isModuleAvailable(MODULE_MISSION_RECYCLE),
 			9	=> !$this->galaxyData[$this->galaxyRow['planet']]['ownPlanet'] && $PLANET[$resource[214]] > 0 && isModuleAvailable(MODULE_MISSION_DESTROY),
 			10	=> !$this->galaxyData[$this->galaxyRow['planet']]['ownPlanet'] && $PLANET[$resource[503]] > 0 && isModuleAvailable(MODULE_MISSION_ATTACK) && isModuleAvailable(MODULE_MISSILEATTACK) && $this->inMissileRange(),
+			18	=> isModuleAvailable(MODULE_MISSION_SALVAGE) && isset($this->salvageByPlanet[(int) $this->galaxyRow['planet']]),
 		);
 	}
 
@@ -291,12 +299,18 @@ class GalaxyRows
 	protected function getDebrisData()
 	{
 		$total		= $this->galaxyRow['der_metal'] + $this->galaxyRow['der_crystal'];
+		$pkg = $this->salvageByPlanet[(int) $this->galaxyRow['planet']] ?? null;
+		if ($pkg !== null) {
+			$loot = PvePackageService::currentLoot($pkg);
+			$total += $loot['metal'] + $loot['crystal'];
+			$this->galaxyData[$this->galaxyRow['planet']]['salvage'] = $this->salvageHint($pkg);
+		}
 		if($total == 0) {
 			$this->galaxyData[$this->galaxyRow['planet']]['debris']	= false;
 		} else {
 			$this->galaxyData[$this->galaxyRow['planet']]['debris']	= array(
-				'metal'			=> $this->galaxyRow['der_metal'],
-				'crystal'		=> $this->galaxyRow['der_crystal'],
+				'metal'			=> $this->galaxyRow['der_metal'] + (int) ($loot['metal'] ?? 0),
+				'crystal'		=> $this->galaxyRow['der_crystal'] + (int) ($loot['crystal'] ?? 0),
 			);
 		}
 	}
@@ -573,15 +587,25 @@ class GalaxyRows
 
 		$vizEnabled = str_contains($themePath, '/hive/');
 		$hasCapacity = PlayerUtil::hasColonizationCapacity($USER);
+		if ($this->salvageByPlanet === []) {
+			foreach (PvePackageService::inSystem(Universe::current(), $galaxy, $system) as $pkg) {
+				$this->salvageByPlanet[(int) $pkg['planet']] = $pkg;
+			}
+		}
 		for ($position = 1; $position <= $maxPlanets; $position++) {
 			if (isset($galaxyData[$position])) {
 				continue;
 			}
 			$colonizeStatus = $this->getColonizeSlotStatus($position, $hasCapacity);
+			$pkg = $this->salvageByPlanet[$position] ?? null;
 			$galaxyData[$position] = array(
 				'uncolonized'             => true,
 				'canColonize'             => $colonizeStatus['canColonize'],
 				'colonizeBlockedReason'   => $colonizeStatus['colonizeBlockedReason'],
+				'salvage'                 => $pkg !== null ? $this->salvageHint($pkg) : null,
+				'missions'                => array(
+					18 => $pkg !== null && isModuleAvailable(MODULE_MISSION_SALVAGE),
+				),
 				'planet'                  => array(
 					'image'   => 'unknown',
 					'vizRef'  => $vizEnabled
@@ -599,12 +623,13 @@ class GalaxyRows
 		}
 
 		if (preg_match('/^slot:(\d+):(\d+):(\d+)$/', $ref, $matches)) {
-			$json = $this->buildUncolonizedPlanetVizJson(
-				(int) $matches[1],
-				(int) $matches[2],
-				(int) $matches[3],
-				$themePath
-			);
+			$galaxy = (int) $matches[1];
+			$system = (int) $matches[2];
+			$planet = (int) $matches[3];
+			$package = PvePackageService::findAt(Universe::current(), $galaxy, $system, $planet);
+			global $USER, $resource;
+			$spyTech = (int) ($USER[$resource[106] ?? 'spy_tech'] ?? $USER['spy_tech'] ?? 0);
+			$json = $this->buildUncolonizedPlanetVizJson($galaxy, $system, $planet, $themePath, $package, $spyTech);
 
 			return json_decode($json, true);
 		}
@@ -697,8 +722,19 @@ class GalaxyRows
 		return is_array($row) ? $row : null;
 	}
 
-	public function buildUncolonizedPlanetVizJson(int $galaxy, int $system, int $planet, string $dpath): string
+	public function buildUncolonizedPlanetVizJson(int $galaxy, int $system, int $planet, string $dpath, ?array $package = null, int $spyTech = 0): string
 	{
+		$debris = null;
+		$salvage = null;
+		if ($package !== null) {
+			$loot = PvePackageService::currentLoot($package);
+			$debris = array(
+				'metal'   => $loot['metal'],
+				'crystal' => $loot['crystal'],
+			);
+			$salvage = $this->salvageHint($package, $spyTech);
+		}
+
 		$payload = array(
 			'shareIntel' => false,
 			'vizState'  => 'unknown',
@@ -722,10 +758,25 @@ class GalaxyRows
 				'hangar'   => 0,
 			),
 			'moon'      => null,
-			'debris'    => null,
+			'debris'    => $debris,
+			'salvage'   => $salvage,
 			'dpath'     => $dpath,
 		);
 
 		return json_encode($payload, JSON_HEX_TAG | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_HEX_AMP);
+	}
+
+	/**
+	 * @param array<string, mixed> $package
+	 * @return array<string, mixed>
+	 */
+	public function salvageHint(array $package, ?int $spyTech = null): array
+	{
+		global $USER, $resource;
+		if ($spyTech === null) {
+			$spyTech = (int) ($USER[$resource[106] ?? 'spy_tech'] ?? $USER['spy_tech'] ?? 0);
+		}
+
+		return PvePackageService::spyHint($package, $spyTech);
 	}
 }

--- a/includes/classes/PushingAccusationQuery.php
+++ b/includes/classes/PushingAccusationQuery.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace HiveNova\Core;
+
+use HiveNova\Core\Database;
+
+class PushingAccusationQuery
+{
+	/**
+	 * User IDs that GM mail names as push destinations (stronger receivers).
+	 *
+	 * @return list<int>
+	 */
+	public static function accusedReceiverIds(int $universe, ?int $now = null): array
+	{
+		$cutoff = ($now ?? TIMESTAMP) - (14 * 24 * 60 * 60);
+
+		$sql = 'SELECT dest_id
+		FROM (
+			SELECT u2.id AS dest_id
+			FROM %%LOG_FLEETS%% fl
+			JOIN %%PLANETS%% p ON fl.fleet_end_id = p.id
+			JOIN %%USERS%% u1 ON u1.id = fl.fleet_owner
+			JOIN %%USERS%% u2 ON u2.id = p.id_owner
+			JOIN %%STATPOINTS%% sp1 ON sp1.id_owner = u1.id AND sp1.universe = :universe
+			JOIN %%STATPOINTS%% sp2 ON sp2.id_owner = u2.id AND sp2.universe = :universe
+			WHERE fl.fleet_mission = 3
+			  AND fl.fleet_owner != p.id_owner
+			  AND sp1.total_points < sp2.total_points
+			  AND fl.start_time > :cutoff
+			  AND p.universe = :universe
+			GROUP BY u1.id, u2.id
+			HAVING COUNT(DISTINCT fl.fleet_id) > 5
+		) pushers
+		GROUP BY dest_id;';
+
+		$rows = Database::get()->select($sql, [
+			':universe' => $universe,
+			':cutoff'   => $cutoff,
+		]);
+
+		$ids = [];
+		foreach ($rows as $row) {
+			$ids[] = (int) $row['dest_id'];
+		}
+
+		return $ids;
+	}
+
+	public static function isAccusedReceiver(int $userId, int $universe, ?int $now = null): bool
+	{
+		return in_array($userId, self::accusedReceiverIds($universe, $now), true);
+	}
+}

--- a/includes/classes/PveNpcFleetFactory.php
+++ b/includes/classes/PveNpcFleetFactory.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace HiveNova\Core;
+
+class PveNpcFleetFactory
+{
+	/**
+	 * Fixed templates by tier (1 small, 2 medium, 3 large) and family.
+	 * Never copies the player's fleet.
+	 *
+	 * @return array<int, int> shipId => count
+	 */
+	public static function template(string $family, int $tier, bool $accusedBump = false): array
+	{
+		$tier = max(1, min(3, $tier));
+		$family = strtolower($family);
+
+		$templates = [
+			'pirate' => [
+				1 => [204 => 8, 202 => 2],
+				2 => [204 => 12, 206 => 4],
+				3 => [206 => 6, 207 => 3],
+			],
+			'alien' => [
+				1 => [205 => 6, 203 => 1],
+				2 => [205 => 10, 215 => 3],
+				3 => [215 => 5, 213 => 2],
+			],
+			'salvager' => [
+				1 => [209 => 4, 204 => 4],
+				2 => [209 => 6, 206 => 3],
+				3 => [219 => 2, 207 => 2],
+			],
+		];
+
+		if (!isset($templates[$family])) {
+			$family = 'pirate';
+		}
+
+		$ships = $templates[$family][$tier];
+		if ($accusedBump) {
+			foreach ($ships as $id => $count) {
+				$ships[$id] = (int) ceil($count * PVE_ACCUSED_SHIP_FACTOR);
+			}
+		}
+
+		return $ships;
+	}
+
+	public static function familyFromSeed(int $seed): string
+	{
+		$roll = abs($seed) % 100;
+		if ($roll < 50) {
+			return 'pirate';
+		}
+		if ($roll < 80) {
+			return 'alien';
+		}
+
+		return 'salvager';
+	}
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	public static function syntheticPlayer(string $username = 'Pirates', int $tech = 5): array
+	{
+		return [
+			'id' => 0,
+			'username' => $username,
+			'military_tech' => $tech,
+			'defence_tech' => $tech,
+			'shield_tech' => $tech,
+			'dmg_cd' => 0,
+			'rpg_amiral' => 0,
+			'lang' => 'en',
+			'factor' => [
+				'Attack' => 0,
+				'Defensive' => 0,
+				'Shield' => 0,
+			],
+		];
+	}
+
+	public static function displayName(string $family): string
+	{
+		return match ($family) {
+			'alien' => 'Aliens',
+			'salvager' => 'Salvagers',
+			default => 'Pirates',
+		};
+	}
+}

--- a/includes/classes/PveNpcFleetFactory.php
+++ b/includes/classes/PveNpcFleetFactory.php
@@ -74,6 +74,7 @@ class PveNpcFleetFactory
 			'dmg_cd' => 0,
 			'rpg_amiral' => 0,
 			'lang' => 'en',
+			'universe' => defined('ROOT_UNI') ? ROOT_UNI : 1,
 			'factor' => [
 				'Attack' => 0,
 				'Defensive' => 0,

--- a/includes/classes/PvePackageService.php
+++ b/includes/classes/PvePackageService.php
@@ -1,0 +1,265 @@
+<?php
+
+namespace HiveNova\Core;
+
+use HiveNova\Core\Config;
+use HiveNova\Core\Database;
+
+class PvePackageService
+{
+	/**
+	 * @param array<string, mixed> $row
+	 * @return array{metal: int, crystal: int}
+	 */
+	public static function currentLoot(array $row, ?int $now = null): array
+	{
+		$now = $now ?? TIMESTAMP;
+		$ageHours = max(0, ($now - (int) $row['spawned_at']) / 3600);
+		$growth = (int) floor($ageHours * PVE_PACKAGE_GROWTH_PER_HOUR);
+
+		return [
+			'metal'   => (int) min(PVE_PACKAGE_CAP_METAL, (int) $row['metal'] + $growth),
+			'crystal' => (int) min(PVE_PACKAGE_CAP_CRYSTAL, (int) $row['crystal'] + $growth),
+		];
+	}
+
+	public static function spawnBudget(int $onlineCount): int
+	{
+		return min(PVE_SPAWN_HARD_CAP, PVE_SPAWN_BASE + $onlineCount * PVE_SPAWN_PER_ONLINE);
+	}
+
+	public static function countOnline(int $universe, ?int $now = null): int
+	{
+		$now = $now ?? TIMESTAMP;
+		$row = Database::get()->selectSingle(
+			'SELECT COUNT(*) AS total FROM %%USERS%%
+			WHERE universe = :universe AND urlaubs_modus = 0 AND onlinetime >= :since;',
+			[
+				':universe' => $universe,
+				':since'    => $now - PVE_ONLINE_WINDOW,
+			]
+		);
+
+		return (int) ($row['total'] ?? 0);
+	}
+
+	public static function expireOld(int $universe, ?int $now = null): void
+	{
+		Database::get()->delete(
+			'DELETE FROM %%SALVAGE_PACKAGES%% WHERE universe = :universe AND expires_at <= :now;',
+			[
+				':universe' => $universe,
+				':now'      => $now ?? TIMESTAMP,
+			]
+		);
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public static function findAt(int $universe, int $galaxy, int $system, int $planet): ?array
+	{
+		$row = Database::get()->selectSingle(
+			'SELECT * FROM %%SALVAGE_PACKAGES%%
+			WHERE universe = :universe AND galaxy = :galaxy AND `system` = :system AND planet = :planet
+			AND expires_at > :now;',
+			[
+				':universe' => $universe,
+				':galaxy'   => $galaxy,
+				':system'   => $system,
+				':planet'   => $planet,
+				':now'      => TIMESTAMP,
+			]
+		);
+
+		return is_array($row) ? $row : null;
+	}
+
+	/**
+	 * @return list<array<string, mixed>>
+	 */
+	public static function inSystem(int $universe, int $galaxy, int $system): array
+	{
+		$rows = Database::get()->select(
+			'SELECT * FROM %%SALVAGE_PACKAGES%%
+			WHERE universe = :universe AND galaxy = :galaxy AND `system` = :system AND expires_at > :now;',
+			[
+				':universe' => $universe,
+				':galaxy'   => $galaxy,
+				':system'   => $system,
+				':now'      => TIMESTAMP,
+			]
+		);
+
+		return is_array($rows) ? $rows : [];
+	}
+
+	/**
+	 * @return array<string, mixed>|null
+	 */
+	public static function lockAt(int $universe, int $galaxy, int $system, int $planet): ?array
+	{
+		$row = Database::get()->selectSingle(
+			'SELECT * FROM %%SALVAGE_PACKAGES%%
+			WHERE universe = :universe AND galaxy = :galaxy AND `system` = :system AND planet = :planet
+			AND expires_at > :now FOR UPDATE;',
+			[
+				':universe' => $universe,
+				':galaxy'   => $galaxy,
+				':system'   => $system,
+				':planet'   => $planet,
+				':now'      => TIMESTAMP,
+			]
+		);
+
+		return is_array($row) ? $row : null;
+	}
+
+	public static function collect(int $id, int $metalTaken, int $crystalTaken): void
+	{
+		Database::get()->update(
+			'UPDATE %%SALVAGE_PACKAGES%%
+			SET metal = GREATEST(0, metal - :metal), crystal = GREATEST(0, crystal - :crystal)
+			WHERE id = :id;',
+			[
+				':metal'   => $metalTaken,
+				':crystal' => $crystalTaken,
+				':id'      => $id,
+			]
+		);
+
+		Database::get()->delete(
+			'DELETE FROM %%SALVAGE_PACKAGES%% WHERE id = :id AND metal <= 0 AND crystal <= 0;',
+			[':id' => $id]
+		);
+	}
+
+	public static function attachToPlanet(int $universe, int $galaxy, int $system, int $planet, int $planetId): void
+	{
+		Database::get()->update(
+			'UPDATE %%SALVAGE_PACKAGES%% SET planet_id = :planetId
+			WHERE universe = :universe AND galaxy = :galaxy AND `system` = :system AND planet = :planet;',
+			[
+				':planetId' => $planetId,
+				':universe' => $universe,
+				':galaxy'   => $galaxy,
+				':system'   => $system,
+				':planet'   => $planet,
+			]
+		);
+	}
+
+	public static function spyHint(array $row, int $spyTech): array
+	{
+		$loot = self::currentLoot($row);
+		$hint = [
+			'metal'   => $loot['metal'],
+			'crystal' => $loot['crystal'],
+		];
+		if ($spyTech >= 4) {
+			$hint['family'] = PveNpcFleetFactory::familyFromSeed((int) $row['encounter_seed']);
+		}
+		if ($spyTech >= 8) {
+			$hint['tier'] = (int) $row['tier'];
+		}
+
+		return $hint;
+	}
+
+	public static function spawnTick(int $universe, ?int $now = null): int
+	{
+		if (!isModuleAvailable(MODULE_MISSION_SALVAGE)) {
+			return 0;
+		}
+
+		$now = $now ?? TIMESTAMP;
+		self::expireOld($universe, $now);
+
+		$existing = (int) (Database::get()->selectSingle(
+			'SELECT COUNT(*) AS total FROM %%SALVAGE_PACKAGES%% WHERE universe = :universe AND expires_at > :now;',
+			[':universe' => $universe, ':now' => $now]
+		)['total'] ?? 0);
+
+		$budget = self::spawnBudget(self::countOnline($universe, $now));
+		$toSpawn = max(0, $budget - $existing);
+		if ($toSpawn === 0) {
+			return 0;
+		}
+
+		$config = Config::get($universe);
+		$accused = PushingAccusationQuery::accusedReceiverIds($universe, $now);
+		$created = 0;
+
+		for ($i = 0; $i < $toSpawn * 8 && $created < $toSpawn; $i++) {
+			$galaxy = mt_rand(1, (int) $config->max_galaxy);
+			$system = mt_rand(1, (int) $config->max_system);
+			$planet = mt_rand(1, (int) $config->max_planets);
+
+			if (self::findAt($universe, $galaxy, $system, $planet) !== null) {
+				continue;
+			}
+
+			$occupied = Database::get()->selectSingle(
+				'SELECT id, id_owner FROM %%PLANETS%%
+				WHERE universe = :universe AND galaxy = :galaxy AND `system` = :system AND planet = :planet
+				AND planet_type = 1 AND destruyed = 0;',
+				[
+					':universe' => $universe,
+					':galaxy'   => $galaxy,
+					':system'   => $system,
+					':planet'   => $planet,
+				]
+			);
+
+			$planetId = null;
+			if (!empty($occupied['id'])) {
+				$overlayChance = PVE_OVERLAY_CHANCE;
+				$ownerId = (int) $occupied['id_owner'];
+				if (in_array($ownerId, $accused, true)) {
+					$overlayChance += PVE_ACCUSED_OVERLAY_BONUS;
+				}
+				if (mt_rand(1, 100) > $overlayChance) {
+					continue;
+				}
+				$owner = Database::get()->selectSingle(
+					'SELECT u.id, u.urlaubs_modus, u.onlinetime, s.total_points FROM %%USERS%% u
+					LEFT JOIN %%STATPOINTS%% s ON s.id_owner = u.id AND s.stat_type = 1
+					WHERE u.id = :id;',
+					[':id' => $ownerId]
+				);
+				if (!empty($owner['urlaubs_modus'])) {
+					continue;
+				}
+				$noobTime = (int) $config->noobprotectiontime;
+				if (!empty($config->noobprotection) && $noobTime > 0
+					&& (int) ($owner['total_points'] ?? 0) <= $noobTime) {
+					continue;
+				}
+				$planetId = (int) $occupied['id'];
+			}
+
+			$tier = mt_rand(1, 3);
+			Database::get()->insert(
+				'INSERT INTO %%SALVAGE_PACKAGES%%
+				(universe, galaxy, `system`, planet, planet_id, metal, crystal, spawned_at, expires_at, tier, encounter_seed)
+				VALUES (:universe, :galaxy, :system, :planet, :planetId, :metal, :crystal, :spawned, :expires, :tier, :seed);',
+				[
+					':universe' => $universe,
+					':galaxy'   => $galaxy,
+					':system'   => $system,
+					':planet'   => $planet,
+					':planetId' => $planetId,
+					':metal'    => PVE_PACKAGE_BASE_METAL * $tier,
+					':crystal'  => PVE_PACKAGE_BASE_CRYSTAL * $tier,
+					':spawned'  => $now,
+					':expires'  => $now + PVE_PACKAGE_TTL,
+					':tier'     => $tier,
+					':seed'     => mt_rand(1, 1000000),
+				]
+			);
+			$created++;
+		}
+
+		return $created;
+	}
+}

--- a/includes/classes/PveRaidService.php
+++ b/includes/classes/PveRaidService.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace HiveNova\Core;
+
+use HiveNova\Core\Database;
+use HiveNova\Core\FleetFunctions;
+
+class PveRaidService
+{
+	public static function run(int $universe, ?int $now = null): int
+	{
+		if (!isModuleAvailable(MODULE_MISSION_SALVAGE)) {
+			return 0;
+		}
+
+		$now = $now ?? TIMESTAMP;
+		$spawned = 0;
+		$spawned += self::raidCombatOutPlayers($universe, $now);
+		$spawned += self::raidAccusedWithoutCombat($universe, $now);
+
+		return $spawned;
+	}
+
+	private static function raidCombatOutPlayers(int $universe, int $now): int
+	{
+		$rows = Database::get()->select(
+			'SELECT DISTINCT fleet_owner, fleet_start_id, fleet_start_galaxy, fleet_start_system,
+				fleet_start_planet, fleet_start_type, fleet_amount
+			FROM %%FLEETS%%
+			WHERE fleet_universe = :universe
+			  AND fleet_mission IN (1, 2, 9)
+			  AND fleet_mess = :outward;',
+			[
+				':universe' => $universe,
+				':outward'  => FLEET_OUTWARD,
+			]
+		);
+
+		$count = 0;
+		foreach ($rows as $row) {
+			if (self::trySpawnRaid($universe, (int) $row['fleet_owner'], $row, $now, false)) {
+				$count++;
+			}
+		}
+
+		return $count;
+	}
+
+	private static function raidAccusedWithoutCombat(int $universe, int $now): int
+	{
+		$count = 0;
+		foreach (PushingAccusationQuery::accusedReceiverIds($universe, $now) as $userId) {
+			if (mt_rand(1, 100) > PVE_ACCUSED_RAID_CHANCE) {
+				continue;
+			}
+			$planet = Database::get()->selectSingle(
+				'SELECT id, galaxy, `system`, planet, planet_type, id_owner FROM %%PLANETS%%
+				WHERE id_owner = :userId AND planet_type = 1 AND destruyed = 0
+				ORDER BY id ASC LIMIT 1;',
+				[':userId' => $userId]
+			);
+			if (empty($planet['id'])) {
+				continue;
+			}
+			$fake = [
+				'fleet_owner' => $userId,
+				'fleet_start_id' => $planet['id'],
+				'fleet_start_galaxy' => $planet['galaxy'],
+				'fleet_start_system' => $planet['system'],
+				'fleet_start_planet' => $planet['planet'],
+				'fleet_start_type' => $planet['planet_type'],
+				'fleet_amount' => 50,
+			];
+			if (self::trySpawnRaid($universe, $userId, $fake, $now, true)) {
+				$count++;
+			}
+		}
+
+		return $count;
+	}
+
+	/**
+	 * @param array<string, mixed> $outward
+	 */
+	public static function trySpawnRaid(int $universe, int $userId, array $outward, int $now, bool $accusedIdlePath): bool
+	{
+		$user = Database::get()->selectSingle(
+			'SELECT id, urlaubs_modus FROM %%USERS%% WHERE id = :id;',
+			[':id' => $userId]
+		);
+		if (empty($user) || !empty($user['urlaubs_modus'])) {
+			return false;
+		}
+
+		$planetId = (int) $outward['fleet_start_id'];
+		if (self::hasInboundNpc($planetId)) {
+			return false;
+		}
+
+		$planet = Database::get()->selectSingle(
+			'SELECT * FROM %%PLANETS%% WHERE id = :id;',
+			[':id' => $planetId]
+		);
+		if (empty($planet['id'])) {
+			return false;
+		}
+
+		$hangar = self::hangarPower($planet);
+		$outbound = max(1, (int) $outward['fleet_amount']);
+		if (!$accusedIdlePath && $hangar >= $outbound * PVE_HANGAR_WEAK_FRACTION) {
+			return false;
+		}
+		if ($accusedIdlePath && $hangar >= $outbound * PVE_HANGAR_WEAK_FRACTION) {
+			return false;
+		}
+
+		$accused = PushingAccusationQuery::isAccusedReceiver($userId, $universe, $now);
+		$family = mt_rand(0, 1) ? 'pirate' : 'alien';
+		$tier = $accused ? 2 : 1;
+		$ships = PveNpcFleetFactory::template($family, $tier, $accused);
+		$flight = PVE_RAID_FLIGHT_SECONDS;
+		$startTime = $now + $flight;
+		$endTime = $startTime + $flight;
+
+		FleetFunctions::sendFleet(
+			$ships,
+			1,
+			0,
+			0,
+			(int) $planet['galaxy'],
+			(int) $planet['system'],
+			(int) $planet['planet'],
+			(int) $planet['planet_type'],
+			$userId,
+			$planetId,
+			(int) $planet['galaxy'],
+			(int) $planet['system'],
+			(int) $planet['planet'],
+			(int) $planet['planet_type'],
+			[901 => 0, 902 => 0, 903 => 0],
+			$startTime,
+			$startTime,
+			$endTime,
+			0,
+			0,
+			1,
+			0,
+			$universe
+		);
+
+		return true;
+	}
+
+	private static function hasInboundNpc(int $planetId): bool
+	{
+		$row = Database::get()->selectSingle(
+			'SELECT COUNT(*) AS total FROM %%FLEETS%%
+			WHERE fleet_end_id = :planetId AND fleet_owner = 0 AND fleet_mission = 1 AND fleet_mess = :outward;',
+			[
+				':planetId' => $planetId,
+				':outward'  => FLEET_OUTWARD,
+			]
+		);
+
+		return (int) ($row['total'] ?? 0) > 0;
+	}
+
+	/**
+	 * @param array<string, mixed> $planet
+	 */
+	public static function hangarPower(array $planet): int
+	{
+		global $resource, $reslist, $pricelist;
+
+		$power = 0;
+		$ids = array_merge($reslist['fleet'] ?? [], $reslist['defense'] ?? []);
+		foreach ($ids as $elementId) {
+			$key = $resource[$elementId] ?? null;
+			if ($key === null || empty($planet[$key])) {
+				continue;
+			}
+			$attack = (int) ($pricelist[$elementId]['attack'] ?? 1);
+			$power += $attack * (int) $planet[$key];
+		}
+
+		return $power;
+	}
+}

--- a/includes/classes/cronjob/PveSpawnCronjob.php
+++ b/includes/classes/cronjob/PveSpawnCronjob.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace HiveNova\Cronjob;
+
+use HiveNova\Core\PvePackageService;
+use HiveNova\Core\PveRaidService;
+use HiveNova\Core\Universe;
+use HiveNova\Cronjob\CronjobTask;
+
+class PveSpawnCronjob implements CronjobTask
+{
+	public function run()
+	{
+		foreach (Universe::availableUniverses() as $universe) {
+			PvePackageService::spawnTick((int) $universe);
+			PveRaidService::run((int) $universe);
+		}
+
+		return true;
+	}
+}

--- a/includes/classes/missions/MissionCaseAttack.php
+++ b/includes/classes/missions/MissionCaseAttack.php
@@ -130,6 +130,7 @@ HTML;
 				$fleetAttack[$fleetID]['player'] = \HiveNova\Core\PveNpcFleetFactory::syntheticPlayer(
 					\HiveNova\Core\PveNpcFleetFactory::displayName($family)
 				);
+				$fleetAttack[$fleetID]['player']['universe'] = (int) $this->_fleet['fleet_universe'];
 			} else {
 				$fleetAttack[$fleetID]['player']	= $this->getUser((int) $fleetDetail['fleet_owner']);
 			}

--- a/includes/classes/missions/MissionCaseAttack.php
+++ b/includes/classes/missions/MissionCaseAttack.php
@@ -125,7 +125,14 @@ HTML;
 		
 		foreach($incomingFleets as $fleetID => $fleetDetail)
 		{
-			$fleetAttack[$fleetID]['player']	= $this->getUser((int) $fleetDetail['fleet_owner']);
+			if ((int) $fleetDetail['fleet_owner'] === 0) {
+				$family = str_contains((string) $fleetDetail['fleet_array'], '205,') ? 'alien' : 'pirate';
+				$fleetAttack[$fleetID]['player'] = \HiveNova\Core\PveNpcFleetFactory::syntheticPlayer(
+					\HiveNova\Core\PveNpcFleetFactory::displayName($family)
+				);
+			} else {
+				$fleetAttack[$fleetID]['player']	= $this->getUser((int) $fleetDetail['fleet_owner']);
+			}
 
 			$fleetAttack[$fleetID]['player']['factor']	= getFactors($fleetAttack[$fleetID]['player'], 'attack', $this->_fleet['fleet_start_time']);
 			$fleetAttack[$fleetID]['fleetDetail']		= $fleetDetail;
@@ -533,6 +540,7 @@ HTML;
 			$debrisType	= 'id';
 		}
 		
+		if ((int) $this->_fleet['fleet_owner'] !== 0) {
 		$sql = 'UPDATE %%PLANETS%% SET
 		der_metal	= :metal,
 		der_crystal	= :crystal
@@ -543,6 +551,7 @@ HTML;
 			':crystal'	=> $planetDebris[902],
 			':planetId'	=> $this->_fleet['fleet_end_id']
 		));
+		}
 
 		$sql = 'UPDATE %%PLANETS%% SET
 		metal		= metal - :metal,
@@ -624,6 +633,11 @@ HTML;
 	
 	function ReturnEvent()
 	{
+		if ((int) $this->_fleet['fleet_owner'] === 0) {
+			$this->KillFleet();
+			return;
+		}
+
 		$LNG		= $this->getLanguage(NULL, $this->_fleet['fleet_owner']);
 
 

--- a/includes/classes/missions/MissionCaseColonisation.php
+++ b/includes/classes/missions/MissionCaseColonisation.php
@@ -88,6 +88,13 @@ class MissionCaseColonisation extends MissionFunctions implements Mission
 					else
 					{
 						$this->_fleet['fleet_end_id']	= $NewOwnerPlanet;
+						\HiveNova\Core\PvePackageService::attachToPlanet(
+							(int) $this->_fleet['fleet_universe'],
+							(int) $this->_fleet['fleet_end_galaxy'],
+							(int) $this->_fleet['fleet_end_system'],
+							(int) $this->_fleet['fleet_end_planet'],
+							(int) $NewOwnerPlanet
+						);
 						$message = sprintf($LNG['sys_colo_allisok'], GetTargetAddressLink($this->_fleet, ''));
 						\HiveNova\Core\AchievementHooks::afterColonisation((int) $this->_fleet['fleet_owner']);
 						$this->StoreGoodsToPlanet();

--- a/includes/classes/missions/MissionCaseSalvage.php
+++ b/includes/classes/missions/MissionCaseSalvage.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace HiveNova\Mission;
+
+use HiveNova\Core\Config;
+use HiveNova\Core\Database;
+use HiveNova\Core\FleetFunctions;
+use HiveNova\Core\MissionFunctions;
+use HiveNova\Core\PlayerUtil;
+use HiveNova\Core\PveNpcFleetFactory;
+use HiveNova\Core\PvePackageService;
+use HiveNova\Core\PushingAccusationQuery;
+use HiveNova\Repository\PlanetRepository;
+
+class MissionCaseSalvage extends MissionFunctions implements Mission
+{
+	function __construct($Fleet)
+	{
+		$this->_fleet = $Fleet;
+	}
+
+	function TargetEvent()
+	{
+		global $pricelist, $resource;
+
+		$db = Database::get();
+		$universe = (int) $this->_fleet['fleet_universe'];
+		$galaxy = (int) $this->_fleet['fleet_end_galaxy'];
+		$system = (int) $this->_fleet['fleet_end_system'];
+		$planet = (int) $this->_fleet['fleet_end_planet'];
+
+		$colonized = $db->selectSingle(
+			'SELECT id FROM %%PLANETS%%
+			WHERE universe = :universe AND galaxy = :galaxy AND `system` = :system AND planet = :planet
+			AND planet_type = 1 AND destruyed = 0;',
+			[
+				':universe' => $universe,
+				':galaxy'   => $galaxy,
+				':system'   => $system,
+				':planet'   => $planet,
+			]
+		);
+		if (!empty($colonized['id']) && (int) $this->_fleet['fleet_end_id'] === 0) {
+			$this->UpdateFleet('fleet_end_id', (int) $colonized['id']);
+			PvePackageService::attachToPlanet($universe, $galaxy, $system, $planet, (int) $colonized['id']);
+			$this->UpdateFleet('fleet_end_id', (int) $colonized['id']);
+			PvePackageService::attachToPlanet($universe, $galaxy, $system, $planet, (int) $colonized['id']);
+		}
+
+		$package = PvePackageService::lockAt($universe, $galaxy, $system, $planet);
+		if ($package === null) {
+			$this->bounceEmpty();
+			return;
+		}
+
+		$owner = $this->getUser((int) $this->_fleet['fleet_owner']);
+		$accused = PushingAccusationQuery::isAccusedReceiver((int) $this->_fleet['fleet_owner'], $universe)
+			|| (!empty($package['planet_id']) && $this->planetOwnerAccused((int) $package['planet_id'], $universe));
+
+		$chance = PVE_ENCOUNTER_CHANCE + ($accused ? PVE_ACCUSED_ENCOUNTER_BONUS : 0);
+		$roll = abs((int) $package['encounter_seed']) % 100;
+		if ($roll < $chance) {
+			$survived = $this->fightEncounter($package, $owner, $accused);
+			if (!$survived) {
+				return;
+			}
+		}
+
+		$loot = PvePackageService::currentLoot($package);
+		$fleetData = FleetFunctions::unserialize($this->_fleet['fleet_array']);
+		$capacity = 0;
+		foreach ($fleetData as $shipId => $shipAmount) {
+			$capacity += ($pricelist[$shipId]['capacity'] ?? 0) * $shipAmount;
+		}
+		$factors = getFactors($owner);
+		$capacity *= (1 + ($factors['ShipStorage'] ?? 0));
+		$incoming = (int) $this->_fleet['fleet_resource_metal']
+			+ (int) $this->_fleet['fleet_resource_crystal']
+			+ (int) $this->_fleet['fleet_resource_deuterium'];
+		$free = max(0, (int) $capacity - $incoming);
+
+		$totalLoot = $loot['metal'] + $loot['crystal'];
+		$factor = $totalLoot > 0 ? min(1, $free / $totalLoot) : 0;
+		$takeMetal = (int) floor($loot['metal'] * $factor);
+		$takeCrystal = (int) floor($loot['crystal'] * $factor);
+
+		PvePackageService::collect((int) $package['id'], $takeMetal, $takeCrystal);
+
+		$this->UpdateFleet('fleet_resource_metal', (int) $this->_fleet['fleet_resource_metal'] + $takeMetal);
+		$this->UpdateFleet('fleet_resource_crystal', (int) $this->_fleet['fleet_resource_crystal'] + $takeCrystal);
+
+		$LNG = $this->getLanguage($owner['lang'] ?? null);
+		PlayerUtil::sendMessage(
+			(int) $this->_fleet['fleet_owner'],
+			0,
+			$LNG['sys_mess_tower'] ?? 'Fleet',
+			15,
+			$LNG['type_mission_18'] ?? 'Salvage',
+			sprintf($LNG['sys_salvage_collected'] ?? 'Collected %s metal and %s crystal.', pretty_number($takeMetal), pretty_number($takeCrystal)),
+			TIMESTAMP,
+			null,
+			1,
+			$universe
+		);
+
+		$this->setState(FLEET_RETURN);
+		$this->SaveFleet();
+	}
+
+	private function bounceEmpty(): void
+	{
+		$owner = $this->getUser((int) $this->_fleet['fleet_owner']);
+		$LNG = $this->getLanguage($owner['lang'] ?? null);
+		PlayerUtil::sendMessage(
+			(int) $this->_fleet['fleet_owner'],
+			0,
+			$LNG['sys_mess_tower'] ?? 'Fleet',
+			15,
+			$LNG['type_mission_18'] ?? 'Salvage',
+			$LNG['fl_salvage_gone'] ?? 'The salvage package is gone.',
+			TIMESTAMP,
+			null,
+			1,
+			(int) $this->_fleet['fleet_universe']
+		);
+		$this->setState(FLEET_RETURN);
+		$this->SaveFleet();
+	}
+
+	private function planetOwnerAccused(int $planetId, int $universe): bool
+	{
+		$row = Database::get()->selectSingle(
+			'SELECT id_owner FROM %%PLANETS%% WHERE id = :id;',
+			[':id' => $planetId]
+		);
+		if (empty($row['id_owner'])) {
+			return false;
+		}
+
+		return PushingAccusationQuery::isAccusedReceiver((int) $row['id_owner'], $universe);
+	}
+
+	/**
+	 * @param array<string, mixed> $package
+	 * @param array<string, mixed> $owner
+	 */
+	private function fightEncounter(array $package, array $owner, bool $accused): bool
+	{
+		$family = PveNpcFleetFactory::familyFromSeed((int) $package['encounter_seed']);
+		$npcShips = PveNpcFleetFactory::template($family, (int) $package['tier'], $accused);
+		$fleetArray = FleetFunctions::unserialize($this->_fleet['fleet_array']);
+
+		$fleetID = $this->_fleet['fleet_id'];
+		$fleetAttack = [];
+		$fleetAttack[$fleetID]['fleetDetail'] = $this->_fleet;
+		$fleetAttack[$fleetID]['player'] = $owner;
+		$fleetAttack[$fleetID]['player']['factor'] = getFactors($owner, 'attack', $this->_fleet['fleet_start_time']);
+		$fleetAttack[$fleetID]['unit'] = $fleetArray;
+
+		$npc = PveNpcFleetFactory::syntheticPlayer(PveNpcFleetFactory::displayName($family));
+		$fleetDefend = [];
+		$fleetDefend[0]['fleetDetail'] = [
+			'fleet_start_galaxy' => $this->_fleet['fleet_end_galaxy'],
+			'fleet_start_system' => $this->_fleet['fleet_end_system'],
+			'fleet_start_planet' => $this->_fleet['fleet_end_planet'],
+			'fleet_start_type' => 1,
+			'fleet_end_galaxy' => $this->_fleet['fleet_end_galaxy'],
+			'fleet_end_system' => $this->_fleet['fleet_end_system'],
+			'fleet_end_planet' => $this->_fleet['fleet_end_planet'],
+			'fleet_end_type' => 1,
+			'fleet_resource_metal' => 0,
+			'fleet_resource_crystal' => 0,
+			'fleet_resource_deuterium' => 0,
+		];
+		$fleetDefend[0]['player'] = $npc;
+		$fleetDefend[0]['player']['factor'] = $npc['factor'];
+		$fleetDefend[0]['unit'] = $npcShips;
+
+		require_once 'includes/classes/missions/functions/calculateAttack.php';
+		$config = Config::get($this->_fleet['fleet_universe']);
+		$combatResult = calculateAttack($fleetAttack, $fleetDefend, $config->Fleet_Cdr, $config->Defs_Cdr);
+
+		$fleetString = '';
+		$totalCount = 0;
+		$fleetAttack[$fleetID]['unit'] = array_filter($fleetAttack[$fleetID]['unit']);
+		foreach ($fleetAttack[$fleetID]['unit'] as $element => $amount) {
+			$fleetString .= $element . ',' . $amount . ';';
+			$totalCount += $amount;
+		}
+
+		if ($totalCount <= 0) {
+			$this->KillFleet();
+			return false;
+		}
+
+		$this->UpdateFleet('fleet_array', substr($fleetString, 0, -1));
+		$this->UpdateFleet('fleet_amount', $totalCount);
+		return true;
+	}
+
+	function EndStayEvent()
+	{
+		return;
+	}
+
+	function ReturnEvent()
+	{
+		$LNG = $this->getLanguage(null, $this->_fleet['fleet_owner']);
+		$planetName = PlanetRepository::getPlanetName($this->_fleet['fleet_start_id']) ?? '';
+		$Message = sprintf(
+			$LNG['sys_fleet_won'] ?? '%s %s %s %s %s %s %s %s',
+			$planetName,
+			GetTargetAddressLink($this->_fleet, ''),
+			pretty_number($this->_fleet['fleet_resource_metal']),
+			$LNG['tech'][901] ?? 'Metal',
+			pretty_number($this->_fleet['fleet_resource_crystal']),
+			$LNG['tech'][902] ?? 'Crystal',
+			pretty_number($this->_fleet['fleet_resource_deuterium']),
+			$LNG['tech'][903] ?? 'Deuterium'
+		);
+		PlayerUtil::sendMessage(
+			$this->_fleet['fleet_owner'],
+			0,
+			$LNG['sys_mess_tower'] ?? '',
+			4,
+			$LNG['sys_mess_fleetback'] ?? '',
+			$Message,
+			$this->_fleet['fleet_end_time'],
+			null,
+			1,
+			$this->_fleet['fleet_universe']
+		);
+		$this->RestoreFleet();
+	}
+}

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -275,7 +275,7 @@ define('ENABLE_SIMULATOR_LINK'		, true);
 // MODULE_AMOUNT must equal the highest module ID + 1.
 // =============================================================================
 
-define('MODULE_AMOUNT'				, 47);
+define('MODULE_AMOUNT'				, 48);
 define('MODULE_ALLIANCE'			, 0);
 define('MODULE_MISSION_ATTACK'		, 1);
 define('MODULE_BUILDING'			, 2);
@@ -322,6 +322,26 @@ define('MODULE_MISSION_ACS'			, 42);
 define('MODULE_MISSION_TRADE'		, 44);
 define('MODULE_MISSION_TRANSFER'	, 45);
 define('MODULE_ACHIEVEMENTS'		, 46);
+define('MODULE_MISSION_SALVAGE'		, 47);
+
+define('PVE_ONLINE_WINDOW'			, 900);
+define('PVE_SPAWN_BASE'				, 2);
+define('PVE_SPAWN_PER_ONLINE'		, 1);
+define('PVE_SPAWN_HARD_CAP'			, 12);
+define('PVE_PACKAGE_TTL'			, 86400);
+define('PVE_PACKAGE_BASE_METAL'		, 5000);
+define('PVE_PACKAGE_BASE_CRYSTAL'	, 2500);
+define('PVE_PACKAGE_GROWTH_PER_HOUR', 500);
+define('PVE_PACKAGE_CAP_METAL'		, 50000);
+define('PVE_PACKAGE_CAP_CRYSTAL'	, 25000);
+define('PVE_HANGAR_WEAK_FRACTION'	, 0.5);
+define('PVE_ACCUSED_SHIP_FACTOR'	, 1.1);
+define('PVE_ACCUSED_RAID_CHANCE'	, 15);
+define('PVE_RAID_FLIGHT_SECONDS'	, 600);
+define('PVE_ENCOUNTER_CHANCE'		, 40);
+define('PVE_ACCUSED_ENCOUNTER_BONUS', 10);
+define('PVE_OVERLAY_CHANCE'			, 20);
+define('PVE_ACCUSED_OVERLAY_BONUS'	, 15);
 
 // =============================================================================
 // ELEMENT / RESOURCE TYPE FLAGS (bitmask)

--- a/includes/dbtables.php
+++ b/includes/dbtables.php
@@ -15,7 +15,7 @@
  * @link https://github.com/jkroepke/2Moons
  */
 
-defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 24);
+defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 25);
 defined('DB_NAME')             || define('DB_NAME',   $database['databasename']);
 defined('DB_PREFIX')           || define('DB_PREFIX', $database['tableprefix']);
 
@@ -75,5 +75,6 @@ $dbTableNames	= array(
 	'USER_ACHIEVEMENT_PROGRESS'	=> DB_PREFIX.'user_achievement_progress',
 	'USER_ACHIEVEMENTS'		=> DB_PREFIX.'user_achievements',
 	'ACHIEVEMENT_GRANTS'	=> DB_PREFIX.'achievement_grants',
+	'SALVAGE_PACKAGES'		=> DB_PREFIX.'salvage_packages',
 );
 // MOD-TABLES

--- a/includes/pages/game/ShowFleetStep3Page.php
+++ b/includes/pages/game/ShowFleetStep3Page.php
@@ -172,7 +172,7 @@ class ShowFleetStep3Page extends AbstractGamePage
 		)) ?: null;
 
 		// Determine target player data
-		if ($targetMission == 7 || $targetMission == 15 || $targetMission == 16) {
+		if ($targetMission == 7 || $targetMission == 15 || $targetMission == 16 || $targetMission == 18) {
 			$targetPlayerData = array(
 				'id'          => 0,
 				'onlinetime'  => TIMESTAMP,
@@ -202,7 +202,7 @@ class ShowFleetStep3Page extends AbstractGamePage
 
 		// For colonize / expedition / market, override targetPlanetData to synthetic after mission check
 		$targetPlanetDataForMission = $targetPlanetData;
-		if ($targetMission == 7 || $targetMission == 15 || $targetMission == 16) {
+		if ($targetMission == 7 || $targetMission == 15 || $targetMission == 16 || $targetMission == 18) {
 			$targetPlanetDataForMission = array('id' => 0, 'id_owner' => 0, 'planettype' => 1);
 		}
 

--- a/install/install.sql
+++ b/install/install.sql
@@ -642,6 +642,25 @@ CREATE TABLE `%PREFIX%planets` (
   KEY `universe` (`universe`,`galaxy`,`system`,`planet`,`planet_type`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8;
 
+CREATE TABLE `%PREFIX%salvage_packages` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `universe` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `galaxy` int(11) unsigned NOT NULL,
+  `system` int(11) unsigned NOT NULL,
+  `planet` int(11) unsigned NOT NULL,
+  `planet_id` int(11) unsigned DEFAULT NULL,
+  `metal` double(50,0) unsigned NOT NULL DEFAULT '0',
+  `crystal` double(50,0) unsigned NOT NULL DEFAULT '0',
+  `spawned_at` int(11) unsigned NOT NULL DEFAULT '0',
+  `expires_at` int(11) unsigned NOT NULL DEFAULT '0',
+  `tier` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `encounter_seed` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `coords` (`universe`, `galaxy`, `system`, `planet`),
+  KEY `expires_at` (`expires_at`),
+  KEY `planet_id` (`planet_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
 CREATE TABLE `%PREFIX%raports` (
   `rid` varchar(32) NOT NULL,
   `raport` longtext NOT NULL,
@@ -1020,7 +1039,8 @@ INSERT INTO `%PREFIX%cronjobs` (`cronjobID`, `name`, `isActive`, `min`, `hours`,
 (NULL, 'databasedump', 1, '30', '1', '*', '*', '1', 'HiveNova\\Cronjob\\DumpCronjob', 0, NULL),
 (NULL, 'tracking', 1, FLOOR(RAND() * 60), FLOOR(RAND() * 24), '*', '*', '0', 'HiveNova\\Cronjob\\TrackingCronjob', 0, NULL),
 (NULL, 'pushing', 1, '0', '0', '*', '*', '0', 'HiveNova\\Cronjob\\PushingDetectionCronjob', 0, NULL),
-(NULL, 'achievement_backfill', 1, '15', '3', '*', '*', '*', 'HiveNova\\Cronjob\\AchievementBackfillCronjob', 0, NULL);
+(NULL, 'achievement_backfill', 1, '15', '3', '*', '*', '*', 'HiveNova\\Cronjob\\AchievementBackfillCronjob', 0, NULL),
+(NULL, 'pve_spawn', 1, '*/15', '*', '*', '*', '*', 'HiveNova\\Cronjob\\PveSpawnCronjob', 0, NULL);
 
 INSERT INTO `%PREFIX%system` (`dbVersion`) VALUES
 (%DB_VERSION%);

--- a/install/migrations/migration_25.sql
+++ b/install/migrations/migration_25.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS `%PREFIX%salvage_packages` (
+  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+  `universe` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `galaxy` int(11) unsigned NOT NULL,
+  `system` int(11) unsigned NOT NULL,
+  `planet` int(11) unsigned NOT NULL,
+  `planet_id` int(11) unsigned DEFAULT NULL,
+  `metal` double(50,0) unsigned NOT NULL DEFAULT '0',
+  `crystal` double(50,0) unsigned NOT NULL DEFAULT '0',
+  `spawned_at` int(11) unsigned NOT NULL DEFAULT '0',
+  `expires_at` int(11) unsigned NOT NULL DEFAULT '0',
+  `tier` tinyint(3) unsigned NOT NULL DEFAULT '1',
+  `encounter_seed` int(11) unsigned NOT NULL DEFAULT '0',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `coords` (`universe`, `galaxy`, `system`, `planet`),
+  KEY `expires_at` (`expires_at`),
+  KEY `planet_id` (`planet_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+
+INSERT INTO `%PREFIX%cronjobs` (`name`, `isActive`, `min`, `hours`, `dom`, `month`, `dow`, `class`, `nextTime`, `lock`)
+VALUES ('pve_spawn', 1, '*/15', '*', '*', '*', '*', 'HiveNova\\Cronjob\\PveSpawnCronjob', 0, NULL);

--- a/language/de/ADMIN.php
+++ b/language/de/ADMIN.php
@@ -1118,6 +1118,7 @@ $LNG['modul_8'] = 'DM-Bank';
 $LNG['modul_9'] = 'Flotte';
 $LNG['modul_10'] = 'Flotte - Handler';
 $LNG['modul_41'] = 'Flotten Shourtcuts';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46'] = 'Achievements';
 $LNG['modul_11'] = 'Galaxie';
 $LNG['modul_12'] = 'Hall of Fame';
@@ -1312,6 +1313,7 @@ $LNG['cronName_inactive'] = 'Inaktive löschen';
 $LNG['cronName_teamspeak'] = 'Teamspeakdaten aktualisieren';
 $LNG['cronName_tracking'] = 'Statistik an globalen Server senden.';
 $LNG['cronName_databasedump'] = 'Datenbank-Backup';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Pushing-Erkennung';
 $LNG['cronName_botdetect'] = 'Bot-Erkennung';
 

--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -38,6 +38,9 @@ $LNG['type_mission_10']  					= 'Raketenangriff';
 $LNG['type_mission_11']  					= 'DM Untersuchung';
 $LNG['type_mission_15'] 					= 'Expedition';
 
+$LNG['fl_salvage_gone']						= 'Das Bergungspaket ist weg.';
+$LNG['sys_salvage_collected']				= '%s Metall und %s Kristall geborgen.';
+
 $LNG['type_planet_1']  						= 'Planet';
 $LNG['type_planet_2']  						= 'Trümmerfeld';
 $LNG['type_planet_3']  						= 'Mond';
@@ -1257,6 +1260,7 @@ $LNG['lo_continue']						= 'Klicken Sie hier, um nicht zu warten';
 
 // Translated into German by Jan . All rights reversed (C) 2011
 $LNG['type_mission_16'] = 'Handel';
+$LNG['type_mission_18'] 					= 'Bergen';
 $LNG['type_mission_17'] = 'Übertrag';
 $LNG['gl_trade_space'] = 'Handelszone';
 $LNG['fl_transfer_alert_message'] = 'Warnung! Die Flottenherrschaft wird auf den Zielspieler übertragen!';

--- a/language/en/ADMIN.php
+++ b/language/en/ADMIN.php
@@ -1154,6 +1154,7 @@ $LNG['modul_26'] = 'Search';
 $LNG['modul_27'] = 'Support Tickets';
 $LNG['modul_28'] = 'Techtree';
 $LNG['modul_41'] = 'Facebook Application';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46'] = 'Achievements';
 $LNG['mod_module'] = 'Modules';
 $LNG['mod_info'] = 'Modules in the Game';
@@ -1316,6 +1317,7 @@ $LNG['cronName_inactive'] = 'Delete inactive';
 $LNG['cronName_teamspeak'] = 'Teamspeak data update';
 $LNG['cronName_tracking'] = 'Send global server statistics';
 $LNG['cronName_databasedump'] = 'Database backup';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Pushing Detection';
 $LNG['cronName_botdetect'] = 'Bot Detection';
 

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -44,7 +44,11 @@ $LNG['type_mission_10']  					= 'Missile attack';
 $LNG['type_mission_11']  					= 'Research Pizzabits';
 $LNG['type_mission_15'] 					= 'Expedition';
 $LNG['type_mission_16'] 					= 'Trade';
+$LNG['type_mission_18'] 					= 'Salvage';
 $LNG['type_mission_17'] 					= 'Transfer';
+
+$LNG['fl_salvage_gone']						= 'The salvage package is gone.';
+$LNG['sys_salvage_collected']				= 'Collected %s metal and %s crystal.';
 
 $LNG['type_planet_1']  					= 'Planet';
 $LNG['type_planet_2']  					= 'Debris Field';

--- a/language/es/ADMIN.php
+++ b/language/es/ADMIN.php
@@ -1127,6 +1127,7 @@ $LNG['modul_26'] = 'Búsqueda';
 $LNG['modul_27'] = 'Tickets de soporte';
 $LNG['modul_28'] = 'Árbol tecnológico';
 $LNG['modul_41'] = 'Aplicación de Facebook';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46'] = 'Achievements';
 $LNG['mod_module'] = 'Módulos';
 $LNG['mod_info'] = 'Módulos en el juego';
@@ -1285,6 +1286,7 @@ $LNG['cronName_inactive'] = 'Eliminar inactivos';
 $LNG['cronName_teamspeak'] = 'Actualización de datos de Teamspeak';
 $LNG['cronName_tracking'] = 'Enviar estadísticas globales del servidor';
 $LNG['cronName_databasedump'] = 'Respaldo de base de datos';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Detección de Pushing';
 $LNG['cronName_botdetect'] = 'Detección de Bots';
 

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -37,6 +37,9 @@ $LNG['type_mission_10']  					= 'Ataque con Misiles';
 $LNG['type_mission_11']  					= 'Investigación Pizzabits';
 $LNG['type_mission_15'] 					= 'Expedición';
 
+$LNG['fl_salvage_gone']						= 'El paquete de salvamento ya no está.';
+$LNG['sys_salvage_collected']				= 'Recogidos %s metal y %s cristal.';
+
 $LNG['type_planet_1']  					= 'Planeta';
 $LNG['type_planet_2']  					= 'Escombros';
 $LNG['type_planet_3']  					= 'Luna';
@@ -1214,6 +1217,7 @@ $LNG['lo_continue']							= 'Pulsa aquí si no redirecciona tu navegador.';
 
 // Translated into Spanish by Angelus_ira . All rights reversed (C) 2011
 $LNG['type_mission_16'] = 'Comercio';
+$LNG['type_mission_18'] 					= 'Salvamento';
 $LNG['type_mission_17'] = 'Transferencia';
 $LNG['lm_marketplace'] = 'Mercado';
 $LNG['ov_online'] = 'En línea';

--- a/language/fr/ADMIN.php
+++ b/language/fr/ADMIN.php
@@ -1179,6 +1179,7 @@ $LNG['modul_26']                       		= 'Rechercher';
 $LNG['modul_27']                       		= 'Tickets Support';
 $LNG['modul_28']                       		= 'Technologies';
 $LNG['modul_41']                           = 'Facebook Application';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46']                           = 'Achievements';
 $LNG['mod_module']					= 'Modules';
 $LNG['mod_info']					= 'Modules dans le Jeu';
@@ -1341,6 +1342,7 @@ $LNG['cronName_inactive']		= 'Supprimer inactive';
 $LNG['cronName_teamspeak']		= 'Teamspeak mise à jour de données';
 $LNG['cronName_tracking']		= 'Envoyer des statistiques globaux du serveur';
 $LNG['cronName_databasedump']	= 'Backup de base de données';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Détection de Pushing';
 $LNG['cronName_botdetect'] = 'Détection de Bots';
 

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -28,6 +28,9 @@ $LNG['type_mission_10']  					= 'MIP - Attaque missile interplanétaire';
 $LNG['type_mission_11']  					= 'Recherche de Matière Noire';
 $LNG['type_mission_15'] 					= 'Expédition';
 
+$LNG['fl_salvage_gone']						= 'Le colis de salvage a disparu.';
+$LNG['sys_salvage_collected']				= 'Collecté %s métal et %s cristal.';
+
 $LNG['type_planet_1']  						= 'Planète';
 $LNG['type_planet_2']	  					= 'Champ de débris';
 $LNG['type_planet_3']  						= 'Lune';
@@ -1199,6 +1202,7 @@ $LNG['lo_notify']						= 'Vous serez redirigé dans <span id="seconds"> 5 </ spa
 $LNG['lo_continue']						= 'Cliquez ici pour être redirigé immédiatement.';
 
 $LNG['type_mission_16'] = 'Commerce';
+$LNG['type_mission_18'] 					= 'Salvage';
 $LNG['type_mission_17'] = 'Transfert';
 $LNG['lm_marketplace'] = 'Marché';
 $LNG['ov_online'] = 'En ligne';

--- a/language/pl/ADMIN.php
+++ b/language/pl/ADMIN.php
@@ -1110,6 +1110,7 @@ $LNG['modul_8']						= 'DM-Bank';
 $LNG['modul_9']						= 'Flota';
 $LNG['modul_10']						= 'Handlarz Floty';
 $LNG['modul_41']						= 'Skróty floty';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46']						= 'Achievements';
 $LNG['modul_11']						= 'Galaktyka';
 $LNG['modul_12']						= 'Hala Sław';
@@ -1303,6 +1304,7 @@ $LNG['cronName_inactive']		= 'Usuń nie aktywnych';
 $LNG['cronName_teamspeak']		= 'Aktualizacja ustawień Teamspeak';
 $LNG['cronName_tracking']		= 'Wyślij statystyki na główny serwer.';
 $LNG['cronName_databasedump']	= 'Backup bazy danych';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Wykrywanie Pushingu';
 $LNG['cronName_botdetect'] = 'Wykrywanie Botów';
 

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -38,6 +38,9 @@ $LNG['type_mission_10']  					= 'Atak Rakietowy';
 $LNG['type_mission_11']  					= 'Żniwa Czarnej Materii';
 $LNG['type_mission_15'] 					= 'Ekspedycja';
 
+$LNG['fl_salvage_gone']						= 'Paczka salvage zniknęła.';
+$LNG['sys_salvage_collected']				= 'Zebrano %s metalu i %s kryształu.';
+
 $LNG['type_planet_1']  					= 'Planeta';
 $LNG['type_planet_2']  					= 'Pole zniszczeń';
 $LNG['type_planet_3']  					= 'Księżyc';
@@ -1236,6 +1239,7 @@ $LNG['lo_continue']						= 'Kliknij tutaj, jeśli nie chcesz zostać przeniesion
 // Translated into Polish by Sirgomo . All rights reversed (C) 2012
 // Edited by TheRavikin. All rights resteemed (C) 2018
 $LNG['type_mission_16'] = 'Handel';
+$LNG['type_mission_18'] 					= 'Salvage';
 $LNG['type_mission_17'] = 'Transfer';
 $LNG['lm_marketplace'] = 'Targ';
 $LNG['ov_online'] = 'Online';

--- a/language/pt/ADMIN.php
+++ b/language/pt/ADMIN.php
@@ -1152,6 +1152,7 @@ $LNG['modul_38']						= 'Sucateiros : Comprador de Frota';
 $LNG['modul_39']						= 'Simulador de batalha';
 $LNG['modul_40']						= 'Atalhos de Frotas';
 $LNG['modul_41']                       = 'Aplicação do Facebook';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46']                       = 'Achievements';
 $LNG['mod_module']						= 'Modulos';
 $LNG['mod_info']						= 'Modulos no Jogo';
@@ -1350,6 +1351,7 @@ $LNG['cronName_inactive']		= 'Excluir inativo';
 $LNG['cronName_teamspeak']		= 'Teamspeak data';
 $LNG['cronName_tracking']		= 'Estatísticas Globais';
 $LNG['cronName_databasedump']	= 'Backup de Base de Dados';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Detecção de Pushing';
 $LNG['cronName_botdetect'] = 'Detecção de Bots';
 

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -42,6 +42,9 @@ $LNG['type_mission_10']  					= 'Ataque de Misseis';
 $LNG['type_mission_11']  					= 'Investigação de Pizzabits';
 $LNG['type_mission_15'] 					= 'Expedição';
 
+$LNG['fl_salvage_gone']						= 'O pacote de salvage desapareceu.';
+$LNG['sys_salvage_collected']				= 'Recolhidos %s metal e %s cristal.';
+
 $LNG['type_planet_1']  					= 'Planeta';
 $LNG['type_planet_2']  					= 'Campo de Destroços';
 $LNG['type_planet_3']  					= 'Lua';
@@ -1226,6 +1229,7 @@ $LNG['lo_continue']							= 'Clica aqui para não esperar';
 
 // Translated into Portuguese by QwataKayean . All rights reversed (C) 2012
 $LNG['type_mission_16'] = 'Comércio';
+$LNG['type_mission_18'] 					= 'Salvage';
 $LNG['type_mission_17'] = 'Transferência';
 $LNG['lm_marketplace'] = 'Mercado';
 $LNG['ov_online'] = 'Online';

--- a/language/ru/ADMIN.php
+++ b/language/ru/ADMIN.php
@@ -1046,6 +1046,7 @@ $LNG['modul_8']                       = 'Инновационнные разра
 $LNG['modul_9']                       = 'Флот';
 $LNG['modul_10']                      = 'Обработчик флота';
 $LNG['modul_41']                      = 'Маршруты';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46']                      = 'Achievements';
 $LNG['modul_11']                      = 'Галактика';
 $LNG['modul_12']                      = 'Зал славы';
@@ -1234,6 +1235,7 @@ $LNG['cronName_inactive']           = 'Удаление неактивных и�
 $LNG['cronName_teamspeak']          = 'Обновление данных Teamspeak';
 $LNG['cronName_tracking']           = 'Отправление статистики Глобальному серверу';
 $LNG['cronName_databasedump']       = 'Резервное копирование БД';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Обнаружение Пушинга';
 $LNG['cronName_botdetect'] = 'Обнаружение Ботов';
 

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -37,6 +37,9 @@ $LNG['type_mission_10']                  = 'Ракетная атака';
 $LNG['type_mission_11']                  = 'Поиск Тёмной материи';
 $LNG['type_mission_15']                  = 'Экспедиция';
 
+$LNG['fl_salvage_gone']						= 'Пакет salvage исчез.';
+$LNG['sys_salvage_collected']				= 'Собрано %s металла и %s кристалла.';
+
 $LNG['type_planet_1']                    = 'Планета';
 $LNG['type_planet_2']                    = 'Поле обломков';
 $LNG['type_planet_3']                    = 'Луна';
@@ -1170,6 +1173,7 @@ $LNG['lo_redirect']                       = 'Перенаправление';
 $LNG['lo_notify']                         = 'Вы будете перенаправлены через <span id="seconds">5</span> секунд';
 $LNG['lo_continue']                       = 'Нажмите здесь, если не хотите ждать';
 $LNG['type_mission_16'] = 'Торговля';
+$LNG['type_mission_18'] 					= 'Salvage';
 $LNG['type_mission_17'] = 'Передача';
 $LNG['lm_marketplace'] = 'Рынок';
 $LNG['ov_online'] = 'Онлайн';

--- a/language/tr/ADMIN.php
+++ b/language/tr/ADMIN.php
@@ -537,6 +537,7 @@ $LNG['modul_26']                                       = 'Ara';
 $LNG['modul_27']                                       = 'Destek/Ticket';
 $LNG['modul_28']                                       = 'Teknoloji';
 $LNG['modul_41']                          				= 'Facebook';
+$LNG['modul_47'] = 'Salvage mission';
 $LNG['modul_46']                          				= 'Achievements';
 $LNG['mod_module']                                      = 'Moduller';
 $LNG['mod_info']                                        = 'Oyundaki Moduller';
@@ -574,6 +575,7 @@ $LNG['cronName_inactive']		= 'Inaktifleri Sil';
 $LNG['cronName_teamspeak']		= 'Teamspeak guncelleme';
 $LNG['cronName_tracking']		= 'Global Server Istatistik Guncellemesi';
 $LNG['cronName_databasedump']	= 'Database backup';
+$LNG['cronName_pve_spawn'] = 'PvE spawn';
 $LNG['cronName_pushing'] = 'Pushing Tespiti';
 $LNG['cronName_botdetect'] = 'Bot Tespiti';
 

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -43,6 +43,9 @@ $LNG['type_mission_10']  					= 'Roket Saldırısı';
 $LNG['type_mission_11']  					= 'KM Araştırmak ';
 $LNG['type_mission_15'] 					= 'Keşif Uçusu';
 
+$LNG['fl_salvage_gone']						= 'Salvage paketi yok.';
+$LNG['sys_salvage_collected']				= '%s metal ve %s kristal toplandı.';
+
 $LNG['type_planet_1']  					= 'Gezegen';
 $LNG['type_planet_2']  					= 'Harabe alanı';
 $LNG['type_planet_3']  					= 'Ay';
@@ -1235,6 +1238,7 @@ $LNG['lo_continue']							= 'Beklemek istemiyorsanız tıklayınız';
 
 //----------------------------------------------------------------------------//
 $LNG['type_mission_16'] = 'Ticaret';
+$LNG['type_mission_18'] 					= 'Salvage';
 $LNG['type_mission_17'] = 'Transfer';
 $LNG['lm_marketplace'] = 'Pazar Yeri';
 $LNG['ov_online'] = 'Çevrimiçi';

--- a/tests/Support/FakeDatabase.php
+++ b/tests/Support/FakeDatabase.php
@@ -25,6 +25,14 @@ class FakeDatabase implements DatabaseInterface
     public int $lastUserInsertId = 0;
 
     /** @var list<array<string, mixed>> */
+    public array $salvagePackages = [];
+
+    /** @var list<int> */
+    public array $accusedDestIds = [];
+
+    public int $lastFleetInsertId = 0;
+
+    /** @var list<array<string, mixed>> */
     public array $galaxyRows = [];
 
     /** @var list<array{ally_name: string}> */
@@ -64,6 +72,12 @@ class FakeDatabase implements DatabaseInterface
 
     public function select($qry, array $params = [])
     {
+        if (str_contains($qry, '%%SALVAGE_PACKAGES%%')) {
+            return $this->salvageSelect($qry, $params);
+        }
+        if (str_contains($qry, '%%LOG_FLEETS%%') && str_contains($qry, 'dest_id')) {
+            return array_map(static fn (int $id): array => ['dest_id' => $id], $this->accusedDestIds);
+        }
         if ($this->isFlyingFleetsTableQuery($qry)) {
             return $this->flyingFleetsTableSelect($qry, $params);
         }
@@ -226,6 +240,14 @@ class FakeDatabase implements DatabaseInterface
 
     public function selectSingle($qry, array $params = [], $field = false)
     {
+        if (str_contains($qry, '%%SALVAGE_PACKAGES%%')) {
+            $rows = $this->salvageSelect($qry, $params);
+            $row = $rows[0] ?? null;
+            if ($row === null) {
+                return $field === false ? null : false;
+            }
+            return $field === false ? $row : ($row[$field] ?? false);
+        }
         if ($this->isPlanetQuery($qry) && str_contains($qry, 'INNER JOIN %%USERS%%')) {
             return $this->planetUserJoinSelectSingle($qry, $params, $field);
         }
@@ -261,8 +283,81 @@ class FakeDatabase implements DatabaseInterface
         return $row;
     }
 
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function salvageSelect(string $qry, array $params): array
+    {
+        if (str_contains($qry, 'COUNT(*)')) {
+            $universe = (int) ($params[':universe'] ?? 0);
+            $now = (int) ($params[':now'] ?? TIMESTAMP);
+            $n = 0;
+            foreach ($this->salvagePackages as $row) {
+                if ((int) $row['universe'] === $universe && (int) $row['expires_at'] > $now) {
+                    $n++;
+                }
+            }
+            return [['total' => $n]];
+        }
+
+        $out = [];
+        foreach ($this->salvagePackages as $row) {
+            if (isset($params[':universe']) && (int) $row['universe'] !== (int) $params[':universe']) {
+                continue;
+            }
+            if (isset($params[':galaxy']) && (int) $row['galaxy'] !== (int) $params[':galaxy']) {
+                continue;
+            }
+            if (isset($params[':system']) && (int) $row['system'] !== (int) $params[':system']) {
+                continue;
+            }
+            if (isset($params[':planet']) && (int) $row['planet'] !== (int) $params[':planet']) {
+                continue;
+            }
+            if (isset($params[':now']) && (int) $row['expires_at'] <= (int) $params[':now']) {
+                continue;
+            }
+            $out[] = $row;
+        }
+        return $out;
+    }
+
     public function insert($qry, array $params = [])
     {
+        if (str_contains($qry, '%%FLEETS%%') && str_contains($qry, 'INSERT')) {
+            $this->lastInsertKind = 'fleet';
+            $this->lastFleetInsertId = ($this->lastFleetInsertId === 0) ? 99 : $this->lastFleetInsertId + 1;
+            $this->fleetRowsById[$this->lastFleetInsertId] = [
+                'fleet_id' => $this->lastFleetInsertId,
+                'fleet_owner' => (int) ($params[':fleetStartOwner'] ?? 0),
+                'fleet_target_owner' => (int) ($params[':fleetTargetOwner'] ?? 0),
+                'fleet_mission' => (int) ($params[':fleetMission'] ?? 0),
+                'fleet_amount' => (int) ($params[':fleetShipCount'] ?? 0),
+                'fleet_end_id' => (int) ($params[':fleetTargetPlanetID'] ?? 0),
+                'fleet_mess' => FLEET_OUTWARD,
+                'fleet_universe' => (int) ($params[':universe'] ?? 1),
+            ];
+            return true;
+        }
+
+        if (str_contains($qry, '%%SALVAGE_PACKAGES%%')) {
+            $id = count($this->salvagePackages) + 1;
+            $this->salvagePackages[] = [
+                'id' => $id,
+                'universe' => (int) ($params[':universe'] ?? 1),
+                'galaxy' => (int) ($params[':galaxy'] ?? 0),
+                'system' => (int) ($params[':system'] ?? 0),
+                'planet' => (int) ($params[':planet'] ?? 0),
+                'planet_id' => $params[':planetId'] ?? null,
+                'metal' => (int) ($params[':metal'] ?? 0),
+                'crystal' => (int) ($params[':crystal'] ?? 0),
+                'spawned_at' => (int) ($params[':spawned'] ?? TIMESTAMP),
+                'expires_at' => (int) ($params[':expires'] ?? TIMESTAMP + 86400),
+                'tier' => (int) ($params[':tier'] ?? 1),
+                'encounter_seed' => (int) ($params[':seed'] ?? 0),
+            ];
+            return true;
+        }
         if ($this->isPlanetQuery($qry) && str_contains($qry, 'INSERT')) {
             $this->lastInsertKind = 'planet';
 
@@ -292,6 +387,32 @@ class FakeDatabase implements DatabaseInterface
 
     public function update($qry, array $params = [])
     {
+        if (str_contains($qry, '%%SALVAGE_PACKAGES%%')) {
+            foreach ($this->salvagePackages as &$row) {
+                if (isset($params[':id']) && (int) $row['id'] !== (int) $params[':id']) {
+                    continue;
+                }
+                if (isset($params[':galaxy']) && (
+                    (int) $row['galaxy'] !== (int) $params[':galaxy']
+                    || (int) $row['system'] !== (int) $params[':system']
+                    || (int) $row['planet'] !== (int) $params[':planet']
+                    || (int) $row['universe'] !== (int) ($params[':universe'] ?? $row['universe'])
+                )) {
+                    continue;
+                }
+                if (isset($params[':planetId'])) {
+                    $row['planet_id'] = (int) $params[':planetId'];
+                }
+                if (isset($params[':metal'])) {
+                    $row['metal'] = max(0, (int) $row['metal'] - (int) $params[':metal']);
+                }
+                if (isset($params[':crystal'])) {
+                    $row['crystal'] = max(0, (int) $row['crystal'] - (int) $params[':crystal']);
+                }
+            }
+            unset($row);
+            return true;
+        }
         return match ($this->route($qry)) {
             'frequent' => $this->frequentLocationUpdate($qry, $params),
             'fleet' => $this->fleetUpdate($qry, $params),
@@ -303,6 +424,24 @@ class FakeDatabase implements DatabaseInterface
 
     public function delete($qry, array $params = [])
     {
+        if (str_contains($qry, '%%SALVAGE_PACKAGES%%')) {
+            $this->salvagePackages = array_values(array_filter(
+                $this->salvagePackages,
+                static function (array $row) use ($params, $qry): bool {
+                    if (isset($params[':id']) && (int) $row['id'] === (int) $params[':id']) {
+                        if (str_contains($qry, 'metal <= 0')) {
+                            return (int) $row['metal'] > 0 || (int) $row['crystal'] > 0;
+                        }
+                        return false;
+                    }
+                    if (isset($params[':now']) && (int) $row['expires_at'] <= (int) $params[':now']) {
+                        return false;
+                    }
+                    return true;
+                }
+            ));
+            return true;
+        }
         return match ($this->route($qry)) {
             'frequent' => $this->frequentLocationDelete($qry, $params),
             'fleet' => $this->fleetDelete($qry, $params),
@@ -343,6 +482,7 @@ class FakeDatabase implements DatabaseInterface
         return match ($this->lastInsertKind) {
             'user' => $this->lastUserInsertId,
             'planet' => $this->lastPlanetInsertId,
+            'fleet' => $this->lastFleetInsertId,
             default => $this->achievement->lastInsertId(),
         };
     }

--- a/tests/Support/FakeFleetQueryHandler.php
+++ b/tests/Support/FakeFleetQueryHandler.php
@@ -24,6 +24,8 @@ trait FakeFleetQueryHandler
     /** Expeditions in target system (LOG_FLEETS COUNT … AS total). */
     public int $expeditionLogCount = 0;
 
+    public int $onlineUserCount = 0;
+
     public int $acsGroupMemberCount = 0;
 
     /** @var list<array{sql: string, params: array}> */
@@ -43,6 +45,31 @@ trait FakeFleetQueryHandler
 
     private function fleetSelect(string $qry, array $params): array
     {
+        if (str_contains($qry, '%%FLEETS%%')
+            && str_contains($qry, 'DISTINCT fleet_owner')
+            && str_contains($qry, 'fleet_mission')) {
+            $seen = [];
+            $out = [];
+            foreach ($this->fleetRowsById as $row) {
+                if ((int) ($row['fleet_universe'] ?? 1) !== (int) ($params[':universe'] ?? 1)) {
+                    continue;
+                }
+                if ((int) ($row['fleet_mess'] ?? 0) !== (int) ($params[':outward'] ?? 0)) {
+                    continue;
+                }
+                if (!in_array((int) ($row['fleet_mission'] ?? 0), [1, 2, 9], true)) {
+                    continue;
+                }
+                $owner = (int) ($row['fleet_owner'] ?? 0);
+                if (isset($seen[$owner])) {
+                    continue;
+                }
+                $seen[$owner] = true;
+                $out[] = $row;
+            }
+            return $out;
+        }
+
         if (str_contains($qry, '%%FLEETS%%')
             && str_contains($qry, 'fleet_end_id')
             && str_contains($qry, 'fleet_mission')
@@ -92,6 +119,36 @@ trait FakeFleetQueryHandler
                 return $field === false ? $count : ($count[$field] ?? false);
             }
             $count = ['state' => $this->bashLogCount];
+            return $field === false ? $count : ($count[$field] ?? false);
+        }
+
+        if (str_contains($qry, '%%USERS%%') && str_contains($qry, 'COUNT(*)') && str_contains($qry, 'onlinetime')) {
+            $count = ['total' => $this->onlineUserCount];
+            return $field === false ? $count : ($count[$field] ?? false);
+        }
+
+        if (str_contains($qry, '%%FLEETS%%')
+            && str_contains($qry, 'COUNT(*)')
+            && str_contains($qry, 'fleet_owner = 0')) {
+            $planetId = (int) ($params[':planetId'] ?? 0);
+            $outward = (int) ($params[':outward'] ?? 0);
+            $n = 0;
+            foreach ($this->fleetRowsById as $row) {
+                if ((int) ($row['fleet_end_id'] ?? 0) !== $planetId) {
+                    continue;
+                }
+                if ((int) ($row['fleet_owner'] ?? -1) !== 0) {
+                    continue;
+                }
+                if ((int) ($row['fleet_mission'] ?? 0) !== 1) {
+                    continue;
+                }
+                if ((int) ($row['fleet_mess'] ?? 0) !== $outward) {
+                    continue;
+                }
+                $n++;
+            }
+            $count = ['total' => $n];
             return $field === false ? $count : ($count[$field] ?? false);
         }
 

--- a/tests/Support/FakePlanetQueryHandler.php
+++ b/tests/Support/FakePlanetQueryHandler.php
@@ -32,6 +32,32 @@ trait FakePlanetQueryHandler
             return $field === false ? $count : ($count[$field] ?? false);
         }
 
+        if (isset($params[':galaxy'], $params[':system'], $params[':planet'])) {
+            foreach ($this->planetRowsById as $row) {
+                if ((int) ($row['galaxy'] ?? 0) !== (int) $params[':galaxy']) {
+                    continue;
+                }
+                if ((int) ($row['system'] ?? 0) !== (int) $params[':system']) {
+                    continue;
+                }
+                if ((int) ($row['planet'] ?? 0) !== (int) $params[':planet']) {
+                    continue;
+                }
+                if (isset($params[':universe']) && isset($row['universe'])
+                    && (int) $row['universe'] !== (int) $params[':universe']) {
+                    continue;
+                }
+                if (str_contains($qry, 'planet_type') && (int) ($row['planet_type'] ?? 1) !== 1) {
+                    continue;
+                }
+                if (str_contains($qry, 'destruyed') && (int) ($row['destruyed'] ?? 0) !== 0) {
+                    continue;
+                }
+                return $field === false ? $row : ($row[$field] ?? false);
+            }
+            return $field === false ? null : false;
+        }
+
         $planetId = (int) ($params[':planetId'] ?? $params[':id'] ?? 0);
         if (str_contains($qry, 'der_') && str_contains($qry, 'AS total')) {
             $row = $this->planetRowsById[$planetId] ?? [

--- a/tests/Support/FakePlanetQueryHandler.php
+++ b/tests/Support/FakePlanetQueryHandler.php
@@ -32,6 +32,22 @@ trait FakePlanetQueryHandler
             return $field === false ? $count : ($count[$field] ?? false);
         }
 
+        if (isset($params[':userId']) && str_contains($qry, 'id_owner')) {
+            foreach ($this->planetRowsById as $row) {
+                if ((int) ($row['id_owner'] ?? 0) !== (int) $params[':userId']) {
+                    continue;
+                }
+                if (str_contains($qry, 'planet_type') && (int) ($row['planet_type'] ?? 1) !== 1) {
+                    continue;
+                }
+                if (str_contains($qry, 'destruyed') && (int) ($row['destruyed'] ?? 0) !== 0) {
+                    continue;
+                }
+                return $field === false ? $row : ($row[$field] ?? false);
+            }
+            return $field === false ? null : false;
+        }
+
         if (isset($params[':galaxy'], $params[':system'], $params[':planet'])) {
             foreach ($this->planetRowsById as $row) {
                 if ((int) ($row['galaxy'] ?? 0) !== (int) $params[':galaxy']) {

--- a/tests/Unit/FleetDispatchServiceTest.php
+++ b/tests/Unit/FleetDispatchServiceTest.php
@@ -51,6 +51,7 @@ class FleetDispatchServiceTest extends TestCase
             'fl_only_planets_colonizable'   => 'Only planets can be colonized',
             'fl_no_target'                  => 'No target',
             'fl_empty_target'               => 'Empty target',
+            'fl_salvage_gone'               => 'Salvage gone',
             'fl_admin_attack'               => 'Admin attack',
             'fl_player_is_noob'             => 'Player is noob',
             'fl_player_is_strong'           => 'Player is strong',
@@ -109,6 +110,48 @@ class FleetDispatchServiceTest extends TestCase
             ['id' => 1],
             $this->basePlanet()
         );
+    }
+
+    public function testValidateTargetThrowsWhenSalvagePackageMissing(): void
+    {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('Salvage gone');
+
+        $params = $this->baseValidateTargetParams([
+            'targetMission' => 18,
+            'targetGalaxy'  => 2,
+            'targetSystem'  => 9,
+            'targetPlanet'  => 4,
+        ]);
+
+        FleetDispatchService::validateTarget($params, ['id' => 1, 'universe' => 1], $this->basePlanet());
+    }
+
+    public function testValidateTargetAcceptsSalvageWhenPackageExists(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 2,
+            'system' => 9,
+            'planet' => 4,
+            'metal' => 1000,
+            'crystal' => 500,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 3600,
+            'tier' => 1,
+            'encounter_seed' => 50,
+        ];
+
+        $params = $this->baseValidateTargetParams([
+            'targetMission' => 18,
+            'targetGalaxy'  => 2,
+            'targetSystem'  => 9,
+            'targetPlanet'  => 4,
+        ]);
+
+        FleetDispatchService::validateTarget($params, ['id' => 1, 'universe' => 1], $this->basePlanet());
+        $this->addToAssertionCount(1);
     }
 
     public function testValidateTargetThrowsOnInvalidCoordinates(): void

--- a/tests/Unit/FleetFunctionsDatabaseTest.php
+++ b/tests/Unit/FleetFunctionsDatabaseTest.php
@@ -377,6 +377,36 @@ class FleetFunctionsDatabaseTest extends TestCase
         $this->assertNotContains(18, $missions);
     }
 
+    public function testGetAvailableMissionsIncludesSalvageOnDebrisTypeWhenPackageExists(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 3,
+            'system' => 4,
+            'planet' => 5,
+            'metal' => 100,
+            'crystal' => 50,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 3600,
+            'tier' => 1,
+            'encounter_seed' => 50,
+        ];
+        $user = ['id' => 1, 'universe' => 1];
+        $misInfo = [
+            'galaxy' => 3,
+            'system' => 4,
+            'planet' => 5,
+            'planettype' => 2,
+            'Ship' => [209 => 1],
+        ];
+        $planet = ['id_owner' => 0, 'der_metal' => 0, 'der_crystal' => 0];
+
+        $missions = FleetFunctions::GetAvailableMissions($user, $misInfo, $planet);
+
+        $this->assertContains(18, $missions);
+    }
+
     public function testGetFleetMissionsHoldBuildsStayBlock(): void
     {
         $user = ['id' => 1, 'universe' => 1];

--- a/tests/Unit/FleetFunctionsDatabaseTest.php
+++ b/tests/Unit/FleetFunctionsDatabaseTest.php
@@ -132,6 +132,7 @@ class FleetFunctionsDatabaseTest extends TestCase
             'MODULE_MISSION_TRADE' => 44,
             'MODULE_MISSION_TRANSFER' => 45,
             'MODULE_MISSION_DARKMATTER' => 31,
+            'MODULE_MISSION_SALVAGE' => 47,
         ];
         foreach ($modules as $name => $value) {
             if (!defined($name)) {
@@ -326,6 +327,54 @@ class FleetFunctionsDatabaseTest extends TestCase
 
         $this->assertContains(4, $missions);
         $this->assertNotContains(1, $missions, 'Attack is not offered on your own planet');
+    }
+
+    public function testGetAvailableMissionsIncludesSalvageWhenPackageExists(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 8,
+            'metal' => 1000,
+            'crystal' => 500,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 3600,
+            'tier' => 1,
+            'encounter_seed' => 50,
+        ];
+
+        $user = ['id' => 1, 'universe' => 1];
+        $misInfo = [
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 8,
+            'planettype' => 1,
+            'Ship' => [202 => 1],
+        ];
+        $planet = ['id_owner' => 0, 'der_metal' => 0, 'der_crystal' => 0];
+
+        $missions = FleetFunctions::GetAvailableMissions($user, $misInfo, $planet);
+
+        $this->assertContains(18, $missions);
+    }
+
+    public function testGetAvailableMissionsExcludesSalvageWithoutPackage(): void
+    {
+        $user = ['id' => 1, 'universe' => 1];
+        $misInfo = [
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 8,
+            'planettype' => 1,
+            'Ship' => [202 => 1],
+        ];
+        $planet = ['id_owner' => 0, 'der_metal' => 0, 'der_crystal' => 0];
+
+        $missions = FleetFunctions::GetAvailableMissions($user, $misInfo, $planet);
+
+        $this->assertNotContains(18, $missions);
     }
 
     public function testGetFleetMissionsHoldBuildsStayBlock(): void

--- a/tests/Unit/GalaxyRowsTest.php
+++ b/tests/Unit/GalaxyRowsTest.php
@@ -95,6 +95,39 @@ class GalaxyRowsTest extends TestCase
         $this->assertTrue($data[6]['action']['buddy']);
     }
 
+    public function test_get_galaxy_data_includes_salvage_on_occupied_slot(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 1,
+            'system' => 5,
+            'planet' => 6,
+            'metal' => 4000,
+            'crystal' => 2000,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 86400,
+            'tier' => 1,
+            'encounter_seed' => 10,
+            'planet_id' => 100,
+        ];
+        $this->seedGalaxyRow([
+            'planet' => 6,
+            'id_owner' => 2,
+            'userid' => 2,
+            'username' => 'rival',
+            'buddy' => 0,
+            'der_metal' => 0,
+            'der_crystal' => 0,
+        ]);
+
+        $data = $this->galaxyRows()->setGalaxy(1)->setSystem(5)->getGalaxyData();
+
+        $this->assertNotNull($data[6]['salvage']);
+        $this->assertSame(4000, $data[6]['salvage']['metal']);
+        $this->assertTrue($data[6]['missions'][18]);
+    }
+
     public function test_get_galaxy_data_escapes_player_and_planet_names(): void
     {
         $this->seedGalaxyRow([
@@ -467,6 +500,7 @@ class GalaxyRowsTest extends TestCase
             'MODULE_MISSION_SPY' => 24,
             'MODULE_MISSION_RECYCLE' => 32,
             'MODULE_MISSION_DESTROY' => 29,
+            'MODULE_MISSION_SALVAGE' => 47,
             'MODULE_BUDDYLIST' => 6,
             'MODULE_MESSAGES' => 16,
             'MODULE_PHALANX' => 19,

--- a/tests/Unit/GalaxyRowsVizJsonTest.php
+++ b/tests/Unit/GalaxyRowsVizJsonTest.php
@@ -4,11 +4,18 @@ use HiveNova\Core\Config;
 use HiveNova\Core\GalaxyRows;
 use PHPUnit\Framework\TestCase;
 
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
 /**
  * Validates GalaxyRows planet/moon vizJson payloads.
  */
 class GalaxyRowsVizJsonTest extends TestCase
 {
+	use SwapDatabaseInstance;
+
+	private FakeDatabase $fake;
+
 	protected function setUp(): void
 	{
 		if (!defined('FIELDS_BY_TERRAFORMER')) {
@@ -17,6 +24,27 @@ class GalaxyRowsVizJsonTest extends TestCase
 		if (!defined('FIELDS_BY_MOONBASIS_LEVEL')) {
 			define('FIELDS_BY_MOONBASIS_LEVEL', 3);
 		}
+
+		$this->fake = new FakeDatabase();
+		$this->swapDatabaseInstance($this->fake);
+
+		$available = new ReflectionProperty(\HiveNova\Core\Universe::class, 'availableUniverses');
+		$available->setAccessible(true);
+		$available->setValue([1]);
+		$current = new ReflectionProperty(\HiveNova\Core\Universe::class, 'currentUniverse');
+		$current->setAccessible(true);
+		$current->setValue(1);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (['availableUniverses', 'currentUniverse', 'emulatedUniverse'] as $prop) {
+			$ref = new ReflectionProperty(\HiveNova\Core\Universe::class, $prop);
+			$ref->setAccessible(true);
+			$ref->setValue(null);
+		}
+		$this->restoreDatabaseInstance();
+		parent::tearDown();
 	}
 
 	private function invokeBuildPlanetVizJson(array $galaxyRow, bool $shareIntel, string $themePath, bool $galaxyPreview = false): string
@@ -423,6 +451,60 @@ class GalaxyRowsVizJsonTest extends TestCase
 		$rows->fillUncolonizedSlots($data, 15, 2, 145, './styles/theme/hive/');
 		$this->assertFalse($data[1]['canColonize']);
 		$this->assertTrue($data[8]['canColonize']);
+	}
+
+	public function testFillUncolonizedSlotsAddsSalvageHintWhenPackagePresent(): void
+	{
+		global $USER, $resource;
+
+		Config::setInstance($this->makeColonizeConfig(['moduls' => implode(';', array_fill(0, 50, 1))]), 1);
+		$resource = array_replace($resource ?? [], [124 => 'astrophysics_tech', 106 => 'spy_tech']);
+		$USER = [
+			'universe'          => 1,
+			'astrophysics_tech' => 8,
+			'spy_tech'          => 8,
+			'factor'            => ['Planets' => 0],
+		];
+
+		$this->fake->salvagePackages[] = [
+			'id' => 1,
+			'universe' => 1,
+			'galaxy' => 2,
+			'system' => 145,
+			'planet' => 4,
+			'metal' => 5000,
+			'crystal' => 2500,
+			'spawned_at' => TIMESTAMP,
+			'expires_at' => TIMESTAMP + 86400,
+			'tier' => 2,
+			'encounter_seed' => 10,
+		];
+
+		$rows = new GalaxyRows();
+		$data = [];
+		$rows->fillUncolonizedSlots($data, 5, 2, 145, './styles/theme/hive/');
+
+		$this->assertNotNull($data[4]['salvage']);
+		$this->assertSame(5000, $data[4]['salvage']['metal']);
+		$this->assertSame('pirate', $data[4]['salvage']['family']);
+		$this->assertSame(2, $data[4]['salvage']['tier']);
+		$this->assertTrue($data[4]['missions'][18]);
+		$this->assertNull($data[1]['salvage']);
+	}
+
+	public function testSalvageHintOmitsFamilyBelowSpyTechFour(): void
+	{
+		$rows = new GalaxyRows();
+		$hint = $rows->salvageHint([
+			'metal' => 1000,
+			'crystal' => 500,
+			'spawned_at' => TIMESTAMP,
+			'encounter_seed' => 10,
+			'tier' => 1,
+		], 3);
+
+		$this->assertArrayNotHasKey('family', $hint);
+		$this->assertArrayNotHasKey('tier', $hint);
 	}
 
 	public function testHasSharedPlanetVizIntelRequiresAcceptedBuddyNotPendingRequest(): void

--- a/tests/Unit/GalaxyRowsVizJsonTest.php
+++ b/tests/Unit/GalaxyRowsVizJsonTest.php
@@ -399,6 +399,29 @@ class GalaxyRowsVizJsonTest extends TestCase
 		$this->assertJsContractValidJson($json);
 	}
 
+	public function testUncolonizedVizJsonIncludesPackageDebrisAndSalvage(): void
+	{
+		$json = (new GalaxyRows())->buildUncolonizedPlanetVizJson(
+			1,
+			88,
+			4,
+			'./styles/theme/hive/',
+			[
+				'metal' => 8000,
+				'crystal' => 3000,
+				'spawned_at' => TIMESTAMP,
+				'encounter_seed' => 10,
+				'tier' => 2,
+			],
+			8
+		);
+		$payload = $this->decodePayload($json);
+
+		$this->assertSame(['metal' => 8000, 'crystal' => 3000], $payload['debris']);
+		$this->assertSame('pirate', $payload['salvage']['family']);
+		$this->assertSame(2, $payload['salvage']['tier']);
+	}
+
 	private function makeColonizeConfig(array $overrides = []): Config
 	{
 		return new Config(array_merge([

--- a/tests/Unit/IncomingHostileFleetQueryTest.php
+++ b/tests/Unit/IncomingHostileFleetQueryTest.php
@@ -89,6 +89,17 @@ class IncomingHostileFleetQueryTest extends TestCase
         $this->assertSame(4, IncomingHostileFleetQuery::countForUser(99));
     }
 
+    public function testNpcOwnerZeroAttackCountsAsHostile(): void
+    {
+        $this->fake->fleetRowsById[1] = $this->fleet([
+            'fleet_owner' => 0,
+            'fleet_target_owner' => 99,
+            'fleet_mission' => 1,
+            'fleet_mess' => FLEET_OUTWARD,
+        ]);
+        $this->assertSame(1, IncomingHostileFleetQuery::countForUser(99));
+    }
+
     public function testAcsTargetingSomeoneElseIsIgnored(): void
     {
         $this->fake->fleetRowsById[1] = $this->fleet([

--- a/tests/Unit/MissionCaseColonisationTest.php
+++ b/tests/Unit/MissionCaseColonisationTest.php
@@ -173,6 +173,30 @@ class MissionCaseColonisationTest extends TestCase
         $this->assertCount(1, $this->fake->achievement->messages);
     }
 
+    public function test_colonisation_attaches_existing_salvage_package(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 8,
+            'planet_id' => null,
+            'metal' => 1000,
+            'crystal' => 500,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 86400,
+            'tier' => 1,
+            'encounter_seed' => 1,
+        ];
+
+        $mission = new MissionCaseColonisation($this->colonisationFleet());
+        $mission->TargetEvent();
+
+        $this->assertSame(200, $mission->_fleet['fleet_end_id']);
+        $this->assertSame(200, $this->fake->salvagePackages[0]['planet_id']);
+    }
+
     public function test_colonisation_end_stay_event_is_noop(): void
     {
         $fleet = $this->colonisationFleet(['fleet_mess' => FLEET_HOLD]);

--- a/tests/Unit/MissionCaseCombatTest.php
+++ b/tests/Unit/MissionCaseCombatTest.php
@@ -121,6 +121,33 @@ class MissionCaseCombatTest extends TestCase
         $this->assertEmpty($this->fake->fleetUpdates);
     }
 
+    public function test_npc_attack_return_kills_fleet_without_owner_mail(): void
+    {
+        $fleet = missionFleetFixture([
+            'fleet_owner' => 0,
+            'fleet_mission' => 1,
+            'fleet_array' => '204,8;',
+        ]);
+        $mission = new MissionCaseAttack($fleet);
+        $mission->ReturnEvent();
+        $this->assertSame(1, $mission->kill);
+        $this->assertEmpty($this->fake->achievement->messages);
+    }
+
+    public function test_npc_attack_runs_combat_with_synthetic_attacker(): void
+    {
+        $fleet = missionFleetFixture([
+            'fleet_owner' => 0,
+            'fleet_target_owner' => 2,
+            'fleet_mission' => 1,
+            'fleet_array' => '204,8;',
+            'fleet_amount' => 8,
+        ]);
+        $mission = new MissionCaseAttack($fleet);
+        $mission->TargetEvent();
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+    }
+
     public function test_attack_with_acs_runs_combat_for_group_fleets(): void
     {
         $this->fake->fleetRowsById[2] = missionCombatAcsMemberFleet(2, 7, ['fleet_owner' => 3]);

--- a/tests/Unit/MissionCaseSalvageTest.php
+++ b/tests/Unit/MissionCaseSalvageTest.php
@@ -1,0 +1,119 @@
+<?php
+
+use HiveNova\Core\Config;
+use HiveNova\Mission\MissionCaseSalvage;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+require_once __DIR__ . '/../Support/MissionFleetFixtures.php';
+
+class MissionCaseSalvageTest extends TestCase
+{
+    use SwapDatabaseInstance;
+
+    private FakeDatabase $fake;
+
+    protected function setUp(): void
+    {
+        $this->fake = new FakeDatabase();
+        $this->swapDatabaseInstance($this->fake);
+        Config::setInstance(new Config([
+            'uni' => 1,
+            'moduls' => implode(';', array_fill(0, 50, 1)),
+            'max_planets' => 15,
+        ]), 1);
+        transportMissionEnvironmentSetup();
+        $this->fake->achievement->users[1] = [
+            'id' => 1,
+            'lang' => 'en',
+            'universe' => 1,
+            'factor' => ['ShipStorage' => 0],
+        ];
+        $this->fake->planetRowsById[10] = ['id' => 10, 'name' => 'Home', 'id_owner' => 1];
+    }
+
+    protected function tearDown(): void
+    {
+        transportMissionEnvironmentTeardown();
+        $ref = new ReflectionProperty(Config::class, 'instances');
+        $ref->setAccessible(true);
+        $ref->setValue(null, []);
+        $this->restoreDatabaseInstance();
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function package(array $overrides = []): array
+    {
+        return array_merge([
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 8,
+            'planet_id' => null,
+            'metal' => 5000,
+            'crystal' => 2500,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 86400,
+            'tier' => 1,
+            'encounter_seed' => 50,
+        ], $overrides);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function salvageFleet(array $overrides = []): array
+    {
+        return missionFleetFixture(array_merge([
+            'fleet_mission' => 18,
+            'fleet_end_id' => 0,
+            'fleet_end_galaxy' => 1,
+            'fleet_end_system' => 1,
+            'fleet_end_planet' => 8,
+            'fleet_array' => '210,20;',
+            'fleet_amount' => 20,
+            'fleet_resource_metal' => 0,
+            'fleet_resource_crystal' => 0,
+            'fleet_resource_deuterium' => 0,
+        ], $overrides));
+    }
+
+    public function testHarvestsPackageWithoutCombatWhenSeedSkipsEncounter(): void
+    {
+        $this->fake->salvagePackages[] = $this->package();
+        $mission = new MissionCaseSalvage($this->salvageFleet());
+        $mission->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertSame(5000, (int) $mission->_fleet['fleet_resource_metal']);
+        $this->assertSame(2500, (int) $mission->_fleet['fleet_resource_crystal']);
+        $this->assertSame([], $this->fake->salvagePackages);
+        $this->assertNotEmpty($this->fake->achievement->messages);
+    }
+
+    public function testSecondHarvestBouncesWhenPackageGone(): void
+    {
+        $this->fake->salvagePackages[] = $this->package();
+        $first = new MissionCaseSalvage($this->salvageFleet());
+        $first->TargetEvent();
+        $second = new MissionCaseSalvage($this->salvageFleet(['fleet_id' => 2]));
+        $second->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $second->_fleet['fleet_mess']);
+        $this->assertSame(0, (int) $second->_fleet['fleet_resource_metal']);
+        $this->assertGreaterThan(1, count($this->fake->achievement->messages));
+    }
+
+    public function testBounceWhenNoPackage(): void
+    {
+        $mission = new MissionCaseSalvage($this->salvageFleet());
+        $mission->TargetEvent();
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertSame(0, (int) $mission->_fleet['fleet_resource_metal']);
+    }
+}

--- a/tests/Unit/MissionCaseSalvageTest.php
+++ b/tests/Unit/MissionCaseSalvageTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/../Support/FakeDatabase.php';
 require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
 require_once __DIR__ . '/../Support/MissionFleetFixtures.php';
+require_once __DIR__ . '/../Support/MissionCombatFixtures.php';
 
 class MissionCaseSalvageTest extends TestCase
 {
@@ -18,18 +19,10 @@ class MissionCaseSalvageTest extends TestCase
     {
         $this->fake = new FakeDatabase();
         $this->swapDatabaseInstance($this->fake);
-        Config::setInstance(new Config([
-            'uni' => 1,
-            'moduls' => implode(';', array_fill(0, 50, 1)),
-            'max_planets' => 15,
-        ]), 1);
+        missionCombatEnvironmentSetup();
+        Config::setInstance(missionCombatConfig(['max_planets' => 15]), 1);
         transportMissionEnvironmentSetup();
-        $this->fake->achievement->users[1] = [
-            'id' => 1,
-            'lang' => 'en',
-            'universe' => 1,
-            'factor' => ['ShipStorage' => 0],
-        ];
+        $this->fake->achievement->users[1] = missionCombatUser(1);
         $this->fake->planetRowsById[10] = ['id' => 10, 'name' => 'Home', 'id_owner' => 1];
     }
 
@@ -115,5 +108,72 @@ class MissionCaseSalvageTest extends TestCase
         $mission->TargetEvent();
         $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
         $this->assertSame(0, (int) $mission->_fleet['fleet_resource_metal']);
+    }
+
+    public function testEncounterDestroysWeakFleet(): void
+    {
+        $this->fake->salvagePackages[] = $this->package([
+            'encounter_seed' => 10,
+            'tier' => 1,
+        ]);
+        $mission = new MissionCaseSalvage($this->salvageFleet([
+            'fleet_array' => '202,1;',
+            'fleet_amount' => 1,
+        ]));
+        $mission->TargetEvent();
+        $this->assertSame(1, $mission->kill);
+    }
+
+    public function testEncounterSurvivesAndCollects(): void
+    {
+        $this->fake->salvagePackages[] = $this->package([
+            'encounter_seed' => 10,
+            'tier' => 1,
+        ]);
+        $mission = new MissionCaseSalvage($this->salvageFleet([
+            'fleet_array' => '202,100;',
+            'fleet_amount' => 100,
+        ]));
+        $mission->TargetEvent();
+        $this->assertSame(0, $mission->kill);
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertGreaterThan(0, (int) $mission->_fleet['fleet_resource_metal']);
+    }
+
+    public function testPlanetOwnerAccusedTriggersFightOnBorderlineSeed(): void
+    {
+        $this->fake->accusedDestIds = [22];
+        $this->fake->planetRowsById[55] = ['id' => 55, 'id_owner' => 22, 'name' => 'Accused'];
+        $this->fake->salvagePackages[] = $this->package([
+            'planet_id' => 55,
+            'encounter_seed' => 45,
+            'tier' => 1,
+        ]);
+        $mission = new MissionCaseSalvage($this->salvageFleet([
+            'fleet_array' => '202,100;',
+            'fleet_amount' => 100,
+        ]));
+        $mission->TargetEvent();
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+    }
+
+    public function testEndStayEventIsNoop(): void
+    {
+        $mission = new MissionCaseSalvage($this->salvageFleet(['fleet_mess' => FLEET_HOLD]));
+        $mission->EndStayEvent();
+        $this->assertSame(FLEET_HOLD, $mission->_fleet['fleet_mess']);
+        $this->assertEmpty($this->fake->fleetUpdates);
+    }
+
+    public function testReturnEventRestoresFleet(): void
+    {
+        $mission = new MissionCaseSalvage($this->salvageFleet([
+            'fleet_mess' => FLEET_RETURN,
+            'fleet_resource_metal' => 100,
+            'fleet_resource_crystal' => 50,
+        ]));
+        $mission->ReturnEvent();
+        $this->assertSame(1, $mission->kill);
+        $this->assertNotEmpty($this->fake->achievement->messages);
     }
 }

--- a/tests/Unit/PushingAccusationQueryTest.php
+++ b/tests/Unit/PushingAccusationQueryTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use HiveNova\Core\PushingAccusationQuery;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+class PushingAccusationQueryTest extends TestCase
+{
+    use SwapDatabaseInstance;
+
+    private FakeDatabase $fake;
+
+    protected function setUp(): void
+    {
+        $this->fake = new FakeDatabase();
+        $this->swapDatabaseInstance($this->fake);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreDatabaseInstance();
+        parent::tearDown();
+    }
+
+    public function testAccusedReceiversAreDestIdsNotSenders(): void
+    {
+        $this->fake->accusedDestIds = [42, 7];
+        $this->assertSame([42, 7], PushingAccusationQuery::accusedReceiverIds(1, TIMESTAMP));
+        $this->assertTrue(PushingAccusationQuery::isAccusedReceiver(42, 1, TIMESTAMP));
+        $this->assertFalse(PushingAccusationQuery::isAccusedReceiver(99, 1, TIMESTAMP));
+    }
+}

--- a/tests/Unit/PveNpcFleetFactoryTest.php
+++ b/tests/Unit/PveNpcFleetFactoryTest.php
@@ -40,4 +40,11 @@ class PveNpcFleetFactoryTest extends TestCase
         $this->assertSame('Aliens', $player['username']);
         $this->assertSame(7, $player['military_tech']);
     }
+
+    public function testDisplayNameMapsFamily(): void
+    {
+        $this->assertSame('Pirates', PveNpcFleetFactory::displayName('pirate'));
+        $this->assertSame('Aliens', PveNpcFleetFactory::displayName('alien'));
+        $this->assertSame('Salvagers', PveNpcFleetFactory::displayName('salvager'));
+    }
 }

--- a/tests/Unit/PveNpcFleetFactoryTest.php
+++ b/tests/Unit/PveNpcFleetFactoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use HiveNova\Core\PveNpcFleetFactory;
+use PHPUnit\Framework\TestCase;
+
+class PveNpcFleetFactoryTest extends TestCase
+{
+    public function testTemplatesAreFixedByFamilyAndTier(): void
+    {
+        $this->assertSame([204 => 8, 202 => 2], PveNpcFleetFactory::template('pirate', 1));
+        $this->assertSame([205 => 10, 215 => 3], PveNpcFleetFactory::template('alien', 2));
+        $this->assertSame([219 => 2, 207 => 2], PveNpcFleetFactory::template('salvager', 3));
+    }
+
+    public function testUnknownFamilyFallsBackToPirate(): void
+    {
+        $this->assertSame(PveNpcFleetFactory::template('pirate', 1), PveNpcFleetFactory::template('unknown', 1));
+    }
+
+    public function testAccusedBumpIncreasesCounts(): void
+    {
+        $base = PveNpcFleetFactory::template('pirate', 1, false);
+        $bumped = PveNpcFleetFactory::template('pirate', 1, true);
+        foreach ($base as $id => $count) {
+            $this->assertSame((int) ceil($count * PVE_ACCUSED_SHIP_FACTOR), $bumped[$id]);
+        }
+    }
+
+    public function testFamilyFromSeedBuckets(): void
+    {
+        $this->assertSame('pirate', PveNpcFleetFactory::familyFromSeed(10));
+        $this->assertSame('alien', PveNpcFleetFactory::familyFromSeed(50));
+        $this->assertSame('salvager', PveNpcFleetFactory::familyFromSeed(80));
+    }
+
+    public function testSyntheticPlayerUsesOwnerZero(): void
+    {
+        $player = PveNpcFleetFactory::syntheticPlayer('Aliens', 7);
+        $this->assertSame(0, $player['id']);
+        $this->assertSame('Aliens', $player['username']);
+        $this->assertSame(7, $player['military_tech']);
+    }
+}

--- a/tests/Unit/PvePackageServiceTest.php
+++ b/tests/Unit/PvePackageServiceTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use HiveNova\Core\Config;
+use HiveNova\Core\PvePackageService;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+class PvePackageServiceTest extends TestCase
+{
+    use SwapDatabaseInstance;
+
+    private FakeDatabase $fake;
+
+    protected function setUp(): void
+    {
+        $this->fake = new FakeDatabase();
+        $this->swapDatabaseInstance($this->fake);
+        Config::setInstance(new Config(['uni' => 1, 'moduls' => implode(';', array_fill(0, 50, 1))]), 1);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreDatabaseInstance();
+        parent::tearDown();
+    }
+
+    public function testCurrentLootGrowsWithAgeAndCaps(): void
+    {
+        $row = [
+            'metal' => 5000,
+            'crystal' => 2500,
+            'spawned_at' => TIMESTAMP - 10 * 3600,
+        ];
+        $loot = PvePackageService::currentLoot($row, TIMESTAMP);
+        $this->assertSame(10000, $loot['metal']);
+        $this->assertSame(7500, $loot['crystal']);
+
+        $capped = PvePackageService::currentLoot([
+            'metal' => 49000,
+            'crystal' => 24000,
+            'spawned_at' => TIMESTAMP - 100 * 3600,
+        ], TIMESTAMP);
+        $this->assertSame(PVE_PACKAGE_CAP_METAL, $capped['metal']);
+        $this->assertSame(PVE_PACKAGE_CAP_CRYSTAL, $capped['crystal']);
+    }
+
+    public function testSpawnBudgetScalesThenCaps(): void
+    {
+        $this->assertSame(2, PvePackageService::spawnBudget(0));
+        $this->assertSame(7, PvePackageService::spawnBudget(5));
+        $this->assertSame(PVE_SPAWN_HARD_CAP, PvePackageService::spawnBudget(100));
+    }
+
+    public function testCollectRemovesEmptyPackage(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 4,
+            'metal' => 100,
+            'crystal' => 50,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 100,
+            'tier' => 1,
+            'encounter_seed' => 1,
+        ];
+        PvePackageService::collect(1, 100, 50);
+        $this->assertSame([], $this->fake->salvagePackages);
+    }
+
+    public function testAttachToPlanetSetsPlanetId(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 2,
+            'system' => 3,
+            'planet' => 8,
+            'planet_id' => null,
+            'metal' => 100,
+            'crystal' => 50,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 100,
+            'tier' => 1,
+            'encounter_seed' => 1,
+        ];
+        PvePackageService::attachToPlanet(1, 2, 3, 8, 77);
+        $this->assertSame(77, $this->fake->salvagePackages[0]['planet_id']);
+    }
+
+    public function testSpyHintRevealsFamilyThenTier(): void
+    {
+        $row = [
+            'metal' => 1000,
+            'crystal' => 500,
+            'spawned_at' => TIMESTAMP,
+            'encounter_seed' => 10,
+            'tier' => 3,
+        ];
+        $low = PvePackageService::spyHint($row, 3);
+        $this->assertArrayNotHasKey('family', $low);
+        $mid = PvePackageService::spyHint($row, 4);
+        $this->assertSame('pirate', $mid['family']);
+        $this->assertArrayNotHasKey('tier', $mid);
+        $high = PvePackageService::spyHint($row, 8);
+        $this->assertSame(3, $high['tier']);
+    }
+
+    public function testExpireOldDeletesPastTtl(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 1,
+            'metal' => 1,
+            'crystal' => 1,
+            'spawned_at' => TIMESTAMP - 10,
+            'expires_at' => TIMESTAMP - 1,
+            'tier' => 1,
+            'encounter_seed' => 1,
+        ];
+        PvePackageService::expireOld(1, TIMESTAMP);
+        $this->assertSame([], $this->fake->salvagePackages);
+    }
+}

--- a/tests/Unit/PvePackageServiceTest.php
+++ b/tests/Unit/PvePackageServiceTest.php
@@ -128,4 +128,32 @@ class PvePackageServiceTest extends TestCase
         PvePackageService::expireOld(1, TIMESTAMP);
         $this->assertSame([], $this->fake->salvagePackages);
     }
+
+    public function testSpawnTickDisabledWhenModuleOff(): void
+    {
+        Config::setInstance(new Config(['uni' => 1, 'moduls' => implode(';', array_fill(0, 50, 0))]), 1);
+        $this->assertSame(0, PvePackageService::spawnTick(1, TIMESTAMP));
+    }
+
+    public function testCountOnlineReadsFakeUserWindow(): void
+    {
+        $this->fake->onlineUserCount = 4;
+        $this->assertSame(4, PvePackageService::countOnline(1, TIMESTAMP));
+    }
+
+    public function testSpawnTickCreatesPackageOnEmptyMap(): void
+    {
+        Config::setInstance(new Config([
+            'uni' => 1,
+            'moduls' => implode(';', array_fill(0, 50, 1)),
+            'max_galaxy' => 1,
+            'max_system' => 1,
+            'max_planets' => 1,
+        ]), 1);
+        $this->fake->onlineUserCount = 0;
+        $created = PvePackageService::spawnTick(1, TIMESTAMP);
+        $this->assertGreaterThan(0, $created);
+        $this->assertNotEmpty($this->fake->salvagePackages);
+        $this->assertSame(1, (int) $this->fake->salvagePackages[0]['galaxy']);
+    }
 }

--- a/tests/Unit/PveRaidServiceTest.php
+++ b/tests/Unit/PveRaidServiceTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use HiveNova\Core\Config;
+use HiveNova\Core\PveRaidService;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+class PveRaidServiceTest extends TestCase
+{
+    use SwapDatabaseInstance;
+
+    private FakeDatabase $fake;
+
+    private array $savedResource = [];
+    private array $savedReslist = [];
+    private array $savedPricelist = [];
+
+    protected function setUp(): void
+    {
+        global $resource, $reslist, $pricelist;
+        $this->savedResource = $resource;
+        $this->savedReslist = $reslist;
+        $this->savedPricelist = $pricelist;
+
+        $this->fake = new FakeDatabase();
+        $this->swapDatabaseInstance($this->fake);
+        Config::setInstance(new Config([
+            'uni' => 1,
+            'moduls' => implode(';', array_fill(0, 50, 1)),
+            'max_planets' => 15,
+        ]), 1);
+
+        $available = new ReflectionProperty(\HiveNova\Core\Universe::class, 'availableUniverses');
+        $available->setAccessible(true);
+        $available->setValue([1]);
+        $current = new ReflectionProperty(\HiveNova\Core\Universe::class, 'currentUniverse');
+        $current->setAccessible(true);
+        $current->setValue(1);
+
+        $this->fake->achievement->users[10] = [
+            'id' => 10,
+            'urlaubs_modus' => 0,
+            'universe' => 1,
+            'lang' => 'en',
+        ];
+        $this->fake->planetRowsById[55] = [
+            'id' => 55,
+            'id_owner' => 10,
+            'galaxy' => 1,
+            'system' => 2,
+            'planet' => 3,
+            'planet_type' => 1,
+            'universe' => 1,
+            'destruyed' => 0,
+        ];
+    }
+
+    protected function tearDown(): void
+    {
+        global $resource, $reslist, $pricelist;
+        $resource = $this->savedResource;
+        $reslist = $this->savedReslist;
+        $pricelist = $this->savedPricelist;
+
+        foreach (['availableUniverses', 'currentUniverse', 'emulatedUniverse'] as $prop) {
+            $ref = new ReflectionProperty(\HiveNova\Core\Universe::class, $prop);
+            $ref->setAccessible(true);
+            $ref->setValue(null);
+        }
+        $this->restoreDatabaseInstance();
+        parent::tearDown();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function outward(array $overrides = []): array
+    {
+        return array_merge([
+            'fleet_owner' => 10,
+            'fleet_start_id' => 55,
+            'fleet_start_galaxy' => 1,
+            'fleet_start_system' => 2,
+            'fleet_start_planet' => 3,
+            'fleet_start_type' => 1,
+            'fleet_amount' => 40,
+        ], $overrides);
+    }
+
+    public function testSkipsVacationMode(): void
+    {
+        $this->fake->achievement->users[10]['urlaubs_modus'] = 1;
+        $this->assertFalse(PveRaidService::trySpawnRaid(1, 10, $this->outward(), TIMESTAMP, false));
+        $this->assertSame(0, $this->fake->lastFleetInsertId);
+    }
+
+    public function testSkipsWhenHangarNotWeak(): void
+    {
+        global $resource, $reslist, $pricelist;
+        $resource[204] = 'light_hunter';
+        $reslist['fleet'] = [204];
+        $reslist['defense'] = [];
+        $pricelist[204]['attack'] = 50;
+        $this->fake->planetRowsById[55]['light_hunter'] = 20;
+
+        $this->assertFalse(PveRaidService::trySpawnRaid(1, 10, $this->outward(['fleet_amount' => 10]), TIMESTAMP, false));
+        $this->assertSame(0, $this->fake->lastFleetInsertId);
+    }
+
+    public function testSpawnsNpcMissionOneWhenHangarWeak(): void
+    {
+        $this->assertTrue(PveRaidService::trySpawnRaid(1, 10, $this->outward(), TIMESTAMP, false));
+        $this->assertSame(99, $this->fake->lastFleetInsertId);
+        $row = $this->fake->fleetRowsById[99];
+        $this->assertSame(0, $row['fleet_owner']);
+        $this->assertSame(1, $row['fleet_mission']);
+        $this->assertSame(10, $row['fleet_target_owner']);
+        $this->assertSame(55, $row['fleet_end_id']);
+    }
+
+    public function testSkipsWhenInboundNpcAlreadyExists(): void
+    {
+        $this->fake->fleetRowsById[9] = [
+            'fleet_owner' => 0,
+            'fleet_end_id' => 55,
+            'fleet_mission' => 1,
+            'fleet_mess' => FLEET_OUTWARD,
+        ];
+        $this->assertFalse(PveRaidService::trySpawnRaid(1, 10, $this->outward(), TIMESTAMP, false));
+    }
+
+    public function testHangarPowerSumsFleetAndDefenseAttack(): void
+    {
+        global $resource, $reslist, $pricelist;
+        $resource[204] = 'light_hunter';
+        $resource[401] = 'misil_launcher';
+        $reslist['fleet'] = [204];
+        $reslist['defense'] = [401];
+        $pricelist[204]['attack'] = 50;
+        $pricelist[401]['attack'] = 80;
+        $power = PveRaidService::hangarPower([
+            'light_hunter' => 2,
+            'misil_launcher' => 1,
+        ]);
+        $this->assertSame(180, $power);
+    }
+}

--- a/tests/Unit/PveRaidServiceTest.php
+++ b/tests/Unit/PveRaidServiceTest.php
@@ -146,4 +146,69 @@ class PveRaidServiceTest extends TestCase
         ]);
         $this->assertSame(180, $power);
     }
+
+    public function testRunReturnsZeroWhenModuleDisabled(): void
+    {
+        Config::setInstance(new Config(['uni' => 1, 'moduls' => implode(';', array_fill(0, 50, 0))]), 1);
+        $this->assertSame(0, PveRaidService::run(1, TIMESTAMP));
+    }
+
+    public function testRunSpawnsFromOutwardCombatFleet(): void
+    {
+        $this->fake->fleetRowsById[3] = [
+            'fleet_owner' => 10,
+            'fleet_start_id' => 55,
+            'fleet_start_galaxy' => 1,
+            'fleet_start_system' => 2,
+            'fleet_start_planet' => 3,
+            'fleet_start_type' => 1,
+            'fleet_amount' => 40,
+            'fleet_mission' => 1,
+            'fleet_mess' => FLEET_OUTWARD,
+            'fleet_universe' => 1,
+        ];
+        $this->assertSame(1, PveRaidService::run(1, TIMESTAMP));
+        $this->assertSame(99, $this->fake->lastFleetInsertId);
+    }
+
+    public function testRunAccusedIdlePathSpawnsWhenChanceHits(): void
+    {
+        $this->fake->accusedDestIds = range(200, 280);
+        foreach ($this->fake->accusedDestIds as $id) {
+            $this->fake->achievement->users[$id] = [
+                'id' => $id,
+                'urlaubs_modus' => 0,
+                'universe' => 1,
+                'lang' => 'en',
+            ];
+            $this->fake->planetRowsById[$id] = [
+                'id' => $id,
+                'id_owner' => $id,
+                'galaxy' => 1,
+                'system' => 1,
+                'planet' => 1,
+                'planet_type' => 1,
+                'universe' => 1,
+                'destruyed' => 0,
+            ];
+        }
+        $spawned = PveRaidService::run(1, TIMESTAMP);
+        $this->assertGreaterThan(0, $spawned);
+    }
+
+    public function testTrySpawnRaidSkipsMissingPlanet(): void
+    {
+        $this->assertFalse(PveRaidService::trySpawnRaid(1, 10, $this->outward(['fleet_start_id' => 404]), TIMESTAMP, false));
+    }
+
+    public function testTrySpawnRaidSkipsAccusedIdleWhenHangarStrong(): void
+    {
+        global $resource, $reslist, $pricelist;
+        $resource[204] = 'light_hunter';
+        $reslist['fleet'] = [204];
+        $reslist['defense'] = [];
+        $pricelist[204]['attack'] = 50;
+        $this->fake->planetRowsById[55]['light_hunter'] = 20;
+        $this->assertFalse(PveRaidService::trySpawnRaid(1, 10, $this->outward(['fleet_amount' => 10]), TIMESTAMP, true));
+    }
 }

--- a/tests/Unit/PveSpawnCronjobTest.php
+++ b/tests/Unit/PveSpawnCronjobTest.php
@@ -49,5 +49,6 @@ class PveSpawnCronjobTest extends TestCase
         $job = new PveSpawnCronjob();
         $this->assertTrue($job->run());
         $this->assertNotEmpty($this->fake->salvagePackages);
+        $this->assertSame(1, (int) $this->fake->salvagePackages[0]['universe']);
     }
 }

--- a/tests/Unit/PveSpawnCronjobTest.php
+++ b/tests/Unit/PveSpawnCronjobTest.php
@@ -1,0 +1,53 @@
+<?php
+
+use HiveNova\Core\Config;
+use HiveNova\Cronjob\PveSpawnCronjob;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+
+class PveSpawnCronjobTest extends TestCase
+{
+    use SwapDatabaseInstance;
+
+    private FakeDatabase $fake;
+
+    protected function setUp(): void
+    {
+        $this->fake = new FakeDatabase();
+        $this->swapDatabaseInstance($this->fake);
+        Config::setInstance(new Config([
+            'uni' => 1,
+            'moduls' => implode(';', array_fill(0, 50, 1)),
+            'max_galaxy' => 1,
+            'max_system' => 1,
+            'max_planets' => 1,
+        ]), 1);
+
+        $available = new ReflectionProperty(\HiveNova\Core\Universe::class, 'availableUniverses');
+        $available->setAccessible(true);
+        $available->setValue([1]);
+        $current = new ReflectionProperty(\HiveNova\Core\Universe::class, 'currentUniverse');
+        $current->setAccessible(true);
+        $current->setValue(1);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (['availableUniverses', 'currentUniverse', 'emulatedUniverse'] as $prop) {
+            $ref = new ReflectionProperty(\HiveNova\Core\Universe::class, $prop);
+            $ref->setAccessible(true);
+            $ref->setValue(null);
+        }
+        $this->restoreDatabaseInstance();
+        parent::tearDown();
+    }
+
+    public function testRunSpawnsPackagesForAvailableUniverses(): void
+    {
+        $job = new PveSpawnCronjob();
+        $this->assertTrue($job->run());
+        $this->assertNotEmpty($this->fake->salvagePackages);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,6 +29,32 @@ require_once __DIR__ . '/../includes/GeneralFunctions.php';
 if (!defined('MODULE_ACHIEVEMENTS')) {
     define('MODULE_ACHIEVEMENTS', 46);
 }
+if (!defined('MODULE_MISSION_SALVAGE')) {
+    define('MODULE_MISSION_SALVAGE', 47);
+}
+if (!defined('MODULE_AMOUNT')) {
+    define('MODULE_AMOUNT', 48);
+}
+if (!defined('PVE_ONLINE_WINDOW')) {
+    define('PVE_ONLINE_WINDOW', 900);
+    define('PVE_SPAWN_BASE', 2);
+    define('PVE_SPAWN_PER_ONLINE', 1);
+    define('PVE_SPAWN_HARD_CAP', 12);
+    define('PVE_PACKAGE_TTL', 86400);
+    define('PVE_PACKAGE_BASE_METAL', 5000);
+    define('PVE_PACKAGE_BASE_CRYSTAL', 2500);
+    define('PVE_PACKAGE_GROWTH_PER_HOUR', 500);
+    define('PVE_PACKAGE_CAP_METAL', 50000);
+    define('PVE_PACKAGE_CAP_CRYSTAL', 25000);
+    define('PVE_HANGAR_WEAK_FRACTION', 0.5);
+    define('PVE_ACCUSED_SHIP_FACTOR', 1.1);
+    define('PVE_ACCUSED_RAID_CHANCE', 15);
+    define('PVE_RAID_FLIGHT_SECONDS', 600);
+    define('PVE_ENCOUNTER_CHANCE', 40);
+    define('PVE_ACCUSED_ENCOUNTER_BONUS', 10);
+    define('PVE_OVERLAY_CHANCE', 20);
+    define('PVE_ACCUSED_OVERLAY_BONUS', 15);
+}
 
 if (!defined('DB_PREFIX')) {
     define('DB_PREFIX', 'uni1_');


### PR DESCRIPTION
## Summary
- Adds salvage packages on empty galaxy slots (and occasional colonized overlays), mission 18 harvest, and spy-tech family/tier hints.
- Spawns real mission-1 pirate/alien raids when combat fleets are out and the hangar is weak; push-mail receivers get a slight extra overlay and ship bump.
- Registers `pve_spawn` cron and `migration_25.sql` (`DB_VERSION` 25).

Closes #108 (scoped to salvage + inbound raids; not expedition retune or live-event firehose).

## Test plan
- [ ] Apply `migration_25.sql` on a test universe and confirm `salvage_packages` + `pve_spawn` cron exist.
- [ ] Galaxy: empty slot with a package offers salvage; spy tech 4/8 shows family/tier.
- [ ] Send mission 18: loot collected, second fleet bounces when the package is gone.
- [ ] Colonize a slot that has a package: package attaches to the new planet.
- [ ] Outward attack with a weak hangar: inbound NPC attack (owner 0) appears; vacation and strong hangar skip.
- [ ] `./vendor/bin/phpunit` (1217 tests passed locally in this worktree).