### PR TITLE
Fix dispatch, combat, and recycler overflow holes

### DIFF
--- a/includes/classes/FleetDispatchService.php
+++ b/includes/classes/FleetDispatchService.php
@@ -185,11 +185,11 @@ class FleetDispatchService
         if ($mission == 7 || $mission == 15 || $mission == 16 || $mission == 18) {
             // synthetic target already set by caller — nothing to check here
         } else {
-            if (!empty($targetPlanetData['destruyed'])) {
+            if (empty($targetPlanetData)) {
                 throw new \RuntimeException($LNG['fl_no_target']);
             }
 
-            if (empty($targetPlanetData)) {
+            if (!empty($targetPlanetData['destruyed'])) {
                 throw new \RuntimeException($LNG['fl_no_target']);
             }
         }

--- a/includes/classes/missions/MissionCaseAttack.php
+++ b/includes/classes/missions/MissionCaseAttack.php
@@ -93,6 +93,11 @@ HTML;
 		}
 
 		$targetUser		= $this->getUser((int) $targetPlanet['id_owner']);
+		if ($targetUser === []) {
+			$this->setState(FLEET_RETURN);
+			$this->SaveFleet();
+			return;
+		}
 		$targetUser['factor']	= getFactors($targetUser, 'basic', $this->_fleet['fleet_start_time']);
 
 		$planetUpdater	= new ResourceUpdate();
@@ -367,8 +372,10 @@ HTML;
 			$targetDebris	= $db->selectSingle($sql, array(
 				':moonId'	=> $this->_fleet['fleet_end_id']
 			));
-			$targetPlanet['der_metal'] += $targetDebris['der_metal'];
-			$targetPlanet['der_crystal'] += $targetDebris['der_crystal'];
+			if (is_array($targetDebris)) {
+				$targetPlanet['der_metal'] += $targetDebris['der_metal'];
+				$targetPlanet['der_crystal'] += $targetDebris['der_crystal'];
+			}
 		}
 		
 		foreach($debrisResource as $elementID)

--- a/includes/classes/missions/MissionCaseColonisation.php
+++ b/includes/classes/missions/MissionCaseColonisation.php
@@ -33,6 +33,11 @@ class MissionCaseColonisation extends MissionFunctions implements Mission
 		$db		= Database::get();
 
 		$senderUser		= $this->getUser((int) $this->_fleet['fleet_owner']);
+		if ($senderUser === []) {
+			$this->setState(FLEET_RETURN);
+			$this->SaveFleet();
+			return;
+		}
 
 		$senderUser['factor']	= getFactors($senderUser, 'basic', $this->_fleet['fleet_start_time']);
 

--- a/includes/classes/missions/MissionCaseRecycling.php
+++ b/includes/classes/missions/MissionCaseRecycling.php
@@ -97,12 +97,15 @@ class MissionCaseRecycling extends MissionFunctions implements Mission
 
 			// fast way
 			$collectFactor	= min(1, $totalStorage / $targetData['total']);
+			$storageLeft	= (int) $totalStorage;
 			foreach($debrisIDs as $debrisID)
 			{
 				$fleetColName	= 'fleet_resource_'.$resource[$debrisID];
 				$debrisColName	= 'der_'.$resource[$debrisID];
 
-				$collectedGoods[$debrisID]			= ceil($targetData[$debrisColName] * $collectFactor);
+				$available					= (int) $targetData[$debrisColName];
+				$collectedGoods[$debrisID]	= (int) min($available, $storageLeft, (int) ceil($available * $collectFactor));
+				$storageLeft				-= $collectedGoods[$debrisID];
 				$collectQuery[]						= $debrisColName.' = GREATEST(0, '.$debrisColName.' - :'.$resource[$debrisID].')';
 				$param[':'.$resource[$debrisID]]	= $collectedGoods[$debrisID];
 

--- a/includes/classes/missions/MissionCaseSalvage.php
+++ b/includes/classes/missions/MissionCaseSalvage.php
@@ -131,7 +131,7 @@ class MissionCaseSalvage extends MissionFunctions implements Mission
 			'SELECT id_owner FROM %%PLANETS%% WHERE id = :id;',
 			[':id' => $planetId]
 		);
-		if (empty($row['id_owner'])) {
+		if (!is_array($row) || empty($row['id_owner'])) {
 			return false;
 		}
 

--- a/includes/classes/missions/MissionCaseStay.php
+++ b/includes/classes/missions/MissionCaseStay.php
@@ -31,6 +31,10 @@ class MissionCaseStay extends MissionFunctions implements Mission
 	function TargetEvent()
 	{
 		$senderUser			= $this->getUser((int) $this->_fleet['fleet_owner']);
+		if ($senderUser === []) {
+			$this->RestoreFleet(false);
+			return;
+		}
 
 		$senderUser['factor']	= getFactors($senderUser, 'basic', $this->_fleet['fleet_start_time']);
 		

--- a/includes/pages/adm/ShowAccountDataPage.php
+++ b/includes/pages/adm/ShowAccountDataPage.php
@@ -100,10 +100,12 @@ function ShowAccountDataPage()
 				$BannedQuery	= Database::get()->selectSingle("SELECT theme,time,longer,author FROM %%BANNED%% WHERE `who` = :username;", [':username' => $UserQuery['username']]);
 				
 				
+				if (is_array($BannedQuery)) {
 				$sus_longer	= _date($LNG['php_tdformat'], $BannedQuery['longer'], $USER['timezone']);
 				$sus_time	= _date($LNG['php_tdformat'], $BannedQuery['time'], $USER['timezone']);
 				$sus_reason	= $BannedQuery['theme'];
 				$sus_author	= $BannedQuery['author'];
+				}
 				
 			}
 			
@@ -114,24 +116,27 @@ function ShowAccountDataPage()
 			stat_type";
 			
 			$StatQuery	= Database::get()->selectSingle("SELECT ".$SpecifyItemsS." FROM %%STATPOINTS%% WHERE `id_owner` = :id AND `stat_type` = 1;", [':id' => $id_u]);
+			if (!is_array($StatQuery)) {
+				$StatQuery = [];
+			}
 
-			$count_tecno	= pretty_number($StatQuery['tech_count']);
-			$count_def		= pretty_number($StatQuery['defs_count']);
-			$count_fleet	= pretty_number($StatQuery['fleet_count']);
-			$count_builds	= pretty_number($StatQuery['build_count']);
+			$count_tecno	= pretty_number($StatQuery['tech_count'] ?? 0);
+			$count_def		= pretty_number($StatQuery['defs_count'] ?? 0);
+			$count_fleet	= pretty_number($StatQuery['fleet_count'] ?? 0);
+			$count_builds	= pretty_number($StatQuery['build_count'] ?? 0);
 				
-			$point_builds	= pretty_number($StatQuery['build_points']);
-			$point_tecno	= pretty_number($StatQuery['tech_points']);
-			$point_def		= pretty_number($StatQuery['defs_points']);
-			$point_fleet	= pretty_number($StatQuery['fleet_points']);
+			$point_builds	= pretty_number($StatQuery['build_points'] ?? 0);
+			$point_tecno	= pretty_number($StatQuery['tech_points'] ?? 0);
+			$point_def		= pretty_number($StatQuery['defs_points'] ?? 0);
+			$point_fleet	= pretty_number($StatQuery['fleet_points'] ?? 0);
 				
 				
-			$ranking_tecno		= $StatQuery['tech_rank'];
-			$ranking_builds	= $StatQuery['build_rank'];
-			$ranking_def		= $StatQuery['defs_rank'];
-			$ranking_fleet		= $StatQuery['fleet_rank'];
+			$ranking_tecno		= $StatQuery['tech_rank'] ?? 0;
+			$ranking_builds	= $StatQuery['build_rank'] ?? 0;
+			$ranking_def		= $StatQuery['defs_rank'] ?? 0;
+			$ranking_fleet		= $StatQuery['fleet_rank'] ?? 0;
 				
-			$total_points	= pretty_number($StatQuery['total_points']);
+			$total_points	= pretty_number($StatQuery['total_points'] ?? 0);
 			
 
 			

--- a/includes/pages/adm/ShowBanPage.php
+++ b/includes/pages/adm/ShowBanPage.php
@@ -64,7 +64,7 @@ function ShowBanPage()
 	$Name					= HTTP::_GP('ban_name', '', true);
 	$BANUSER				= $GLOBALS['DATABASE']->getFirstRow("SELECT b.theme, b.longer, u.id, u.urlaubs_modus, u.banaday FROM ".USERS." as u LEFT JOIN ".BANNED." as b ON u.`username` = b.`who` WHERE u.`username` = '".$GLOBALS['DATABASE']->sql_escape($Name)."' AND u.`universe` = '".Universe::getEmulated()."';");
 
-	if(isset($_POST['panel']))
+	if(isset($_POST['panel']) && is_array($BANUSER))
 	{
 		if ($BANUSER['banaday'] <= TIMESTAMP)
 		{
@@ -100,7 +100,7 @@ function ShowBanPage()
 			'timesus'			=> $timesus,
 			'vacation'			=> $vacation,
 		));
-	} elseif (isset($_POST['bannow']) && $BANUSER['id'] != 1) {
+	} elseif (isset($_POST['bannow']) && is_array($BANUSER) && $BANUSER['id'] != 1) {
 		$Name              = HTTP::_GP('ban_name', '' ,true);
 		$reas              = HTTP::_GP('why', '' ,true);
 		$days              = HTTP::_GP('days', 0);

--- a/includes/pages/game/ShowFleetStep3Page.php
+++ b/includes/pages/game/ShowFleetStep3Page.php
@@ -181,9 +181,9 @@ class ShowFleetStep3Page extends AbstractGamePage
 				'authattack'  => 0,
 				'total_points' => 0,
 			);
-		} elseif (isset($targetPlanetData['id_owner']) && $targetPlanetData['id_owner'] == $USER['id']) {
+		} elseif (is_array($targetPlanetData) && isset($targetPlanetData['id_owner']) && $targetPlanetData['id_owner'] == $USER['id']) {
 			$targetPlayerData = $USER;
-		} elseif (!empty($targetPlanetData['id_owner'])) {
+		} elseif (is_array($targetPlanetData) && !empty($targetPlanetData['id_owner'])) {
 			$targetPlayerData = UserRepository::getUserWithStats((int) $targetPlanetData['id_owner']);
 		} else {
 			$targetPlayerData = array();

--- a/includes/pages/game/ShowRaportPage.php
+++ b/includes/pages/game/ShowRaportPage.php
@@ -170,7 +170,11 @@ class ShowRaportPage extends AbstractGamePage
 		}
 
 		$combatReport			= safe_unserialize($reportData['raport']);
-		if($isAttacker && !$isDefender && $combatReport['result'] == 'r' && count($combatReport['rounds']) <= 2) {
+		if (!is_array($combatReport)) {
+			$this->printMessage($LNG['sys_raport_not_found']);
+			return;
+		}
+		if($isAttacker && !$isDefender && $combatReport['result'] == 'r' && count($combatReport['rounds'] ?? []) <= 2) {
 			$this->printMessage($LNG['sys_raport_lost_contact']);
 		}
 

--- a/includes/pages/game/ShowShipyardPage.php
+++ b/includes/pages/game/ShowShipyardPage.php
@@ -38,6 +38,9 @@ class ShowShipyardPage extends AbstractGamePage
 	{
 		global $USER, $PLANET, $resource;
 		$ElementQueue = safe_unserialize($PLANET['b_hangar_id']);
+		if (!is_array($ElementQueue)) {
+			return false;
+		}
 		
 		$CancelArray	= HTTP::_GP('auftr', array());
 		
@@ -168,11 +171,13 @@ class ShowShipyardPage extends AbstractGamePage
 		if (!empty($PLANET['b_building_id']))
 		{
 			$CurrentQueue 	= safe_unserialize($PLANET['b_building_id']);
-			foreach($CurrentQueue as $ElementArray)
-			{
-				if($ElementArray[0] == 21 || $ElementArray[0] == 15) {
-					$NotBuilding = false;
-					break;
+			if (is_array($CurrentQueue)) {
+				foreach($CurrentQueue as $ElementArray)
+				{
+					if($ElementArray[0] == 21 || $ElementArray[0] == 15) {
+						$NotBuilding = false;
+						break;
+					}
 				}
 			}
 		}

--- a/tests/Unit/MissionCaseColonisationTest.php
+++ b/tests/Unit/MissionCaseColonisationTest.php
@@ -231,4 +231,15 @@ class MissionCaseColonisationTest extends TestCase
             )
         );
     }
+
+    public function test_colonisation_returns_when_owner_is_gone(): void
+    {
+        unset($this->fake->achievement->users[1]);
+
+        $mission = new MissionCaseColonisation($this->colonisationFleet());
+        $mission->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertEmpty($this->fake->planetInserts);
+    }
 }

--- a/tests/Unit/MissionCaseCombatTest.php
+++ b/tests/Unit/MissionCaseCombatTest.php
@@ -117,6 +117,37 @@ class MissionCaseCombatTest extends TestCase
         $this->assertSame([], $this->fake->achievement->universeEvents);
     }
 
+    public function test_attack_returns_when_defender_user_is_gone(): void
+    {
+        unset($this->fake->achievement->users[2]);
+
+        $mission = new MissionCaseAttack(missionFleetFixture([
+            'fleet_mission' => 1,
+            'fleet_array' => '202,10;',
+            'fleet_amount' => 10,
+            'fleet_target_owner' => 2,
+        ]));
+        $mission->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertEmpty($this->fake->achievement->messages);
+    }
+
+    public function test_attack_on_moon_skips_missing_parent_debris(): void
+    {
+        $mission = new MissionCaseAttack(missionFleetFixture([
+            'fleet_mission' => 1,
+            'fleet_array' => '202,10;',
+            'fleet_amount' => 10,
+            'fleet_target_owner' => 2,
+            'fleet_end_type' => 3,
+        ]));
+        $mission->TargetEvent();
+
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $this->assertNotEmpty($this->fake->achievement->messages);
+    }
+
     public function test_mip_kills_fleet_when_target_planet_is_gone(): void
     {
         unset($this->fake->planetRowsById[99]);

--- a/tests/Unit/MissionCasePhase5Test.php
+++ b/tests/Unit/MissionCasePhase5Test.php
@@ -109,6 +109,31 @@ class MissionCasePhase5Test extends TestCase
         $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
     }
 
+    public function test_recycling_does_not_collect_more_than_storage(): void
+    {
+        $GLOBALS['pricelist'][209]['capacity'] = 1;
+        $this->fake->planetRowsById[99] = [
+            'der_metal' => 1,
+            'der_crystal' => 1,
+            'total' => 2,
+        ];
+
+        $fleet = missionFleetFixture([
+            'fleet_mission' => 8,
+            'fleet_array' => '209,1;',
+            'fleet_resource_metal' => 0,
+            'fleet_resource_crystal' => 0,
+        ]);
+
+        $mission = new MissionCaseRecycling($fleet);
+        $mission->TargetEvent();
+
+        $this->assertLessThanOrEqual(
+            1,
+            (int) $mission->_fleet['fleet_resource_metal'] + (int) $mission->_fleet['fleet_resource_crystal']
+        );
+    }
+
     public function test_stay_target_event_sends_message_and_kills_fleet(): void
     {
         $this->fake->planetRowsById[99] = ['id' => 99, 'id_owner' => 2, 'name' => 'Target'];
@@ -124,6 +149,21 @@ class MissionCasePhase5Test extends TestCase
 
         $this->assertSame(1, $mission->kill);
         $this->assertNotEmpty($this->fake->achievement->messages);
+    }
+
+    public function test_stay_deploys_when_owner_is_gone(): void
+    {
+        unset($this->fake->achievement->users[1]);
+        $this->fake->planetRowsById[99] = ['id' => 99, 'id_owner' => 2, 'name' => 'Target'];
+
+        $mission = new MissionCaseStay(missionFleetFixture([
+            'fleet_mission' => 5,
+            'fleet_array' => '202,5;',
+            'fleet_target_owner' => 2,
+        ]));
+        $mission->TargetEvent();
+
+        $this->assertSame(1, $mission->kill);
     }
 
     private function defineMissionModules(): void

--- a/tests/Unit/MissionCaseSalvageTest.php
+++ b/tests/Unit/MissionCaseSalvageTest.php
@@ -176,4 +176,15 @@ class MissionCaseSalvageTest extends TestCase
         $this->assertSame(1, $mission->kill);
         $this->assertNotEmpty($this->fake->achievement->messages);
     }
+
+    public function testHarvestIgnoresMissingPackagePlanetOwner(): void
+    {
+        $this->fake->salvagePackages[] = $this->package([
+            'planet_id' => 404,
+            'encounter_seed' => 99,
+        ]);
+        $mission = new MissionCaseSalvage($this->salvageFleet());
+        $mission->TargetEvent();
+        $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+    }
 }


### PR DESCRIPTION
## Summary
- Fleet dispatch and step 3 no longer read offsets on a missing planet; attack/stay/colony/salvage abort cleanly when the user or planet row is gone.
- Combat reports, shipyard queues, admin stats/bans, and moon debris merges guard `false` from `selectSingle` / unserialize.
- Recycler collection now caps haul to remaining cargo so `ceil` cannot overfill.

## Test plan
- [ ] Send a transport/attack to empty coords — error, no PHP crash
- [ ] Recycle 1 metal + 1 crystal with 1 cargo — haul at most 1
- [ ] Open a corrupt combat report and a shipyard with a bad building queue
- [ ] PHPUnit: FleetDispatchServiceTest, MissionCaseCombatTest, MissionCasePhase5Test, MissionCaseColonisationTest, MissionCaseSalvageTest