### PR TITLE
fix: stop salvage loot dupes and isolate fleet throws

### DIFF
--- a/includes/classes/FlyingFleetHandler.php
+++ b/includes/classes/FlyingFleetHandler.php
@@ -76,17 +76,26 @@ class FlyingFleetHandler
 			/** @var \HiveNova\Mission\Mission $missionObj */
 			$missionObj	= new $missionName($fleetRow);
 
-			switch($fleetRow['fleet_mess'])
-			{
-				case 0:
-					$missionObj->TargetEvent();
-				break;
-				case 1:
-					$missionObj->ReturnEvent();
-				break;
-				case 2:
-					$missionObj->EndStayEvent();
-				break;
+			try {
+				switch($fleetRow['fleet_mess'])
+				{
+					case 0:
+						$missionObj->TargetEvent();
+					break;
+					case 1:
+						$missionObj->ReturnEvent();
+					break;
+					case 2:
+						$missionObj->EndStayEvent();
+					break;
+				}
+			} catch (\Throwable $e) {
+				error_log(sprintf(
+					'FlyingFleetHandler: fleet %s mission %s: %s',
+					$fleetRow['fleet_id'] ?? '?',
+					$fleetRow['fleet_mission'] ?? '?',
+					$e->getMessage()
+				));
 			}
 		}
 	}

--- a/includes/classes/PvePackageService.php
+++ b/includes/classes/PvePackageService.php
@@ -115,23 +115,32 @@ class PvePackageService
 		return is_array($row) ? $row : null;
 	}
 
-	public static function collect(int $id, int $metalTaken, int $crystalTaken): void
+	public static function collect(int $id, int $metalTaken, int $crystalTaken, int $expectedMetal, int $expectedCrystal): bool
 	{
-		Database::get()->update(
+		$db = Database::get();
+		$db->update(
 			'UPDATE %%SALVAGE_PACKAGES%%
 			SET metal = GREATEST(0, metal - :metal), crystal = GREATEST(0, crystal - :crystal)
-			WHERE id = :id;',
+			WHERE id = :id AND metal = :expectedMetal AND crystal = :expectedCrystal;',
 			[
-				':metal'   => $metalTaken,
-				':crystal' => $crystalTaken,
-				':id'      => $id,
+				':metal'          => $metalTaken,
+				':crystal'        => $crystalTaken,
+				':id'             => $id,
+				':expectedMetal'  => $expectedMetal,
+				':expectedCrystal'=> $expectedCrystal,
 			]
 		);
 
-		Database::get()->delete(
+		if ((int) $db->rowCount() === 0) {
+			return false;
+		}
+
+		$db->delete(
 			'DELETE FROM %%SALVAGE_PACKAGES%% WHERE id = :id AND metal <= 0 AND crystal <= 0;',
 			[':id' => $id]
 		);
+
+		return true;
 	}
 
 	public static function attachToPlanet(int $universe, int $galaxy, int $system, int $planet, int $planetId): void

--- a/includes/classes/missions/MissionCaseAttack.php
+++ b/includes/classes/missions/MissionCaseAttack.php
@@ -145,7 +145,10 @@ HTML;
 			$fleetAttack[$fleetID]['fleetDetail']		= $fleetDetail;
 			$fleetAttack[$fleetID]['unit']				= FleetFunctions::unserialize($fleetDetail['fleet_array']);
 			
-			$userAttack[$fleetAttack[$fleetID]['player']['id']]	= $fleetAttack[$fleetID]['player']['username'];
+			$attackerId = (int) $fleetAttack[$fleetID]['player']['id'];
+			if ($attackerId !== 0) {
+				$userAttack[$attackerId] = $fleetAttack[$fleetID]['player']['username'];
+			}
 		}
 
 		$sql	= "SELECT * FROM %%FLEETS%%
@@ -597,20 +600,23 @@ HTML;
 			(string) $combatResult['won']
 		);
 
-		$sql = 'UPDATE %%USERS%% SET
-		`'.$attackStatus.'` = `'.$attackStatus.'` + 1,
-		kbmetal		= kbmetal + :debrisMetal,
-		kbcrystal	= kbcrystal + :debrisCrystal,
-		lostunits	= lostunits + :lostUnits,
-		desunits	= desunits + :destroyedUnits
-		WHERE id IN ('.implode(',', array_keys($userAttack)).');';
+		$attackerIds = array_keys($userAttack);
+		if ($attackerIds !== []) {
+			$sql = 'UPDATE %%USERS%% SET
+			`'.$attackStatus.'` = `'.$attackStatus.'` + 1,
+			kbmetal		= kbmetal + :debrisMetal,
+			kbcrystal	= kbcrystal + :debrisCrystal,
+			lostunits	= lostunits + :lostUnits,
+			desunits	= desunits + :destroyedUnits
+			WHERE id IN ('.implode(',', $attackerIds).');';
 
-		$db->update($sql, array(
-			':debrisMetal'		=> $debris[901],
-			':debrisCrystal'	=> $debris[902],
-			':lostUnits'		=> $combatResult['unitLost']['attacker'],
-			':destroyedUnits'	=> $combatResult['unitLost']['defender']
-	  	));
+			$db->update($sql, array(
+				':debrisMetal'		=> $debris[901],
+				':debrisCrystal'	=> $debris[902],
+				':lostUnits'		=> $combatResult['unitLost']['attacker'],
+				':destroyedUnits'	=> $combatResult['unitLost']['defender']
+			));
+		}
 
 		$sql = 'UPDATE %%USERS%% SET
 		`'.$defendStatus.'` = `'.$defendStatus.'` + 1,

--- a/includes/classes/missions/MissionCaseSalvage.php
+++ b/includes/classes/missions/MissionCaseSalvage.php
@@ -45,7 +45,7 @@ class MissionCaseSalvage extends MissionFunctions implements Mission
 			PvePackageService::attachToPlanet($universe, $galaxy, $system, $planet, (int) $colonized['id']);
 		}
 
-		$package = PvePackageService::lockAt($universe, $galaxy, $system, $planet);
+		$package = PvePackageService::findAt($universe, $galaxy, $system, $planet);
 		if ($package === null) {
 			$this->bounceEmpty();
 			return;
@@ -64,7 +64,6 @@ class MissionCaseSalvage extends MissionFunctions implements Mission
 			}
 		}
 
-		$loot = PvePackageService::currentLoot($package);
 		$fleetData = FleetFunctions::unserialize($this->_fleet['fleet_array']);
 		$capacity = 0;
 		foreach ($fleetData as $shipId => $shipAmount) {
@@ -76,13 +75,43 @@ class MissionCaseSalvage extends MissionFunctions implements Mission
 			+ (int) $this->_fleet['fleet_resource_crystal']
 			+ (int) $this->_fleet['fleet_resource_deuterium'];
 		$free = max(0, (int) $capacity - $incoming);
+		$takeMetal = 0;
+		$takeCrystal = 0;
 
-		$totalLoot = $loot['metal'] + $loot['crystal'];
-		$factor = $totalLoot > 0 ? min(1, $free / $totalLoot) : 0;
-		$takeMetal = (int) floor($loot['metal'] * $factor);
-		$takeCrystal = (int) floor($loot['crystal'] * $factor);
+		$db->beginTransaction();
+		try {
+			$locked = PvePackageService::lockAt($universe, $galaxy, $system, $planet);
+			if ($locked === null) {
+				$db->rollback();
+				$this->bounceEmpty();
+				return;
+			}
 
-		PvePackageService::collect((int) $package['id'], $takeMetal, $takeCrystal);
+			$loot = PvePackageService::currentLoot($locked);
+			$totalLoot = $loot['metal'] + $loot['crystal'];
+			$factor = $totalLoot > 0 ? min(1, $free / $totalLoot) : 0;
+			$takeMetal = (int) floor($loot['metal'] * $factor);
+			$takeCrystal = (int) floor($loot['crystal'] * $factor);
+
+			if ($takeMetal > 0 || $takeCrystal > 0) {
+				$collected = PvePackageService::collect(
+					(int) $locked['id'],
+					$takeMetal,
+					$takeCrystal,
+					(int) $locked['metal'],
+					(int) $locked['crystal']
+				);
+				if (!$collected) {
+					$db->rollback();
+					$this->bounceEmpty();
+					return;
+				}
+			}
+			$db->commit();
+		} catch (\Throwable $e) {
+			$db->rollback();
+			throw $e;
+		}
 
 		$this->UpdateFleet('fleet_resource_metal', (int) $this->_fleet['fleet_resource_metal'] + $takeMetal);
 		$this->UpdateFleet('fleet_resource_crystal', (int) $this->_fleet['fleet_resource_crystal'] + $takeCrystal);

--- a/includes/dbtables.php
+++ b/includes/dbtables.php
@@ -15,7 +15,7 @@
  * @link https://github.com/jkroepke/2Moons
  */
 
-defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 27);
+defined('DB_VERSION_REQUIRED') || define('DB_VERSION_REQUIRED', 28);
 defined('DB_NAME')             || define('DB_NAME',   $database['databasename']);
 defined('DB_PREFIX')           || define('DB_PREFIX', $database['tableprefix']);
 

--- a/install/install.sql
+++ b/install/install.sql
@@ -660,7 +660,7 @@ CREATE TABLE `%PREFIX%salvage_packages` (
   UNIQUE KEY `coords` (`universe`, `galaxy`, `system`, `planet`),
   KEY `expires_at` (`expires_at`),
   KEY `planet_id` (`planet_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 CREATE TABLE `%PREFIX%raports` (
   `rid` varchar(32) NOT NULL,

--- a/install/migrations/migration_26.sql
+++ b/install/migrations/migration_26.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `%PREFIX%salvage_packages` (
   UNIQUE KEY `coords` (`universe`, `galaxy`, `system`, `planet`),
   KEY `expires_at` (`expires_at`),
   KEY `planet_id` (`planet_id`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 INSERT INTO `%PREFIX%cronjobs` (`name`, `isActive`, `min`, `hours`, `dom`, `month`, `dow`, `class`, `nextTime`, `lock`)
 VALUES ('pve_spawn', 1, '*/15', '*', '*', '*', '*', 'HiveNova\\Cronjob\\PveSpawnCronjob', 0, NULL);

--- a/install/migrations/migration_28.sql
+++ b/install/migrations/migration_28.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `%PREFIX%salvage_packages` ENGINE=InnoDB;

--- a/tests/Support/FakeDatabase.php
+++ b/tests/Support/FakeDatabase.php
@@ -33,6 +33,13 @@ class FakeDatabase implements DatabaseInterface
     public int $lastFleetInsertId = 0;
 
     /** @var list<array<string, mixed>> */
+    public array $eventFleets = [];
+
+    public ?int $lastRowCount = null;
+
+    public int $transactionDepth = 0;
+
+    /** @var list<array<string, mixed>> */
     public array $galaxyRows = [];
 
     /** @var list<array{ally_name: string}> */
@@ -72,6 +79,9 @@ class FakeDatabase implements DatabaseInterface
 
     public function select($qry, array $params = [])
     {
+        if (str_contains($qry, '%%FLEETS_EVENT%%')) {
+            return $this->eventFleets;
+        }
         if (str_contains($qry, '%%SALVAGE_PACKAGES%%')) {
             return $this->salvageSelect($qry, $params);
         }
@@ -388,6 +398,7 @@ class FakeDatabase implements DatabaseInterface
     public function update($qry, array $params = [])
     {
         if (str_contains($qry, '%%SALVAGE_PACKAGES%%')) {
+            $this->lastRowCount = 0;
             foreach ($this->salvagePackages as &$row) {
                 if (isset($params[':id']) && (int) $row['id'] !== (int) $params[':id']) {
                     continue;
@@ -400,6 +411,11 @@ class FakeDatabase implements DatabaseInterface
                 )) {
                     continue;
                 }
+                if (isset($params[':expectedMetal'])
+                    && ((int) $row['metal'] !== (int) $params[':expectedMetal']
+                        || (int) $row['crystal'] !== (int) $params[':expectedCrystal'])) {
+                    continue;
+                }
                 if (isset($params[':planetId'])) {
                     $row['planet_id'] = (int) $params[':planetId'];
                 }
@@ -409,6 +425,7 @@ class FakeDatabase implements DatabaseInterface
                 if (isset($params[':crystal'])) {
                     $row['crystal'] = max(0, (int) $row['crystal'] - (int) $params[':crystal']);
                 }
+                $this->lastRowCount++;
             }
             unset($row);
             return true;
@@ -489,7 +506,7 @@ class FakeDatabase implements DatabaseInterface
 
     public function rowCount()
     {
-        return $this->achievement->rowCount();
+        return $this->lastRowCount ?? $this->achievement->rowCount();
     }
 
     public function getQueryCounter()
@@ -515,18 +532,21 @@ class FakeDatabase implements DatabaseInterface
 
     public function beginTransaction(): void
     {
+        $this->transactionDepth++;
         $this->achievement->beginTransaction();
         $this->session->beginTransaction();
     }
 
     public function commit(): void
     {
+        $this->transactionDepth = max(0, $this->transactionDepth - 1);
         $this->achievement->commit();
         $this->session->commit();
     }
 
     public function rollback(): void
     {
+        $this->transactionDepth = max(0, $this->transactionDepth - 1);
         $this->achievement->rollback();
         $this->session->rollback();
     }

--- a/tests/Support/FlyingFleetHandlerProbeMission.php
+++ b/tests/Support/FlyingFleetHandlerProbeMission.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace HiveNova\Mission;
+
+class FlyingFleetHandlerProbeMission implements Mission
+{
+    public static int $started = 0;
+
+    public static int $finished = 0;
+
+    public static ?int $throwOnFleetId = null;
+
+    /**
+     * @param array<string, mixed> $Fleet
+     */
+    public function __construct(private array $Fleet)
+    {
+    }
+
+    public function TargetEvent()
+    {
+        self::$started++;
+        if (self::$throwOnFleetId !== null && (int) $this->Fleet['fleet_id'] === self::$throwOnFleetId) {
+            throw new \RuntimeException('probe boom');
+        }
+        self::$finished++;
+    }
+
+    public function EndStayEvent()
+    {
+    }
+
+    public function ReturnEvent()
+    {
+    }
+
+    public static function reset(): void
+    {
+        self::$started = 0;
+        self::$finished = 0;
+        self::$throwOnFleetId = null;
+    }
+}

--- a/tests/Unit/FlyingFleetHandlerTest.php
+++ b/tests/Unit/FlyingFleetHandlerTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use HiveNova\Core\FlyingFleetHandler;
+use HiveNova\Mission\FlyingFleetHandlerProbeMission;
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../Support/FakeDatabase.php';
+require_once __DIR__ . '/../Support/SwapDatabaseInstance.php';
+require_once __DIR__ . '/../Support/FlyingFleetHandlerProbeMission.php';
+
+class FlyingFleetHandlerTest extends TestCase
+{
+    use SwapDatabaseInstance;
+
+    private FakeDatabase $fake;
+
+    /** @var array<int, string> */
+    private array $originalPattern;
+
+    protected function setUp(): void
+    {
+        $this->fake = new FakeDatabase();
+        $this->swapDatabaseInstance($this->fake);
+        $this->originalPattern = FlyingFleetHandler::$missionObjPattern;
+        FlyingFleetHandler::$missionObjPattern[99] = FlyingFleetHandlerProbeMission::class;
+        FlyingFleetHandlerProbeMission::reset();
+    }
+
+    protected function tearDown(): void
+    {
+        FlyingFleetHandler::$missionObjPattern = $this->originalPattern;
+        FlyingFleetHandlerProbeMission::reset();
+        $this->restoreDatabaseInstance();
+        parent::tearDown();
+    }
+
+    public function testRunContinuesAfterMissionThrow(): void
+    {
+        $this->fake->eventFleets = [
+            [
+                'fleet_id' => 1,
+                'fleet_mission' => 99,
+                'fleet_mess' => FLEET_OUTWARD,
+            ],
+            [
+                'fleet_id' => 2,
+                'fleet_mission' => 99,
+                'fleet_mess' => FLEET_OUTWARD,
+            ],
+        ];
+        FlyingFleetHandlerProbeMission::$throwOnFleetId = 1;
+
+        $handler = new FlyingFleetHandler();
+        $handler->setToken('tok');
+        $handler->run();
+
+        $this->assertSame(2, FlyingFleetHandlerProbeMission::$started);
+        $this->assertSame(1, FlyingFleetHandlerProbeMission::$finished);
+    }
+}

--- a/tests/Unit/MissionCaseCombatTest.php
+++ b/tests/Unit/MissionCaseCombatTest.php
@@ -217,6 +217,12 @@ class MissionCaseCombatTest extends TestCase
         $mission = new MissionCaseAttack($fleet);
         $mission->TargetEvent();
         $this->assertSame(FLEET_RETURN, $mission->_fleet['fleet_mess']);
+        $ownerIds = array_map(
+            static fn (array $message): int => (int) ($message[':userId'] ?? 0),
+            $this->fake->achievement->messages
+        );
+        $this->assertNotContains(0, $ownerIds);
+        $this->assertContains(2, $ownerIds);
     }
 
     public function test_attack_with_acs_runs_combat_for_group_fleets(): void

--- a/tests/Unit/MissionCaseSalvageTest.php
+++ b/tests/Unit/MissionCaseSalvageTest.php
@@ -86,6 +86,7 @@ class MissionCaseSalvageTest extends TestCase
         $this->assertSame(5000, (int) $mission->_fleet['fleet_resource_metal']);
         $this->assertSame(2500, (int) $mission->_fleet['fleet_resource_crystal']);
         $this->assertSame([], $this->fake->salvagePackages);
+        $this->assertSame(0, $this->fake->transactionDepth);
         $this->assertNotEmpty($this->fake->achievement->messages);
     }
 
@@ -100,6 +101,7 @@ class MissionCaseSalvageTest extends TestCase
         $this->assertSame(FLEET_RETURN, $second->_fleet['fleet_mess']);
         $this->assertSame(0, (int) $second->_fleet['fleet_resource_metal']);
         $this->assertGreaterThan(1, count($this->fake->achievement->messages));
+        $this->assertSame(0, $this->fake->transactionDepth);
     }
 
     public function testBounceWhenNoPackage(): void

--- a/tests/Unit/PvePackageServiceTest.php
+++ b/tests/Unit/PvePackageServiceTest.php
@@ -68,8 +68,28 @@ class PvePackageServiceTest extends TestCase
             'tier' => 1,
             'encounter_seed' => 1,
         ];
-        PvePackageService::collect(1, 100, 50);
+        $this->assertTrue(PvePackageService::collect(1, 100, 50, 100, 50));
         $this->assertSame([], $this->fake->salvagePackages);
+    }
+
+    public function testCollectRejectsStaleSnapshot(): void
+    {
+        $this->fake->salvagePackages[] = [
+            'id' => 1,
+            'universe' => 1,
+            'galaxy' => 1,
+            'system' => 1,
+            'planet' => 4,
+            'metal' => 40,
+            'crystal' => 20,
+            'spawned_at' => TIMESTAMP,
+            'expires_at' => TIMESTAMP + 100,
+            'tier' => 1,
+            'encounter_seed' => 1,
+        ];
+        $this->assertFalse(PvePackageService::collect(1, 100, 50, 100, 50));
+        $this->assertSame(40, $this->fake->salvagePackages[0]['metal']);
+        $this->assertSame(20, $this->fake->salvagePackages[0]['crystal']);
     }
 
     public function testAttachToPlanetSetsPlanetId(): void


### PR DESCRIPTION
## Summary
- Convert salvage packages to InnoDB, collect inside a transaction after `FOR UPDATE`, and reject stale stored-metal/crystal snapshots so two concurrent hauls cannot credit the same loot.
- Skip synthetic NPC `user id 0` from combat mail, `TOPKB_USERS`, and `USERS` win/loss updates (drive-tech crash already landed in #262).
- Catch per-mission exceptions in `FlyingFleetHandler` so one throw cannot pin the `FLEETS_EVENT.lock` token for every fleet in the batch.

## Test plan
- [x] `./vendor/bin/phpunit` (1278 tests, all passing)
- [ ] Apply `migration_28.sql` on an existing universe and confirm `salvage_packages` is InnoDB
- [ ] Send two salvage fleets to the same package in the same tick; only one should haul
- [ ] Confirm an inbound NPC raid still completes combat and the incoming-attack banner clears
- [ ] Confirm a thrown mission no longer leaves later fleets in the same token locked