### PR TITLE
Fix missing-row crashes, jump origin, phalanx debit, moon intel

### DIFF
--- a/includes/classes/GalaxyRows.php
+++ b/includes/classes/GalaxyRows.php
@@ -389,12 +389,13 @@ class GalaxyRows
 				? $THEME->getTheme()
 				: '';
 			$vizEnabled = str_contains($themePath, '/hive/');
+			$shareIntel = $this->hasSharedPlanetVizIntel();
 			$this->galaxyData[$this->galaxyRow['planet']]['moon']	= array(
 				'id'		=> $this->galaxyRow['m_id'],
 				'name'		=> htmlspecialchars((string) $this->galaxyRow['m_name'], ENT_QUOTES, "UTF-8"),
-				'temp_min'	=> $this->galaxyRow['m_temp_min'], 
-				'temp_max'	=> $this->galaxyRow['m_temp_max'],
-				'diameter'	=> $this->galaxyRow['m_diameter'],
+				'temp_min'	=> $shareIntel ? $this->galaxyRow['m_temp_min'] : 0, 
+				'temp_max'	=> $shareIntel ? $this->galaxyRow['m_temp_max'] : 0,
+				'diameter'	=> $shareIntel ? $this->galaxyRow['m_diameter'] : 0,
 				'vizRef'	=> $vizEnabled ? ('moon:' . (int) $this->galaxyRow['m_id']) : '',
 			);
 		}

--- a/includes/classes/PveRaidService.php
+++ b/includes/classes/PveRaidService.php
@@ -59,7 +59,7 @@ class PveRaidService
 				ORDER BY id ASC LIMIT 1;',
 				[':userId' => $userId]
 			);
-			if (empty($planet['id'])) {
+			if (!is_array($planet) || empty($planet['id'])) {
 				continue;
 			}
 			$fake = [
@@ -101,7 +101,7 @@ class PveRaidService
 			'SELECT * FROM %%PLANETS%% WHERE id = :id;',
 			[':id' => $planetId]
 		);
-		if (empty($planet['id'])) {
+		if (!is_array($planet) || empty($planet['id'])) {
 			return false;
 		}
 

--- a/includes/classes/missions/MissionCaseRecycling.php
+++ b/includes/classes/missions/MissionCaseRecycling.php
@@ -54,7 +54,7 @@ class MissionCaseRecycling extends MissionFunctions implements Mission
 			':planetId'	=> $this->_fleet['fleet_end_id']
 		));
 
-		if(!empty($targetData['total']))
+		if(is_array($targetData) && !empty($targetData['total']))
 		{
 			$targetUser			= $this->getUser((int) $this->_fleet['fleet_owner']);
 

--- a/includes/classes/missions/MissionCaseSalvage.php
+++ b/includes/classes/missions/MissionCaseSalvage.php
@@ -40,9 +40,7 @@ class MissionCaseSalvage extends MissionFunctions implements Mission
 				':planet'   => $planet,
 			]
 		);
-		if (!empty($colonized['id']) && (int) $this->_fleet['fleet_end_id'] === 0) {
-			$this->UpdateFleet('fleet_end_id', (int) $colonized['id']);
-			PvePackageService::attachToPlanet($universe, $galaxy, $system, $planet, (int) $colonized['id']);
+		if (is_array($colonized) && !empty($colonized['id']) && (int) $this->_fleet['fleet_end_id'] === 0) {
 			$this->UpdateFleet('fleet_end_id', (int) $colonized['id']);
 			PvePackageService::attachToPlanet($universe, $galaxy, $system, $planet, (int) $colonized['id']);
 		}

--- a/includes/classes/missions/MissionCaseSpy.php
+++ b/includes/classes/missions/MissionCaseSpy.php
@@ -46,6 +46,12 @@ class MissionCaseSpy extends MissionFunctions implements Mission
 
 		$senderPlanetName	= PlanetRepository::getPlanetName($this->_fleet['fleet_start_id']);
 
+		if (!is_array($targetPlanet) || $senderUser === [] || $targetUser === []) {
+			$this->setState(FLEET_RETURN);
+			$this->SaveFleet();
+			return;
+		}
+
 		$LNG			= $this->getLanguage($senderUser['lang']);
 
 		$senderUser['factor']	= getFactors($senderUser, 'basic', $this->_fleet['fleet_start_time']);

--- a/includes/classes/missions/MissionCaseTransport.php
+++ b/includes/classes/missions/MissionCaseTransport.php
@@ -127,6 +127,11 @@ class MissionCaseTransport extends MissionFunctions implements Mission
 				':id'	=> $this->_fleet['fleet_owner']
 			));
 
+			if (!is_array($originUser)) {
+				$this->KillFleet();
+				return;
+			}
+
 			$this->UpdateFleet('fleet_start_id', $originUser['id_planet']);
 			$this->UpdateFleet('fleet_start_galaxy', $originUser['galaxy']);
 			$this->UpdateFleet('fleet_start_system', $originUser['system']);

--- a/includes/pages/adm/ShowAccountDataPage.php
+++ b/includes/pages/adm/ShowAccountDataPage.php
@@ -35,7 +35,7 @@ function ShowAccountDataPage()
 	{
 		$OnlyQueryLogin 	= Database::get()->selectSingle("SELECT `id`, `authlevel` FROM %%USERS%% WHERE `id` = :id AND `universe` = :universe;", [':id' => $id_u, ':universe' => Universe::getEmulated()]);
 
-		if(!isset($OnlyQueryLogin))
+		if(!is_array($OnlyQueryLogin))
 		{
 			$template->message($LNG['ac_username_doesnt'], '?page=accoutdata');
 		}

--- a/includes/pages/adm/ShowNewsPage.php
+++ b/includes/pages/adm/ShowNewsPage.php
@@ -69,13 +69,15 @@ function ShowNewsPage(){
 			"SELECT id, title, text FROM %%NEWS%% WHERE id = :id;",
 			[':id' => HTTP::_GP('id', 0)]
 		);
-		$template->assign_vars(array(
-			'mode'			=> 1,
-			'nws_head'		=> sprintf($LNG['nws_head_edit'], $News['title']),
-			'news_id'		=> $News['id'],
-			'news_title'	=> $News['title'],
-			'news_text'		=> $News['text'],
-		));
+		if (is_array($News)) {
+			$template->assign_vars(array(
+				'mode'			=> 1,
+				'nws_head'		=> sprintf($LNG['nws_head_edit'], $News['title']),
+				'news_id'		=> $News['id'],
+				'news_title'	=> $News['title'],
+				'news_text'		=> $News['text'],
+			));
+		}
 	} elseif(($_GET['action'] ?? '') == 'create') {
 		$template->assign_vars(array(
 			'mode'			=> 2,

--- a/includes/pages/adm/ShowRightsPage.php
+++ b/includes/pages/adm/ShowRightsPage.php
@@ -57,6 +57,9 @@ function ShowRightsPage()
 					"SELECT rights FROM %%USERS%% WHERE `id` = :id;",
 					[':id' => $id]
 				);
+				if (!is_array($Rights)) {
+					$Rights = ['rights' => []];
+				}
 				if(($Rights['rights'] = safe_unserialize($Rights['rights'])) === false) {
 					$Rights['rights']	= array();
 				}

--- a/includes/pages/game/ShowAlliancePage.php
+++ b/includes/pages/game/ShowAlliancePage.php
@@ -89,7 +89,7 @@ class ShowAlliancePage extends AbstractGamePage
 				));
 			}
 
-			if (!isset($this->rights)) {
+			if (!is_array($this->rights)) {
 				$this->rights	= array_combine($this->availableRanks, array_fill(0, count($this->availableRanks), false));
 				$this->rights['EVENTS']    = true; // enable events visibility by default
 			}
@@ -593,7 +593,7 @@ class ShowAlliancePage extends AbstractGamePage
 	public function memberList()
 	{
 		global $USER, $LNG;
-		if (!isset($this->rights) || !$this->rights['MEMBERLIST']) {
+		if (!is_array($this->rights) || !$this->rights['MEMBERLIST']) {
 			$this->redirectToHome();
 		}
 

--- a/includes/pages/game/ShowBuildingsPage.php
+++ b/includes/pages/game/ShowBuildingsPage.php
@@ -91,6 +91,9 @@ class ShowBuildingsPage extends AbstractGamePage
         }
 
 		$CurrentQueue  = safe_unserialize($PLANET['b_building_id']);
+		if (!is_array($CurrentQueue)) {
+			return false;
+		}
 		$ActualCount   = count($CurrentQueue);
 		if($ActualCount <= 1) {
 			return $this->CancelBuildingFromQueue();

--- a/includes/pages/game/ShowInformationPage.php
+++ b/includes/pages/game/ShowInformationPage.php
@@ -50,6 +50,14 @@ class ShowInformationPage extends AbstractGamePage
 
 		$NextJumpTime = self::getNextJumpWaitTime($PLANET['last_jump_time']);
 
+		if ((int) ($PLANET['planet_type'] ?? 0) !== 3 || empty($PLANET[$resource[43]]))
+		{
+			$this->sendJSON(array(
+				'message' => $LNG['in_jump_gate_doesnt_have_one'],
+				'error' => true
+			));
+		}
+
 		if (TIMESTAMP < $NextJumpTime)
 		{
 			$this->sendJSON(array(

--- a/includes/pages/game/ShowPhalanxPage.php
+++ b/includes/pages/game/ShowPhalanxPage.php
@@ -74,12 +74,6 @@ class ShowPhalanxPage extends AbstractGamePage
 		}
 
 		$db = Database::get();
-		$sql = "UPDATE %%PLANETS%% SET deuterium = deuterium - :phalanxDeuterium WHERE id = :planetID;";
-		$db->update($sql, array(
-			':phalanxDeuterium'	=> PHALANX_DEUTERIUM,
-			':planetID'			=> $PLANET['id']
-		));
-
 		$sql = "SELECT id, name, id_owner FROM %%PLANETS%% WHERE universe = :universe
 		AND galaxy = :galaxy AND `system` = :system AND planet = :planet AND planet_type = :type;";
 		
@@ -95,6 +89,12 @@ class ShowPhalanxPage extends AbstractGamePage
 		{
 			$this->printMessage($LNG['px_out_of_range']);
 		}
+
+		$sql = "UPDATE %%PLANETS%% SET deuterium = deuterium - :phalanxDeuterium WHERE id = :planetID;";
+		$db->update($sql, array(
+			':phalanxDeuterium'	=> PHALANX_DEUTERIUM,
+			':planetID'			=> $PLANET['id']
+		));
 		
 
 		$fleetTableObj = new FlyingFleetsTable;

--- a/includes/pages/login/ShowLostPasswordPage.php
+++ b/includes/pages/login/ShowLostPasswordPage.php
@@ -76,6 +76,13 @@ class ShowLostPasswordPage extends AbstractLoginPage
 			':userID'	=> $userID,
 		));
 
+		if (!is_array($userData)) {
+			$this->printMessage($LNG['passwordValidInValid'], array(array(
+				'label'	=> $LNG['passwordBack'],
+				'url'	=> 'index.php',
+			)));
+		}
+
 		$config			= Config::get($userData['universe']);
 
 		$MailRAW		= $LNG->getTemplate('email_lost_password_changed');

--- a/tests/Support/FakePlanetQueryHandler.php
+++ b/tests/Support/FakePlanetQueryHandler.php
@@ -76,11 +76,10 @@ trait FakePlanetQueryHandler
 
         $planetId = (int) ($params[':planetId'] ?? $params[':id'] ?? 0);
         if (str_contains($qry, 'der_') && str_contains($qry, 'AS total')) {
-            $row = $this->planetRowsById[$planetId] ?? [
-                'der_metal' => 0,
-                'der_crystal' => 0,
-                'total' => 0,
-            ];
+            if (!isset($this->planetRowsById[$planetId])) {
+                return $field === false ? null : false;
+            }
+            $row = $this->planetRowsById[$planetId];
             if (!isset($row['total'])) {
                 $row['total'] = (int) ($row['der_metal'] ?? 0) + (int) ($row['der_crystal'] ?? 0);
             }

--- a/tests/Unit/GalaxyRowsTest.php
+++ b/tests/Unit/GalaxyRowsTest.php
@@ -221,6 +221,26 @@ class GalaxyRowsTest extends TestCase
         $this->assertSame('Luna', $data[11]['moon']['name']);
     }
 
+    public function test_get_galaxy_data_hides_stranger_moon_diameter(): void
+    {
+        $this->seedGalaxyRow([
+            'planet' => 13,
+            'buddy' => 0,
+            'm_id' => 502,
+            'm_name' => 'Hidden',
+            'm_temp_min' => -80,
+            'm_temp_max' => 20,
+            'm_diameter' => 8888,
+        ]);
+
+        $data = $this->galaxyRows()->setGalaxy(1)->setSystem(5)->getGalaxyData();
+
+        $this->assertSame(502, $data[13]['moon']['id']);
+        $this->assertSame(0, $data[13]['moon']['diameter']);
+        $this->assertSame(0, $data[13]['moon']['temp_min']);
+        $this->assertSame(0, $data[13]['moon']['temp_max']);
+    }
+
     public function test_get_galaxy_data_without_debris_or_moon(): void
     {
         $this->seedGalaxyRow([

--- a/tests/Unit/MissionCasePhase5Test.php
+++ b/tests/Unit/MissionCasePhase5Test.php
@@ -94,6 +94,21 @@ class MissionCasePhase5Test extends TestCase
         $this->assertNotEmpty($this->fake->achievement->messages);
     }
 
+    public function test_recycling_returns_when_target_planet_is_gone(): void
+    {
+        unset($this->fake->planetRowsById[99]);
+
+        $fleet = missionFleetFixture([
+            'fleet_mission' => 8,
+            'fleet_array' => '209,1;',
+        ]);
+
+        $mission = new MissionCaseRecycling($fleet);
+        $mission->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+    }
+
     public function test_stay_target_event_sends_message_and_kills_fleet(): void
     {
         $this->fake->planetRowsById[99] = ['id' => 99, 'id_owner' => 2, 'name' => 'Target'];

--- a/tests/Unit/MissionCaseSpyTest.php
+++ b/tests/Unit/MissionCaseSpyTest.php
@@ -253,4 +253,19 @@ class MissionCaseSpyTest extends TestCase
         $this->assertSame(1, $mission->kill);
         $this->assertNotEmpty($this->fake->fleetUpdates);
     }
+
+    public function test_spy_returns_when_target_planet_is_gone(): void
+    {
+        unset($this->fake->planetRowsById[99]);
+
+        $mission = new MissionCaseSpy(missionFleetFixture([
+            'fleet_mission' => 6,
+            'fleet_array' => '210,1;',
+        ]));
+        $mission->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertSame(0, $mission->kill);
+        $this->assertEmpty($this->fake->achievement->messages);
+    }
 }

--- a/tests/Unit/MissionCaseTransportTest.php
+++ b/tests/Unit/MissionCaseTransportTest.php
@@ -86,4 +86,15 @@ class MissionCaseTransportTest extends TestCase
         $this->assertCount(1, $this->fake->achievement->messages);
         $this->assertSame(1, $mission->kill);
     }
+
+    public function test_transport_kills_fleet_when_origin_user_is_gone(): void
+    {
+        unset($this->fake->planetRowsById[10], $this->fake->achievement->users[1]);
+
+        $fleet = transportFleetFixture();
+        $mission = new MissionCaseTransport($fleet);
+        $mission->TargetEvent();
+
+        $this->assertSame(1, $mission->kill);
+    }
 }

--- a/tests/Unit/PveRaidServiceTest.php
+++ b/tests/Unit/PveRaidServiceTest.php
@@ -201,6 +201,19 @@ class PveRaidServiceTest extends TestCase
         $this->assertFalse(PveRaidService::trySpawnRaid(1, 10, $this->outward(['fleet_start_id' => 404]), TIMESTAMP, false));
     }
 
+    public function testRunAccusedIdleSkipsUserWithNoPlanet(): void
+    {
+        $this->fake->accusedDestIds = [404];
+        $this->fake->achievement->users[404] = [
+            'id' => 404,
+            'urlaubs_modus' => 0,
+            'universe' => 1,
+            'lang' => 'en',
+        ];
+
+        $this->assertSame(0, PveRaidService::run(1, TIMESTAMP));
+    }
+
     public function testTrySpawnRaidSkipsAccusedIdleWhenHangarStrong(): void
     {
         global $resource, $reslist, $pricelist;


### PR DESCRIPTION
## Summary
- Guard `selectSingle` false/null offsets so recycle, spy, salvage, transport, PVE raids, alliance ranks, admin/login pages, and building queues do not TypeError under PHP 8.
- Require a jump gate on the origin moon; charge phalanx deuterium only after a live planet exists; hide stranger moon diameter/temp in galaxy HTML.

## Test plan
- [ ] Recycle a debris field after the planet row is gone — fleet returns, tick continues
- [ ] Spy a destroyed colony — probes return without a report crash
- [ ] Galaxy tooltip for a stranger moon shows 0 size/temp; buddy/own moon still shows real values
- [ ] Jump from a planet (no gate) is rejected; moon-to-moon still works
- [ ] Phalanx an empty slot — no deuterium deducted
- [ ] PHPUnit: `MissionCasePhase5Test`, `MissionCaseSpyTest`, `MissionCaseTransportTest`, `GalaxyRowsTest`, `PveRaidServiceTest`