### PR TITLE
Log moon creation on the event firehose

### DIFF
--- a/includes/classes/EventFirehoseFeed.php
+++ b/includes/classes/EventFirehoseFeed.php
@@ -72,7 +72,7 @@ class EventFirehoseFeed
 			'id'        => (int) ($row['id'] ?? 0),
 			'time'      => _date($LNG['php_tdformat'] ?? 'd. M Y, H:i:s', $time, $timezone),
 			'eventType' => (string) ($LNG['ef_event_' . $eventType] ?? $LNG['ef_event_battle'] ?? 'Battle'),
-			'size'      => (string) ($LNG['ef_size_' . $size] ?? $size),
+			'size'      => (string) ($LNG['ef_size_' . $eventType . '_' . $size] ?? $LNG['ef_size_' . $size] ?? $size),
 			'outcome'   => (string) ($LNG['ef_outcome_' . $outcome] ?? $outcome),
 		];
 	}

--- a/includes/classes/EventFirehoseWriter.php
+++ b/includes/classes/EventFirehoseWriter.php
@@ -8,6 +8,8 @@ class EventFirehoseWriter
 {
 	public const EVENT_BATTLE = 'battle';
 
+	public const EVENT_MOON = 'moon';
+
 	public const SIZE_SMALL = 'small';
 
 	public const SIZE_MEDIUM = 'medium';
@@ -20,9 +22,15 @@ class EventFirehoseWriter
 
 	public const OUTCOME_DRAW = 'draw';
 
+	public const OUTCOME_FORMED = 'formed';
+
 	public const SMALL_MAX = 1_000_000;
 
 	public const MEDIUM_MAX = 100_000_000;
+
+	public const MOON_SMALL_MAX = 6000;
+
+	public const MOON_MEDIUM_MAX = 8000;
 
 	public static function sizeBucket(float $totalUnitsLost): string
 	{
@@ -30,6 +38,18 @@ class EventFirehoseWriter
 			return self::SIZE_SMALL;
 		}
 		if ($totalUnitsLost < self::MEDIUM_MAX) {
+			return self::SIZE_MEDIUM;
+		}
+
+		return self::SIZE_LARGE;
+	}
+
+	public static function moonSizeBucket(float $diameter): string
+	{
+		if ($diameter < self::MOON_SMALL_MAX) {
+			return self::SIZE_SMALL;
+		}
+		if ($diameter < self::MOON_MEDIUM_MAX) {
 			return self::SIZE_MEDIUM;
 		}
 
@@ -47,6 +67,28 @@ class EventFirehoseWriter
 
 	public static function record(int $universe, int $time, float $totalUnitsLost, string $won): void
 	{
+		self::insert(
+			$universe,
+			$time,
+			self::EVENT_BATTLE,
+			self::sizeBucket($totalUnitsLost),
+			self::outcome($won)
+		);
+	}
+
+	public static function recordMoon(int $universe, int $time, float $diameter): void
+	{
+		self::insert(
+			$universe,
+			$time,
+			self::EVENT_MOON,
+			self::moonSizeBucket($diameter),
+			self::OUTCOME_FORMED
+		);
+	}
+
+	private static function insert(int $universe, int $time, string $eventType, string $sizeBucket, string $outcome): void
+	{
 		try {
 			Database::get()->insert(
 				'INSERT INTO %%UNIVERSE_EVENTS%% SET
@@ -58,9 +100,9 @@ class EventFirehoseWriter
 				[
 					':universe'		=> $universe,
 					':time'			=> $time,
-					':eventType'	=> self::EVENT_BATTLE,
-					':sizeBucket'	=> self::sizeBucket($totalUnitsLost),
-					':outcome'		=> self::outcome($won),
+					':eventType'	=> $eventType,
+					':sizeBucket'	=> $sizeBucket,
+					':outcome'		=> $outcome,
 				]
 			);
 		} catch (Throwable $e) {

--- a/includes/classes/PlayerUtil.php
+++ b/includes/classes/PlayerUtil.php
@@ -7,6 +7,7 @@ use HiveNova\Core\Config;
 use HiveNova\Core\Cache;
 use HiveNova\Core\Universe;
 use HiveNova\Core\FleetFunctions;
+use HiveNova\Core\EventFirehoseWriter;
 use Exception;
 
 /**
@@ -514,6 +515,8 @@ class PlayerUtil
 			':moonId'	=> $moonId,
 			':planetId'	=> $parentPlanet['id'],
 		));
+
+		EventFirehoseWriter::recordMoon((int) $universe, TIMESTAMP, (float) $diameter);
 
 		return $moonId;
 	}

--- a/language/de/INGAME.php
+++ b/language/de/INGAME.php
@@ -105,12 +105,17 @@ $LNG['lm_disclamer']						= 'Impressum';
 $LNG['ef_title']							= 'Universums-Feed';
 $LNG['ef_empty']							= 'Das Universum ist still.';
 $LNG['ef_event_battle']					= 'Kampf';
+$LNG['ef_event_moon']						= 'Mond';
 $LNG['ef_size_small']						= 'Scharmützel';
 $LNG['ef_size_medium']						= 'Gefecht';
 $LNG['ef_size_large']						= 'Große Schlacht';
+$LNG['ef_size_moon_small']					= 'Klein';
+$LNG['ef_size_moon_medium']					= 'Mittel';
+$LNG['ef_size_moon_large']					= 'Groß';
 $LNG['ef_outcome_attacker']				= 'Angreifer siegten';
 $LNG['ef_outcome_defender']				= 'Verteidiger hielten stand';
 $LNG['ef_outcome_draw']					= 'Unentschieden';
+$LNG['ef_outcome_formed']					= 'Entstanden';
 	
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/en/INGAME.php
+++ b/language/en/INGAME.php
@@ -115,12 +115,17 @@ $LNG['lm_disclamer']						= 'Credits';
 $LNG['ef_title']							= 'Universe feed';
 $LNG['ef_empty']							= 'The universe is quiet.';
 $LNG['ef_event_battle']					= 'Battle';
+$LNG['ef_event_moon']						= 'Moon';
 $LNG['ef_size_small']						= 'Skirmish';
 $LNG['ef_size_medium']						= 'Clash';
 $LNG['ef_size_large']						= 'Major battle';
+$LNG['ef_size_moon_small']					= 'Small';
+$LNG['ef_size_moon_medium']					= 'Medium';
+$LNG['ef_size_moon_large']					= 'Large';
 $LNG['ef_outcome_attacker']				= 'Attackers prevailed';
 $LNG['ef_outcome_defender']				= 'Defenders held';
 $LNG['ef_outcome_draw']					= 'Stalemate';
+$LNG['ef_outcome_formed']					= 'Formed';
 
 //----------------------------------------------------------------------------//
 // Overview

--- a/language/es/INGAME.php
+++ b/language/es/INGAME.php
@@ -104,12 +104,17 @@ $LNG['lm_disclamer']						= 'Contacto';
 $LNG['ef_title']							= 'Actividad del universo';
 $LNG['ef_empty']							= 'El universo está en calma.';
 $LNG['ef_event_battle']					= 'Batalla';
+$LNG['ef_event_moon']						= 'Luna';
 $LNG['ef_size_small']						= 'Escaramuza';
 $LNG['ef_size_medium']						= 'Choque';
 $LNG['ef_size_large']						= 'Gran batalla';
+$LNG['ef_size_moon_small']					= 'Pequeña';
+$LNG['ef_size_moon_medium']					= 'Mediana';
+$LNG['ef_size_moon_large']					= 'Grande';
 $LNG['ef_outcome_attacker']				= 'Los atacantes prevalecieron';
 $LNG['ef_outcome_defender']				= 'Los defensores resistieron';
 $LNG['ef_outcome_draw']					= 'Empate';
+$LNG['ef_outcome_formed']					= 'Formada';
 
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/fr/INGAME.php
+++ b/language/fr/INGAME.php
@@ -94,12 +94,17 @@ $LNG['lm_disclamer']						= 'Crédits';
 $LNG['ef_title']							= 'Flux univers';
 $LNG['ef_empty']							= 'L\'univers est calme.';
 $LNG['ef_event_battle']					= 'Bataille';
+$LNG['ef_event_moon']						= 'Lune';
 $LNG['ef_size_small']						= 'Escarmouche';
 $LNG['ef_size_medium']						= 'Affrontement';
 $LNG['ef_size_large']						= 'Grande bataille';
+$LNG['ef_size_moon_small']					= 'Petite';
+$LNG['ef_size_moon_medium']					= 'Moyenne';
+$LNG['ef_size_moon_large']					= 'Grande';
 $LNG['ef_outcome_attacker']				= 'Les attaquants l\'ont emporté';
 $LNG['ef_outcome_defender']				= 'Les défenseurs ont tenu';
 $LNG['ef_outcome_draw']					= 'Match nul';
+$LNG['ef_outcome_formed']					= 'Formée';
 
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/pl/INGAME.php
+++ b/language/pl/INGAME.php
@@ -107,12 +107,17 @@ $LNG['lm_disclamer']						= 'Kontakt';
 $LNG['ef_title']							= 'Kanał uniwersum';
 $LNG['ef_empty']							= 'Uniwersum jest ciche.';
 $LNG['ef_event_battle']					= 'Bitwa';
+$LNG['ef_event_moon']						= 'Księżyc';
 $LNG['ef_size_small']						= 'Potyczka';
 $LNG['ef_size_medium']						= 'Starcie';
 $LNG['ef_size_large']						= 'Wielka bitwa';
+$LNG['ef_size_moon_small']					= 'Mały';
+$LNG['ef_size_moon_medium']					= 'Średni';
+$LNG['ef_size_moon_large']					= 'Duży';
 $LNG['ef_outcome_attacker']				= 'Atakujący zwyciężyli';
 $LNG['ef_outcome_defender']				= 'Obrońcy się utrzymali';
 $LNG['ef_outcome_draw']					= 'Remis';
+$LNG['ef_outcome_formed']					= 'Powstał';
 	
 //----------------------------------------------------------------------------//
 //OVERVIEW

--- a/language/pt/INGAME.php
+++ b/language/pt/INGAME.php
@@ -108,12 +108,17 @@ $LNG['lm_disclamer']						= 'Creditos';
 $LNG['ef_title']							= 'Feed do universo';
 $LNG['ef_empty']							= 'O universo está calmo.';
 $LNG['ef_event_battle']					= 'Batalha';
+$LNG['ef_event_moon']						= 'Lua';
 $LNG['ef_size_small']						= 'Escaramuça';
 $LNG['ef_size_medium']						= 'Confronto';
 $LNG['ef_size_large']						= 'Grande batalha';
+$LNG['ef_size_moon_small']					= 'Pequena';
+$LNG['ef_size_moon_medium']					= 'Média';
+$LNG['ef_size_moon_large']					= 'Grande';
 $LNG['ef_outcome_attacker']				= 'Os atacantes prevaleceram';
 $LNG['ef_outcome_defender']				= 'Os defensores resistiram';
 $LNG['ef_outcome_draw']					= 'Empate';
+$LNG['ef_outcome_formed']					= 'Formada';
 	
 //----------------------------------------------------------------------------//
 // Vista Geral

--- a/language/ru/INGAME.php
+++ b/language/ru/INGAME.php
@@ -101,12 +101,17 @@ $LNG['lm_disclamer']                      = 'Контакты';
 $LNG['ef_title']							= 'Лента вселенной';
 $LNG['ef_empty']							= 'Во вселенной тихо.';
 $LNG['ef_event_battle']					= 'Бой';
+$LNG['ef_event_moon']						= 'Луна';
 $LNG['ef_size_small']						= 'Стычка';
 $LNG['ef_size_medium']						= 'Сражение';
 $LNG['ef_size_large']						= 'Крупный бой';
+$LNG['ef_size_moon_small']					= 'Малая';
+$LNG['ef_size_moon_medium']					= 'Средняя';
+$LNG['ef_size_moon_large']					= 'Крупная';
 $LNG['ef_outcome_attacker']				= 'Атакующие победили';
 $LNG['ef_outcome_defender']				= 'Защитники устояли';
 $LNG['ef_outcome_draw']					= 'Ничья';
+$LNG['ef_outcome_formed']					= 'Образовалась';
 
 // Обзор
 $LNG['ov_newname_specialchar']            = 'Название планеты и луны может состоять только из букв, цифр, пробелов и символов "_", "-", "."';

--- a/language/tr/INGAME.php
+++ b/language/tr/INGAME.php
@@ -110,12 +110,17 @@ $LNG['lm_disclamer']						= 'Iletişim';
 $LNG['ef_title']							= 'Evren akışı';
 $LNG['ef_empty']							= 'Evren sessiz.';
 $LNG['ef_event_battle']					= 'Savaş';
+$LNG['ef_event_moon']						= 'Ay';
 $LNG['ef_size_small']						= 'Çatışma';
 $LNG['ef_size_medium']						= 'Kapışma';
 $LNG['ef_size_large']						= 'Büyük savaş';
+$LNG['ef_size_moon_small']					= 'Küçük';
+$LNG['ef_size_moon_medium']					= 'Orta';
+$LNG['ef_size_moon_large']					= 'Büyük';
 $LNG['ef_outcome_attacker']				= 'Saldıranlar üstün geldi';
 $LNG['ef_outcome_defender']				= 'Savunanlar dayandı';
 $LNG['ef_outcome_draw']					= 'Berabere';
+$LNG['ef_outcome_formed']					= 'Oluştu';
 
 
 //----------------------------------------------------------------------------//

--- a/tests/Unit/EventFirehoseFeedTest.php
+++ b/tests/Unit/EventFirehoseFeedTest.php
@@ -25,12 +25,17 @@ class EventFirehoseFeedTest extends TestCase
 		$this->lng = [
 			'php_tdformat' => 'Y-m-d',
 			'ef_event_battle' => 'Battle',
+			'ef_event_moon' => 'Moon',
 			'ef_size_small' => 'Skirmish',
 			'ef_size_medium' => 'Clash',
 			'ef_size_large' => 'Major battle',
+			'ef_size_moon_small' => 'Small',
+			'ef_size_moon_medium' => 'Medium',
+			'ef_size_moon_large' => 'Large',
 			'ef_outcome_attacker' => 'Attackers prevailed',
 			'ef_outcome_defender' => 'Defenders held',
 			'ef_outcome_draw' => 'Stalemate',
+			'ef_outcome_formed' => 'Formed',
 		];
 	}
 
@@ -103,5 +108,20 @@ class EventFirehoseFeedTest extends TestCase
 		$this->fake->achievement->throwOnUniverseEventsSelect = true;
 
 		$this->assertSame([], EventFirehoseFeed::fetch(1, $this->lng, 'UTC'));
+	}
+
+	public function test_present_uses_moon_labels(): void
+	{
+		$presented = EventFirehoseFeed::present([
+			'id' => 4,
+			'time' => 1_700_000_000,
+			'event_type' => 'moon',
+			'size_bucket' => 'large',
+			'outcome' => 'formed',
+		], $this->lng, 'UTC');
+
+		$this->assertSame('Moon', $presented['eventType']);
+		$this->assertSame('Large', $presented['size']);
+		$this->assertSame('Formed', $presented['outcome']);
 	}
 }

--- a/tests/Unit/EventFirehoseWriterTest.php
+++ b/tests/Unit/EventFirehoseWriterTest.php
@@ -56,4 +56,34 @@ class EventFirehoseWriterTest extends TestCase
 		EventFirehoseWriter::record(1, 1, 10, 'w');
 		$this->assertSame([], $this->fake->achievement->universeEvents);
 	}
+
+	public function test_moon_size_bucket_boundaries(): void
+	{
+		$this->assertSame(EventFirehoseWriter::SIZE_SMALL, EventFirehoseWriter::moonSizeBucket(0));
+		$this->assertSame(EventFirehoseWriter::SIZE_SMALL, EventFirehoseWriter::moonSizeBucket(5999));
+		$this->assertSame(EventFirehoseWriter::SIZE_MEDIUM, EventFirehoseWriter::moonSizeBucket(6000));
+		$this->assertSame(EventFirehoseWriter::SIZE_MEDIUM, EventFirehoseWriter::moonSizeBucket(7999));
+		$this->assertSame(EventFirehoseWriter::SIZE_LARGE, EventFirehoseWriter::moonSizeBucket(8000));
+	}
+
+	public function test_record_moon_stores_formed_event(): void
+	{
+		EventFirehoseWriter::recordMoon(1, 1_700_000_000, 8500);
+
+		$rows = $this->fake->achievement->universeEvents;
+		$this->assertCount(1, $rows);
+		$row = $rows[0];
+		$this->assertSame('moon', $row['event_type']);
+		$this->assertSame('large', $row['size_bucket']);
+		$this->assertSame('formed', $row['outcome']);
+		$this->assertArrayNotHasKey('rid', $row);
+		$this->assertArrayNotHasKey('diameter', $row);
+	}
+
+	public function test_record_moon_failure_does_not_throw(): void
+	{
+		$this->fake->achievement->throwOnUniverseEventsInsert = true;
+		EventFirehoseWriter::recordMoon(1, 1, 5000);
+		$this->assertSame([], $this->fake->achievement->universeEvents);
+	}
 }

--- a/tests/Unit/PlayerUtilDatabaseTest.php
+++ b/tests/Unit/PlayerUtilDatabaseTest.php
@@ -373,6 +373,7 @@ class PlayerUtilDatabaseTest extends TestCase
 
         $this->assertFalse(PlayerUtil::createMoon(1, 2, 100, 8, 77, 10));
         $this->assertCount(0, $this->fake->planetInserts);
+        $this->assertSame([], $this->fake->achievement->universeEvents);
     }
 
     public function testCreateMoonInsertsMoonAndLinksParent(): void
@@ -394,6 +395,10 @@ class PlayerUtilDatabaseTest extends TestCase
         $this->assertSame(3, $this->fake->planetInserts[0][':type']);
         $this->assertSame(8500, $this->fake->planetInserts[0][':diameter']);
         $this->assertSame(200, $this->fake->planetRowsById[150]['id_luna']);
+        $this->assertCount(1, $this->fake->achievement->universeEvents);
+        $this->assertSame('moon', $this->fake->achievement->universeEvents[0]['event_type']);
+        $this->assertSame('large', $this->fake->achievement->universeEvents[0]['size_bucket']);
+        $this->assertSame('formed', $this->fake->achievement->universeEvents[0]['outcome']);
     }
 
     public function testCreateMoonUsesLngDefaultNameWhenMoonNameEmpty(): void


### PR DESCRIPTION
## Summary
- Successful moon creation (combat or admin) now writes an anonymous `moon` event to the universe firehose.
- Size uses diameter buckets (small < 6k, medium < 8k, large 8k+) with moon-specific labels so battle wording is not reused.
- Failed moon creation still does not write a row; insert failures are logged and do not break `createMoon`.

## Test plan
- [ ] `php vendor/bin/phpunit tests/Unit/EventFirehoseWriterTest.php tests/Unit/EventFirehoseFeedTest.php tests/Unit/PlayerUtilDatabaseTest.php tests/Unit/ShowEventFirehosePageTest.php`
- [ ] `php .github/scripts/check-language-files.php`
- [ ] Create a moon in-game (or via admin) and confirm the Universe feed shows `Moon` / size / `Formed` without player names or coords
- [ ] Confirm a battle still shows as `Battle` / Skirmish-Clash-Major battle / attacker-defender-draw