### PR TITLE
Fix alliance, buddy, jump-gate, and firehose poll holes

### DIFF
--- a/includes/classes/EventFirehoseFeed.php
+++ b/includes/classes/EventFirehoseFeed.php
@@ -21,7 +21,7 @@ class EventFirehoseFeed
 			$sql = 'SELECT id, time, event_type, size_bucket, outcome
 				FROM %%UNIVERSE_EVENTS%%
 				WHERE universe = :universe AND id > :sinceId
-				ORDER BY id DESC
+				ORDER BY id ASC
 				LIMIT ' . $limit;
 			$params = [
 				':universe' => $universe,
@@ -38,10 +38,19 @@ class EventFirehoseFeed
 			];
 		}
 
-		$rows = Database::get()->select($sql, $params);
+		try {
+			$rows = Database::get()->select($sql, $params);
+		} catch (\Throwable $e) {
+			error_log('EventFirehoseFeed: ' . $e->getMessage());
+			return [];
+		}
 		$out  = [];
 		foreach ($rows as $row) {
 			$out[] = self::present($row, $LNG, $timezone);
+		}
+
+		if ($sinceId > 0) {
+			$out = array_reverse($out);
 		}
 
 		return $out;

--- a/includes/classes/Session.php
+++ b/includes/classes/Session.php
@@ -197,7 +197,7 @@ class Session
 			[':sessionId' => $sessionId]
 		);
 
-		if (empty($row['userID']) || (int) $row['lastonline'] < TIMESTAMP - SESSION_LIFETIME) {
+		if (empty($row) || !is_array($row) || empty($row['userID']) || (int) $row['lastonline'] < TIMESTAMP - SESSION_LIFETIME) {
 			return null;
 		}
 
@@ -206,7 +206,7 @@ class Session
 			[':userId' => $row['userID']]
 		);
 
-		if (empty($user['id']) || (int) $user['bana'] === 1) {
+		if (empty($user) || !is_array($user) || empty($user['id']) || (int) $user['bana'] === 1) {
 			return null;
 		}
 

--- a/includes/classes/missions/MissionCaseDestruction.php
+++ b/includes/classes/missions/MissionCaseDestruction.php
@@ -335,7 +335,9 @@ HTML;
 			$targetDebris	= $db->selectSingle($sql, array(
 				':moonId'	=> $this->_fleet['fleet_end_id']
 			));
-			$targetPlanet 	+= $targetDebris;
+			if (is_array($targetDebris)) {
+				$targetPlanet 	+= $targetDebris;
+			}
 		}
 
 		foreach($debrisResource as $elementID)

--- a/includes/classes/missions/MissionCaseMIP.php
+++ b/includes/classes/missions/MissionCaseMIP.php
@@ -53,17 +53,22 @@ class MissionCaseMIP extends MissionFunctions implements Mission
 			':planetId'	=> $this->_fleet['fleet_end_id']
 		));
 
+		$sql		= 'SELECT lang, military_tech FROM %%USERS%% WHERE id = :userId;';
+		$senderData	= $db->selectSingle($sql, array(
+			':userId'	=> $this->_fleet['fleet_owner']
+		));
+
+		if (!is_array($targetData) || !is_array($senderData)) {
+			$this->KillFleet();
+			return;
+		}
+
 		if ($this->_fleet['fleet_end_type'] == 3) {
 			$sql	= 'SELECT ' . $resource[502] . ' FROM %%PLANETS%% WHERE id_luna = :moonId;';
 			$targetData[$resource[502]]	= $db->selectSingle($sql, array(
 				':moonId'	=> $this->_fleet['fleet_end_id']
 			), $resource[502]);
 		}
-
-		$sql		= 'SELECT lang, military_tech FROM %%USERS%% WHERE id = :userId;';
-		$senderData	= $db->selectSingle($sql, array(
-			':userId'	=> $this->_fleet['fleet_owner']
-		));
 
 		if (
 			!in_array($this->_fleet['fleet_target_obj'], array_merge($reslist['defense'], $reslist['missile']))

--- a/includes/pages/game/ShowAlliancePage.php
+++ b/includes/pages/game/ShowAlliancePage.php
@@ -72,6 +72,12 @@ class ShowAlliancePage extends AbstractGamePage
 			':allianceId'	=> $allianceId
 		));
 
+		if (!is_array($this->allianceData)) {
+			$this->hasAlliance = false;
+			$this->allianceData = null;
+			return;
+		}
+
 		if ($USER['ally_id'] == $allianceId) {
 			if ($this->allianceData['ally_owner'] == $USER['id']) {
 				$this->rights	= array_combine($this->availableRanks, array_fill(0, count($this->availableRanks), true));
@@ -209,10 +215,12 @@ class ShowAlliancePage extends AbstractGamePage
 		$db	= Database::get();
 		$sql	= "SELECT a.ally_tag FROM %%ALLIANCE_REQUEST%% r INNER JOIN %%ALLIANCE%% a ON a.id = r.allianceId WHERE r.userId = :userId;";
 		$allianceResult = $db->selectSingle($sql, array(
-			':userId'	=> $USER['id_planet']
+			':userId'	=> $USER['id']
 		));
 
-		if(empty($allianceResult['ally_tag'])) { $allianceResult['ally_tag'] = 0; }
+		if (!is_array($allianceResult) || empty($allianceResult['ally_tag'])) {
+			$allianceResult = ['ally_tag' => 0];
+		}
 
 		$this->assign(array(
 			'request_text'	=> sprintf($LNG['al_request_wait_message'], $allianceResult['ally_tag']),
@@ -970,6 +978,9 @@ class ShowAlliancePage extends AbstractGamePage
 			$Rank = $db->selectSingle($sql, array(
 				':LeaderID'	=> $postleader
 			));
+			if (!is_array($Rank)) {
+				$this->redirectToHome();
+			}
 
 			$sql = "UPDATE %%USERS%% SET ally_rank_id = :AllyRank WHERE id = :UserID;";
 			$db->update($sql, array(
@@ -1605,7 +1616,7 @@ class ShowAlliancePage extends AbstractGamePage
 		if (empty($targetAlliance)) {
 			$this->sendJSON(array(
 				'error'		=> true,
-				'message'	=> sprintf($LNG['al_diplo_no_alliance'], $targetAlliance['id']),
+				'message'	=> sprintf($LNG['al_diplo_no_alliance'], $id),
 			));
 		}
 

--- a/includes/pages/game/ShowBuddyListPage.php
+++ b/includes/pages/game/ShowBuddyListPage.php
@@ -95,6 +95,14 @@ class ShowBuddyListPage extends AbstractGamePage
 			$this->printMessage($LNG['bu_request_exists']);
 		}
 
+        $sql = "SELECT username, lang FROM %%USERS%% WHERE id = :friendID;";
+        $row = $db->selectSingle($sql, array(
+            ':friendID'  => $id
+        ));
+		if (!is_array($row)) {
+			$this->printMessage($LNG['page_doesnt_exist']);
+		}
+
         $sql = "INSERT INTO %%BUDDY%% SET sender = :userID,	owner = :friendID, universe = :universe;";
         $db->insert($sql, array(
             ':userID'	=> $USER['id'],
@@ -108,11 +116,6 @@ class ShowBuddyListPage extends AbstractGamePage
         $db->insert($sql, array(
             ':buddyID'  => $buddyID,
             ':text' => $text
-        ));
-
-        $sql = "SELECT username, lang FROM %%USERS%% WHERE id = :friendID;";
-        $row = $db->selectSingle($sql, array(
-            ':friendID'  => $id
         ));
 		
 		$Friend_LNG = $LNG;
@@ -142,7 +145,7 @@ class ShowBuddyListPage extends AbstractGamePage
 
 		if($isAllowed)
 		{
-			$sql = "SELECT COUNT(*) as count FROM %%BUDDY_REQUEST%% WHERE :id;";
+			$sql = "SELECT COUNT(*) as count FROM %%BUDDY_REQUEST%% WHERE id = :id;";
             $isRequest = $db->selectSingle($sql, array(
                 ':id'  => $id
             ), 'count');
@@ -152,8 +155,11 @@ class ShowBuddyListPage extends AbstractGamePage
                 $sql = "SELECT u.username, u.id, u.lang FROM %%BUDDY%% b INNER JOIN %%USERS%% u ON u.id = IF(b.sender = :userID,b.owner,b.sender) WHERE b.id = :id;";
                 $requestData = $db->selectSingle($sql, array(
                     ':id'       => $id,
-                    'userID'    => $USER['id']
+                    ':userID'    => $USER['id']
                 ));
+				if (!is_array($requestData)) {
+					$this->redirectTo("game.php?page=buddyList");
+				}
 				
 				$Enemy_LNG = $LNG;
 				
@@ -180,13 +186,17 @@ class ShowBuddyListPage extends AbstractGamePage
 		$id	= HTTP::_GP('id', 0);
 		$db = Database::get();
 
+        $sql = "SELECT sender, u.username, u.lang FROM %%BUDDY%% b INNER JOIN %%USERS%% u ON sender = u.id WHERE b.id = :id AND b.owner = :userID;";
+        $sender = $db->selectSingle($sql, array(
+            ':id'       => $id,
+            ':userID'   => $USER['id'],
+        ));
+		if (!is_array($sender)) {
+			$this->redirectTo("game.php?page=buddyList");
+		}
+
         $sql = "DELETE FROM %%BUDDY_REQUEST%% WHERE id = :id;";
         $db->delete($sql, array(
-            ':id'       => $id
-        ));
-
-        $sql = "SELECT sender, u.username, u.lang FROM %%BUDDY%% b INNER JOIN %%USERS%% u ON sender = u.id WHERE b.id = :id;";
-        $sender = $db->selectSingle($sql, array(
             ':id'       => $id
         ));
 		

--- a/includes/pages/game/ShowFleetStep1Page.php
+++ b/includes/pages/game/ShowFleetStep1Page.php
@@ -284,12 +284,12 @@ class ShowFleetStep1Page extends AbstractGamePage
                 ':targetType' => (($targetPlanetType == 2) ? 1 : $targetPlanetType),
             ));
 
-            if ($targetPlanetType == 3 && !isset($planetData))
+            if ($targetPlanetType == 3 && !is_array($planetData))
 			{
 				$this->sendJSON($LNG['fl_error_no_moon']);
 			}
 
-			if ($targetPlanetType != 2 && !empty($planetData['urlaubs_modus']) && isVacationMode($planetData))
+			if ($targetPlanetType != 2 && is_array($planetData) && !empty($planetData['urlaubs_modus']) && isVacationMode($planetData))
 			{
 				$this->sendJSON($LNG['fl_in_vacation_player']);
 			}
@@ -306,7 +306,7 @@ class ShowFleetStep1Page extends AbstractGamePage
 				$this->sendJSON($LNG['fl_error_not_avalible']);
 			}
 
-			if($targetPlanetType == 2 && empty($planetData['der_metal']) && empty($planetData['der_crystal']))
+			if($targetPlanetType == 2 && (!is_array($planetData) || (empty($planetData['der_metal']) && empty($planetData['der_crystal']))))
 			{
 				$this->sendJSON($LNG['fl_error_empty_derbis']);
 			}

--- a/includes/pages/game/ShowInformationPage.php
+++ b/includes/pages/game/ShowInformationPage.php
@@ -66,7 +66,7 @@ class ShowInformationPage extends AbstractGamePage
 			':userID'   => $USER['id']
 		));
 
-		if (!isset($TargetGate) || $TargetPlanet == $PLANET['id'])
+		if (!is_array($TargetGate) || $TargetPlanet == $PLANET['id'])
 		{
 			$this->sendJSON(array(
 				'message' => $LNG['in_jump_gate_doesnt_have_one'],

--- a/includes/pages/game/ShowOverviewPage.php
+++ b/includes/pages/game/ShowOverviewPage.php
@@ -456,6 +456,9 @@ class ShowOverviewPage extends AbstractGamePage
 							':planetId'	=> $PLANET['id'],
 							':destroyed'=> 0
 						));
+						if (!is_array($NEXT_PLANET)) {
+							$this->sendJSON(array('message' => $LNG['ov_abandon_planet_not_possible']));
+						}
 
 						$sql = "UPDATE %%USERS%% SET id_planet = :new_main_planet_id WHERE id = :userId;";
 						$db->update($sql, array(

--- a/includes/pages/game/ShowResearchPage.php
+++ b/includes/pages/game/ShowResearchPage.php
@@ -128,12 +128,13 @@ class ShowResearchPage extends AbstractGamePage
 					continue;
 
 				if($ListIDArray[4] != $PLANET['id']) {
-					$sql = "SELECT :resource6, :resource31, id FROM %%PLANETS%% WHERE id = :id;";
+					$sql = "SELECT `".$resource[6]."`, `".$resource[31]."`, id FROM %%PLANETS%% WHERE id = :id;";
 					$CPLANET = $db->selectSingle($sql, array(
-						':resource6'	=> $resource[6],
-						':resource31'	=> $resource[31],
 						':id'			=> $ListIDArray[4]
 					));
+					if (!is_array($CPLANET)) {
+						continue;
+					}
 				} else
 					$CPLANET		= $PLANET;
 
@@ -194,12 +195,13 @@ class ShowResearchPage extends AbstractGamePage
 				if($ListIDArray[4] != $PLANET['id']) {
 					$db = Database::get();
 
-					$sql = "SELECT :resource6, :resource31, id FROM %%PLANETS%% WHERE id = :id;";
+					$sql = "SELECT `".$resource[6]."`, `".$resource[31]."`, id FROM %%PLANETS%% WHERE id = :id;";
 					$CPLANET = $db->selectSingle($sql, array(
-						':resource6'	=> $resource[6],
-						':resource31'	=> $resource[31],
 						':id'			=> $ListIDArray[4]
 					));
+					if (!is_array($CPLANET)) {
+						continue;
+					}
 				} else
 					$CPLANET				= $PLANET;
 

--- a/includes/pages/game/ShowTicketPage.php
+++ b/includes/pages/game/ShowTicketPage.php
@@ -105,10 +105,15 @@ class ShowTicketPage extends AbstractGamePage
 		} else {
 			$db = Database::get();
 
-			$sql = "SELECT status FROM %%TICKETS%% WHERE ticketID = :ticketID;";
+			$sql = "SELECT status FROM %%TICKETS%% WHERE ticketID = :ticketID AND ownerID = :ownerID;";
 			$ticketStatus = $db->selectSingle($sql, array(
-				':ticketID'	=> $ticketID
+				':ticketID'	=> $ticketID,
+				':ownerID'	=> $USER['id']
 			), 'status');
+
+			if ($ticketStatus === false || $ticketStatus === null) {
+				$this->printMessage(sprintf($LNG['ti_not_exist'], $ticketID));
+			}
 
 			if ($ticketStatus == 2)
 			{

--- a/tests/Support/FakeAchievementDatabase.php
+++ b/tests/Support/FakeAchievementDatabase.php
@@ -164,7 +164,13 @@ class FakeAchievementDatabase implements DatabaseInterface
                     return true;
                 }
             ));
-            usort($rows, static fn (array $a, array $b): int => (int) $b['id'] <=> (int) $a['id']);
+            $asc = stripos($qry, 'ORDER BY id ASC') !== false;
+            usort(
+                $rows,
+                static fn (array $a, array $b): int => $asc
+                    ? ((int) $a['id'] <=> (int) $b['id'])
+                    : ((int) $b['id'] <=> (int) $a['id'])
+            );
             $limit = 50;
             if (preg_match('/LIMIT\s+(\d+)/i', $qry, $m)) {
                 $limit = (int) $m[1];

--- a/tests/Support/FakeAchievementDatabase.php
+++ b/tests/Support/FakeAchievementDatabase.php
@@ -30,6 +30,8 @@ class FakeAchievementDatabase implements DatabaseInterface
 
     public bool $throwOnUniverseEventsInsert = false;
 
+    public bool $throwOnUniverseEventsSelect = false;
+
     /** @var list<array<string, mixed>> */
     public array $messages = [];
 
@@ -149,6 +151,9 @@ class FakeAchievementDatabase implements DatabaseInterface
         }
 
         if (str_contains($qry, 'FROM %%UNIVERSE_EVENTS%%')) {
+            if ($this->throwOnUniverseEventsSelect) {
+                throw new RuntimeException('universe events select failed');
+            }
             $universe = (int) ($params[':universe'] ?? 0);
             $sinceId = (int) ($params[':sinceId'] ?? 0);
             $rows = array_values(array_filter(

--- a/tests/Support/FakePlanetQueryHandler.php
+++ b/tests/Support/FakePlanetQueryHandler.php
@@ -48,7 +48,7 @@ trait FakePlanetQueryHandler
             return $field === false ? $row : ($row[$field] ?? false);
         }
 
-        $planetId = (int) ($params[':id'] ?? $planetId);
+        $planetId = (int) ($params[':id'] ?? $params[':moonId'] ?? $planetId);
         $row = $this->planetRowsById[$planetId] ?? null;
         if ($row === null) {
             return $field === false ? null : false;

--- a/tests/Unit/EventFirehoseFeedTest.php
+++ b/tests/Unit/EventFirehoseFeedTest.php
@@ -84,4 +84,16 @@ class EventFirehoseFeedTest extends TestCase
 		$rows = EventFirehoseFeed::fetch(1, $this->lng, 'UTC');
 		$this->assertCount(50, $rows);
 	}
+
+	public function test_since_id_returns_oldest_new_events_first(): void
+	{
+		for ($i = 0; $i < 70; $i++) {
+			EventFirehoseWriter::record(1, 100 + $i, 10, 'a');
+		}
+
+		$caughtUp = EventFirehoseFeed::fetch(1, $this->lng, 'UTC', 5);
+		$this->assertCount(50, $caughtUp);
+		$this->assertSame(55, $caughtUp[0]['id']);
+		$this->assertSame(6, $caughtUp[49]['id']);
+	}
 }

--- a/tests/Unit/EventFirehoseFeedTest.php
+++ b/tests/Unit/EventFirehoseFeedTest.php
@@ -96,4 +96,12 @@ class EventFirehoseFeedTest extends TestCase
 		$this->assertSame(55, $caughtUp[0]['id']);
 		$this->assertSame(6, $caughtUp[49]['id']);
 	}
+
+	public function test_fetch_returns_empty_when_select_throws(): void
+	{
+		EventFirehoseWriter::record(1, 100, 10, 'a');
+		$this->fake->achievement->throwOnUniverseEventsSelect = true;
+
+		$this->assertSame([], EventFirehoseFeed::fetch(1, $this->lng, 'UTC'));
+	}
 }

--- a/tests/Unit/MissionCaseCombatTest.php
+++ b/tests/Unit/MissionCaseCombatTest.php
@@ -78,6 +78,24 @@ class MissionCaseCombatTest extends TestCase
         $this->assertSame('battle', $this->fake->achievement->universeEvents[0]['event_type']);
     }
 
+    public function test_destruction_on_moon_merges_parent_debris_when_present(): void
+    {
+        $this->fake->planetRowsById[99]['der_metal'] = 40;
+        $this->fake->planetRowsById[99]['der_crystal'] = 20;
+
+        $mission = new MissionCaseDestruction(missionFleetFixture([
+            'fleet_mission' => 9,
+            'fleet_array' => '202,50;',
+            'fleet_amount' => 50,
+            'fleet_target_owner' => 2,
+            'fleet_end_type' => 3,
+        ]));
+        $mission->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertNotEmpty($this->fake->achievement->messages);
+    }
+
     public function test_mip_destroys_defenses_when_missiles_outnumber_interceptors(): void
     {
         $this->fake->planetRowsById[99]['interplanetary_missile'] = 0;
@@ -97,6 +115,22 @@ class MissionCaseCombatTest extends TestCase
         $this->assertSame(1, $mission->kill);
         $this->assertGreaterThanOrEqual(2, count($this->fake->achievement->messages));
         $this->assertSame([], $this->fake->achievement->universeEvents);
+    }
+
+    public function test_mip_kills_fleet_when_target_planet_is_gone(): void
+    {
+        unset($this->fake->planetRowsById[99]);
+
+        $mission = new MissionCaseMIP(missionFleetFixture([
+            'fleet_mission' => 10,
+            'fleet_amount' => 5,
+            'fleet_target_obj' => 401,
+            'fleet_array' => '503,5;',
+        ]));
+        $mission->TargetEvent();
+
+        $this->assertSame(1, $mission->kill);
+        $this->assertSame([], $this->fake->achievement->messages);
     }
 
     public function test_attack_return_event_restores_fleet_and_notifies_owner(): void


### PR DESCRIPTION
## Summary
- Guard missing `selectSingle` rows on jump gates, fleet-step moons, alliance home/apply-wait/diplo, buddy send/accept/delete, tickets, research queues, MIP, moon-destroy debris, session restore, and abandoning the main planet.
- Buddy accept requires you to be the request owner; ticket replies require `ownerID`; research queue loads real lab/nanite columns instead of PDO-bound names.
- Event firehose incremental polls use `ORDER BY id ASC LIMIT 50` (then reverse) so bursts of more than 50 battles are not skipped; a missing table returns an empty feed instead of 500.

## Test plan
- [ ] Pending alliance application: Alliance page shows the tag, no PHP error
- [ ] Jump to a planet without a gate / bogus `jmpto`: JSON error, not a TypeError
- [ ] Buddy request to a missing user; accept a request you do not own
- [ ] Reply to another player’s ticket id: not exist
- [ ] Queue research on another planet, abandon it, cancel queue
- [ ] `php vendor/bin/phpunit tests/Unit/EventFirehoseFeedTest.php tests/Unit/SessionTest.php`